### PR TITLE
Non-record: Mamba2 SSM + Attention Hybrid (SP8192) - val_bpb= 1.1005 prequant, Research preview over 56 SSM runs, limitations and findings

### DIFF
--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/README.md
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/README.md
@@ -1,0 +1,438 @@
+# Mamba2 SSM + Attention Hybrid (SP8192) — Non-Record Submission
+
+> A single-attention Mamba2/SSM hybrid trained at SP8192 in 600 seconds on 8×H100. This submission documents the architecture's strong pre-quant quality (sliding `val_bpb` ≈ 1.10) and the compression cliff that prevents it from fitting cleanly under the 16 MB cap.
+
+
+This is a non-record attempt but could be useful. This is all I could muster up in 3 sundays and limited compute budget. My goal was to match or come as close to transfomers using a SSM focused attempt. 
+
+The readme is AI generated so apologies for the slop. 
+
+
+
+
+## Submitted-Run Numbers
+
+| Metric | Value |
+|---|---|
+| **Pre-quant sliding `val_bpb`** | **1.1005** |
+| **Pre-quant standard `val_bpb`** | **1.1053** |
+| **Post-quant sliding `val_bpb`** | **1.2938** |
+| **Post-quant standard `val_bpb`** | **1.2985** |
+| **Compressed artifact size** | **16,094,692 bytes** (~95 KB over the 16,000,000-byte cap) |
+| Training time | 611 s on 8×H100 (`MAX_WALLCLOCK_SECONDS=600`) |
+| Steps | 4,300 |
+| Total params | 45,651,000 |
+| Sequence length (train + eval) | 8,192 |
+| Vocab | SP8192 |
+| Compression | role-bit packed (int4 FFN gate, int4 FFN down, int5 Mamba/attn, int6 embed) + LZMA preset 9 extreme |
+
+The full training log is in `train.log`. The exact env override used for the submitted run is documented in the `Reproduction` section near the bottom of this README.
+
+### Why this is a *non-record* submission
+
+The submitted artifact is **just over the 16 MB cap** (16,094,692 bytes ≥ 16,000,000). A more aggressive quantization variant (`Run #1` in `train.log`, int3 FFN gate / auto-prune to 15.85 MB) does fit at 10,910,872 bytes (10.4 MB) but post-quant quality collapses to 2.12 sliding `val_bpb`. The architecture is competitive at full precision; the remaining work is purely on the compression side. We submit this as a research contribution under the 16 MB non-record track to document SSM-hybrid behavior in the constraint envelope.
+
+---
+
+## Background
+
+This README was originally written as an experiment chronicle of all SSM/attention-hybrid runs we made during the challenge, not just the submitted one. The high-level conclusions and table of all single-run experiments below give the broader context that informed the submitted configuration.
+
+The work focused on Mamba/SSM + attention hybrids, compression, and optimizer behavior. These were **exploratory single-run experiments**, not record-quality submissions. Unless otherwise stated, each result is from **one run only**, typically one seed, and should be treated as directional rather than statistically conclusive. We did **not** run multi-seed means, confidence intervals, or record-style validation.
+
+## High-level conclusion
+
+The strongest pre-quant result I found came from the old/full-capacity architecture:
+
+```text
+10 layers
+9 Mamba2/SSM blocks + 1 attention block at layer 6
+full independent SwiGLU FFN in every block
+SP8192 tokenizer
+D_MODEL=512
+D_STATE=64
+SEQ_LEN=8192
+Muon on large 2D matrices
+AdamW on scalar/control/embed groups
+```
+
+This reached roughly:
+
+```text
+prequant standard BPB: ~1.105
+prequant sliding BPB:  ~1.100
+```
+There is a variant in ablations somewhere which got to 1.089 as well but honestly, I forgot which one. 
+
+
+Compression is the main unresolved bottleneck. The model has about **45.65M parameters**, so even good byte-int6 + LZMA compression landed around **24.6 MB**, well above the 16 MB cap. More aggressive compression is needed, but the smaller/shared/narrow FFN architectures usually lost too much quality.
+
+A second major conclusion is that **SSM optimizer behavior matters a lot**. Pure AdamW was faster but much worse in our short-run setting, while naive high-LR AdamW for Mamba projections catastrophically hurt performance. The best current optimizer path remains Muon-heavy, but we suspect SSMs need more careful Muon/AdamW hybridization or trust-clipped Muon updates.
+
+## Experimental caveat
+
+These experiments are not leaderboard-record attempts. They were meant to rapidly test architecture and optimizer hypotheses. Therefore:
+
+- Most rows are **single-seed, single-run** measurements.
+- Results are not averaged over seeds.
+- Some scripts changed multiple factors at once, especially during early exploration.
+- Several TTT, Mamba3, and compression runs were deliberately diagnostic rather than submission-ready.
+- Reported BPB values should be read as rough ablation evidence, not final records.
+
+## Result summary
+
+| Experiment / variant | Params | Key setup | Steps | Standard BPB | Sliding BPB | Notes |
+|---|---:|---|---:|---:|---:|---|
+| Full FFN clean / full Muon baseline | 45.65M | 10L, FFN all layers, attn layer 6, Muon big matrices | 4200 | 1.1051 | **1.1003** | Best clean prequant architecture anchor |
+| Full FFN clean, byte-int6/LZMA | 45.65M | Same as full baseline; byte INT6/INT8 + LZMA | 4300 | 1.1036 pre / 1.1148 post | **1.0987 pre / 1.1100 post** | Quality good, size 24.6 MB, still over cap |
+| Full FFN clean, BF16 storage | 45.65M | BF16 storage for FFN/attn/embed/bigram, Mamba kept fp32 | 4300 | 1.1186 | 1.1138 | Slight speedup, large BPB loss; not worth keeping |
+| Full FFN, Muon FFN+attn, AdamW Mamba high LR | 45.65M | Mamba moved to AdamW with too-high LR | 4500 | ~1.247 | ~1.245 | Catastrophic; AdamW LR was Muon-scale and too hot |
+| Sparse FFN baseline | 26.77M | FFN only on layers 6 and 9 | 5400 | 1.1383 | 1.1334 | Much smaller/faster but loses substantial quality |
+| Sparse FFN + carryover eval | 26.77M | Direct-kernel stateful-overlap carryover | 5400 | — | 1.1393 carryover | Carryover worse than sliding; SSM state not trained for this |
+| J tied-dense | 30.19M | Shared SSM FFN on SSM layers + attention correction at 2,5 | 3900 | 1.1280 | 1.1226 | Best shared-FFN model, still far behind full FFN |
+| J-384 | 29.92M | J with attention-correction dim 384 | 3800 | 1.1309 | 1.1256 | Shrinking attention correction hurt; little speed gain |
+| Shared final FFN + small attention correction | 27.29M | Sparse FFN with shared final FFN reuse and 256-dim attn corr | 4600 | 1.1373 | 1.1319 | Small improvement over sparse, not enough |
+| Fusion A | 30.30M | SSM + gated attention correction at layers 2,5 | 4670 | 1.1328 | 1.1272 | Attention correction helped; TTT was bad |
+| Fusion B | 29.25M | Attention-before-Mamba injection | ~5090 | 1.1597 | 1.1563 | Dropped |
+| Fusion C | 27.00M | Hard attention layers 2,5 + QK conditioning | ~5260 | 1.1394 | 1.1340 | Better size/quality tradeoff than B, worse than A/J/full |
+| E1 carrier | 19.42M | Narrow SSM carrier, too few full sequence mixers | 3610 | 1.1974 | 1.1924 | Collapsed; not enough real SSM/FFN capacity |
+| E2 carrier + memory tokens | 19.94M | E1 + SSM memory tokens | 3790 | 1.1998 | 1.1947 | Memory tokens did not help |
+| E3 carrier + cache distill | 19.94M | E2 + train-only repetition/cache distillation | 3850 | 1.2064 | 1.2014 | Distill objective hurt in current form |
+| K35 TaskMuon | 34.65M | Tied head, EMBED_DIM=320, no bigram, SSM FFN hidden 896 | ~4000+ | poor | poor | Under-learned; too aggressively shrunk |
+| K35 wider TaskMuon | 38.19M | EMBED_DIM=384, bigram on, SSM FFN hidden 1024 | 4300 | 1.1597 | 1.1546 | Still bad; architecture/optimizer interaction weak |
+| K35 pure AdamW, hot LR | 38.19M | AdamW-only, FFN/attn LR 0.0025 | 5000 | 1.1684 | — | Faster but poor generalization |
+| K35 pure AdamW, cooler LR | 38.19M | AdamW-only, FFN/attn LR 0.001 | 4900 | 1.1896 | 1.1846 | Faster but much worse |
+| Old 28.2M int6 packed/Brotli run | 28.21M | 2-attn, FFN mult 2, compressed int6 | 4300 | 1.1534 pre / 1.1831 post | 1.1480 pre / 1.1779 post | Nearly fit size, but quality too weak |
+
+## Architecture learnings
+
+### Full independent FFNs matter
+
+The biggest architectural lesson is that full independent FFNs are doing a lot of work. The full-FFN baseline was both the best and surprisingly efficient:
+
+```text
+45.65M params, FFN everywhere → ~1.1003 sliding BPB
+```
+
+Attempts to share, sparsify, or aggressively compress FFNs structurally usually hurt:
+
+- FFN only on layers 6 and 9: ~1.1334 sliding BPB.
+- Shared SSM FFN / J: ~1.1226 sliding BPB.
+- Post-hoc shared-base + rank-64 SVD residuals: catastrophic, post-SVD BPB above 2.0.
+- Trainable compact FFN rank-96 was undertrained and weak, around ~1.1385 sliding BPB before optimizer fixes.
+
+Conclusion: do not simply remove FFN capacity. If model size must drop, use compression or carefully trained structure, not naive sharing/post-hoc SVD.
+
+### Fewer/full blocks may be better than same depth with weak FFNs
+
+K35 tried to keep 10 layers while shrinking most SSM FFNs. That performed much worse than expected, even at 38M parameters. The lesson appears to be:
+
+```text
+Full FFN expressivity > preserving layer count with narrow FFNs
+```
+
+A future compressed architecture may be better as **fewer layers with full FFNs**, rather than 10 layers with many weakened FFNs.
+
+### Attention correction helps, but not enough
+
+Fusion A and J showed that extra attention correction paths can help. However, attention correction is not free, and replacing real SSM or FFN capacity with attention did not consistently improve results.
+
+Useful observations:
+
+- Fusion A was the best of the fusion sweep at ~1.1272 sliding BPB.
+- Shrinking J attention correction from 512 to 384 hurt quality with little speed gain.
+- Removing the early attention correction in J worsened performance.
+
+Conclusion: attention correction is useful, but it does not replace full FFN capacity.
+
+### Carrier-style SSM memory was too weak
+
+The E1/E2/E3 carrier experiments collapsed around 1.19–1.20 BPB. They replaced too much real sequence/FFN capacity with narrow carriers and FFN-only blocks.
+
+Conclusion: SSMs can be useful, but narrow carrier side channels are not enough unless the main sequence mixer remains strong.
+
+## SSM-specific learnings
+
+### SSM state carryover did not help yet
+
+Stateful-overlap carryover was implemented using a direct Mamba chunk-scan path, but carryover eval was worse than sliding eval in the sparse baseline:
+
+```text
+sliding:   ~1.1334 BPB
+carryover: ~1.1393 BPB
+```
+
+This suggests the model was not trained to use nonzero carried Mamba states. If carryover is revisited, it likely needs training-time state carry with detached recurrent states, not only eval-time carryover.
+
+### seq_idx fixes were principled but not a big BPB lever
+
+Adding doc-boundary `seq_idx` reset and explicit Mamba2 knobs was cleaner, but the BPB difference compared to no reset/default dt was small. The best practical setting remains:
+
+```text
+SEQ_IDX_ENABLED=1
+DT_MIN=0.0005
+DT_MAX=0.05
+HEADDIM=64
+D_STATE=64
+```
+
+### Mamba3 was not useful in this pass
+
+A Mamba3 port was attempted because public Mamba3-style SSMs can be faster, but the local build/API path was not clean enough and the experiment did not produce a useful result. The conclusion is not that Mamba3 is bad; only that this attempt was not a productive path within this time budget.
+
+## Optimizer learnings
+
+### Muon is still the strongest known optimizer for this setup
+
+The strongest model used Muon on large 2D matrices:
+
+```text
+matrix=45 Muon
+scalar/control AdamW
+embed AdamW
+```
+
+This consistently beat pure AdamW and AdamW-heavy hybrids in our short-run setup.
+
+### Pure AdamW was faster but much worse
+
+Pure AdamW K35 runs achieved much higher throughput and more steps, but validation was much worse:
+
+```text
+~5000 steps, ~4.3M tok/s, but ~1.18 sliding BPB
+```
+
+This shows AdamW is computationally attractive, but our AdamW configuration and/or architecture did not converge to a good basin in 600 seconds.
+
+### High-LR AdamW for Mamba is catastrophic
+
+Moving all Mamba matrices to AdamW with LR values like 0.006 for `mamba.in_proj` / `mamba.out_proj` destroyed performance. Those values are Muon-scale, not AdamW-scale.
+
+If AdamW is used for SSM internals, it likely needs much lower rates:
+
+```text
+Mamba in/out projections: 3e-4 to 8e-4
+Mamba dynamics:           5e-5 to 2e-4
+```
+
+### Full-Muon + trust clipping is the best current optimizer direction
+
+The current best optimizer hypothesis is not “remove Muon.” It is:
+
+```text
+Keep full-Muon routing for large matrices.
+Add per-role update trust clipping.
+Use lower trust ratios for Mamba in/out projections.
+```
+
+This directly targets observed loss oscillations without throwing away the optimizer that produced the best BPB.
+
+Suggested role trust ratios:
+
+```text
+FFN:        0.020
+Attention:  0.015
+Mamba in:   0.008
+Mamba out:  0.008
+Embed proj: 0.010
+Bigram:     0.010
+Generic:    0.010
+```
+
+### EMA failed in the current script
+
+EMA with decay 0.9965 produced an unusable evaluation in one run:
+
+```text
+live BPB: ~1.1035
+EMA BPB:  ~4.36
+```
+
+The likely issue is averaging from step 1 and/or averaging fragile recurrent/control parameters. If revisited, use late-start EMA, exclude Mamba dynamics, or checkpoint soup instead of naive full EMA.
+
+## Compression learnings
+
+### byte-int6/LZMA preserved quality but was too large
+
+The best compression quality result was byte-stored INT6/INT8 with LZMA:
+
+```text
+prequant sliding:  ~1.0987 BPB
+postquant sliding: ~1.1100 BPB
+artifact:          24,604,112 bytes
+```
+
+This proved the quantization loss can be manageable. The size, not the BPB, is the remaining problem.
+
+### zstd/int8 was too large
+
+A full int8+zstd path compressed to about 37.3 MB. It was less destructive but nowhere near the 16 MB cap.
+
+### BF16 storage during training hurt quality
+
+Selective BF16 storage for non-Mamba projection weights cast about 26.5M parameters to BF16 storage, mostly FFNs. It gave only a small throughput gain but hurt sliding BPB by roughly 13 mBPB. Full FFN weights appear to need FP32 storage during training with the current Muon path.
+
+### Aggressive hybrid low-bit compression is the next final-attempt path
+
+The current final compression attempt targets the full-Muon/full-FFN model with:
+
+```text
+FFN gate_up: packed INT3
+FFN down:    packed INT4
+Mamba:       packed INT4 with protected dynamics rows
+Attention:   packed INT5
+Embeddings:  packed INT6 with opt-clip
+Small params: fp16
+Compressor:  LZMA-9 extreme
+```
+
+This is aggressive and may damage BPB, but it is the right scale of compression needed to push a 45M model toward 16 MB.
+
+## TTT learnings
+
+The LoRA score-first TTT path was harmful in the current implementation:
+
+```text
+Fusion A sliding: ~1.1272
+Fusion A TTT:     ~1.1835
+```
+
+TTT also consumed a large amount of evaluation time. Until the TTT objective is fixed, it should remain disabled for architecture/compression sweeps.
+
+Likely issues:
+
+- TTT trained on too many overlapping context tokens.
+- LoRA targets included unstable modules.
+- Adaptation LR/WD was too high.
+- Rank-local chunking was correct, but the update objective was not aligned enough with scoring.
+
+A safer future TTT path would adapt only tiny calibration parameters such as norms, q_gain, residual scales, or final bias.
+
+## Profiling learnings
+
+Profiling showed the full model is not dominated by one operation. Costs were split across:
+
+- Mamba backward / scan kernels.
+- FFN and output/head dense matmuls.
+- Muon optimizer step.
+- Attention backward.
+
+The full-FFN model was actually faster end-to-end than some smaller shared/adapter models because it uses large dense GEMMs that H100 handles well. Smaller low-rank/adapted models often introduced many small/skinny operations and optimizer overhead.
+
+## Current best direction
+
+The most promising path is:
+
+```text
+1. Keep full independent FFN architecture as the quality anchor.
+2. Keep full-Muon optimizer, but add per-role trust clipping.
+3. Use aggressive low-bit hybrid compression and dynamics protection.
+4. Avoid pure AdamW, naive EMA, current LoRA TTT, and structural FFN sharing unless new evidence appears.
+```
+
+The leading open question is whether the 45.65M full-FFN model can be compressed under 16 MB while preserving enough of the ~1.10 prequant BPB. If the aggressive quantization path loses too much BPB, the next architecture direction should be fewer layers with full FFNs rather than the K35-style “same depth, narrower FFNs” approach.
+
+## Reproducibility notes
+
+All major runs used:
+
+```text
+8 x H100 80GB
+SP8192 tokenizer
+FineWeb challenge data
+SEQ_LEN=8192 for the strongest runs
+train_batch_tokens(global)=524288 unless noted
+600 second training cap
+sliding eval stride=64 for serious comparisons
+```
+
+Because these are exploratory, non-record runs, the reported table should be used to guide follow-up ablations only. A record attempt would need:
+
+- Multiple seeds.
+- Mean BPB reporting.
+- Strict final artifact accounting.
+- Official eval path consistency.
+- No diagnostic shortcuts.
+- Repeated compression/TTT validation after decompression.
+
+---
+
+## Reproduction
+
+### Setup (fresh 8×H100 pod)
+
+```bash
+# 1. Clone the parameter-golf repo
+cd /workspace
+git clone https://github.com/openai/parameter-golf.git parameter-golf-repo
+
+# 2. Install Python deps (H100 only, parallel build)
+cd parameter-golf-repo
+TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=16 \
+  pip install -r requirements.txt --no-build-isolation
+# This submission also requires:
+pip install mamba-ssm causal-conv1d einops zstandard
+
+# 3. Download SP8192 data + tokenizer (lives in a fork)
+MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf \
+  python3 data/cached_challenge_fineweb.py --variant sp8192 --train-shards 80
+```
+
+### Submitted-run command (Run #2 — moderate int4/5 quant, no auto-prune)
+
+```bash
+CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+SEQ_LEN=8192 \
+N_UNIQUE_BLOCKS=10 \
+ATTN_LAYER_IDXS=6 \
+FFN_MULT=3 \
+FFN_ACTIVE_POLICY=all \
+EMBED_DIM=512 \
+BIGRAM_ENABLED=1 \
+HEADDIM=64 \
+DT_MIN=0.0005 \
+DT_MAX=0.05 \
+SEQ_IDX_ENABLED=1 \
+DOC_BOUNDARY_TOKEN=1 \
+CARRYOVER_EVAL_ENABLED=0 \
+SCORE_FIRST_TTT_ENABLED=0 \
+TTT_ENABLED=0 \
+RUN_POSTQUANT=1 \
+QUANT_FORMAT=fullmuon_aggressive_lzma \
+QUANT_BITS_FFN_GATE=4 \
+QUANT_BITS_FFN_DOWN=4 \
+QUANT_BITS_MAMBA=5 \
+QUANT_BITS_ATTN=5 \
+QUANT_BITS_EMBED=6 \
+QUANT_BITS_MATRIX=5 \
+QUANT_PACK_ALL=1 \
+QUANT_PASSTHROUGH_NUMEL=65536 \
+QUANT_K_FFN_GATE=12.85 \
+QUANT_K_FFN_DOWN=12.85 \
+QUANT_K_MAMBA=12.85 \
+QUANT_K_ATTN=12.85 \
+QUANT_K_EMBED=20.0 \
+QUANT_SCALE_FLOOR_MULT=1.0 \
+QUANT_PROTECT_DYNAMICS=1 \
+QUANT_OPTCLIP_EMBED=1 \
+QUANT_OPTCLIP_STEPS=8 \
+QUANT_AUTO_PRUNE_TO_BYTES=0 \
+QUANT_TARGET_BYTES=15850000 \
+QUANT_LZMA_PRESET=9 \
+QUANT_LZMA_EXTREME=1 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 train_gpt.py
+```
+
+### "Fits the cap" variant (Run #1 — aggressive int3 + auto-prune; quality collapses)
+
+Same as above but with:
+
+```bash
+QUANT_BITS_FFN_GATE=3 \
+QUANT_BITS_MAMBA=4 \
+QUANT_AUTO_PRUNE_TO_BYTES=1 \
+QUANT_AUTO_PRUNE_FRACS=0,0.25,0.40,0.55,0.70,0.85
+```
+
+This produces a 10,910,872-byte artifact (under the cap) but post-quant sliding `val_bpb` collapses to 2.1248. Provided in `train.log` for completeness.

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/README.md
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/README.md
@@ -1,0 +1,18 @@
+# Ablations
+
+These are the 56 single-run ablation scripts that informed the submitted configuration. Each file is a self-contained training script tied to one row in the *Result summary* table of the parent `../README.md`. Filenames roughly map to the variant names in that table:
+
+- `ssm_recall_sota_sp8192_fullmuon_final_compress.py` — the submitted file (also a copy at `../train_gpt.py`)
+- `ssm_recall_sota_sp8192_fullmuon_final_compress_trustclip.py` — Run #3 (trust-clipped Muon variant) referenced in the README
+- `ssm_recall_sota_sp8192_race_best*.py` — sparse / shared / fused FFN attempts
+- `ssm_recall_sota_sp8192_j_tieddense*.py` — tied-FFN J family
+- `ssm_recall_sota_sp8192_k35_*.py` — K35 narrow-FFN family (TaskMuon, AdamW, etc.)
+- `ssm_recall_sota_sp8192_*ttt*.py` — TTT variants (LoRA, dynamic bias, score-first)
+- `ssm_recall_sota_sp8192_hybrid_*.py` / `*_fusion*` / `*_sidecar.py` — attention-fusion attempts
+- `ssm_recall_sota_sp8192_*_compactffn*.py` — compact / SVD-rank FFN
+- `ssm_recall_sota_sp8192_h3_compare.py`, `*_long_s4d.py`, `*_smeargate.py` — alt SSM/architecture variants
+- `ssm_recall_sota_sp8192_*_curriculum.py`, `*_rope*.py`, `*_tail_loss.py` — training-recipe variants
+- `ssm_recall_sota_sp8192_nbit_quant.py`, `*_byteint6_lzma.py`, `*_hybrid_int5_lzma.py`, `*_bf16storage.py` — quantization/storage variants
+- `ssm_param_golf_fixed.py`, `ssm_param_golf_repair.py`, `ssm_recall.py`, `ssm_ropebridge_taskmuon.py` — earlier exploratory baselines
+
+These are kept here for full provenance — most are exploratory and not tuned. The submitted configuration is `../train_gpt.py`. See the parent README's *Result summary* and *Architecture/Optimizer/Compression learnings* sections for the conclusions drawn from these runs.

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_param_golf_fixed.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_param_golf_fixed.py
@@ -1,0 +1,3626 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None  # state-carryover eval will be unavailable
+# Direct kernel access for proper chunked state passing — InferenceParams
+# routes through step() one token at a time and silently no-ops state
+# carryover on the chunked path. mamba_chunk_scan_combined natively supports
+# initial_states / return_final_states.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+# Brotli for compressed artifact (preferred over zstd).
+try:
+    import brotli  # type: ignore
+    _HAS_BROTLI = True
+except ImportError:
+    _HAS_BROTLI = False
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# torch._dynamo specializes on each block instance reference inside the
+# forward loop (10 distinct block objects → 10 recompiles for the dispatch
+# wrapper). Default cache_size_limit is 8, so we hit the warning and dynamo
+# falls back to eager for that frame. Bump it well above n_blocks.
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = 64
+    torch._dynamo.config.accumulated_cache_size_limit = 256
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))  # tested 128 — added ~17% throughput cost without recovering it in BPB at 10min training budget. 64 wins empirically here.
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Mamba2-specific knobs (passed to mamba_ssm.modules.mamba2.Mamba2)
+HEADDIM = int(os.environ.get("HEADDIM", "64"))   # tested 32 — slower kernel path at this size, didn't pay back in BPB
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))  # sharper than Mamba2 default 0.001
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))    # sharper than Mamba2 default 0.1
+FFN_MULT = int(os.environ.get("FFN_MULT", "2"))  # was 3 — FFN dominates the param budget; cutting to 2 saves ~8M params (~6MB compressed) at modest BPB cost
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document boundary handling for SSM training. SSMs accumulate state across
+# the entire sequence, so when multiple short docs are packed into a single
+# 8192-token training row, doc B's state is contaminated by doc A. Mamba2's
+# chunk-scan kernel accepts a `seq_idx` (B, T) int32 that zeros state
+# transitions at chunk boundaries where seq_idx changes. Reset granularity
+# is the chunk_size of the scan (256 by default), so contamination is
+# bounded to <=256 tokens after each boundary instead of unbounded.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))  # this tokenizer has bos=1 (<s>), pad=0; <s> appears every ~811 tokens in val data → real doc separator
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # genuine factoring: tok_emb is 8192x256, embed_proj 256->512. Saves ~2.1M raw on tok_emb, costs ~131K on embed_proj. Net ~1.5MB compressed savings vs EMBED_DIM=512 (which is no-op factoring).
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"  # default tied: saves 4.2M params at vocab=8192. Untied costs ~3MB compressed for ~0.005 BPB; not worth it under 16MB cap.
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "2,5").split(",") if x.strip()]  # PR #1644 reports 2-attn at SP8192 7L beats 1-attn by 7.5 mBPB; testing this with our existing block
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "leaky_relu2").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.10"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.20"))  # 80% warmdown (was 0.28 = 72%); EMA/SWA do not work for this SSM, so the schedule itself has to land precisely
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"  # off by default: saves ~1MB compressed (1.4M params), BPB cost ~0.002-0.005. Bigram hash gave marginal lift; not worth the bytes given the 16MB cap.
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# State carryover at eval — SSM-native: thread Mamba2 hidden state across
+# non-overlapping seq_len blocks of the val set so every scored token has the
+# entire validation prefix in its recurrent state (transformers can't do this).
+# Implementation: mamba_ssm InferenceParams cache, seqlen_offset held at 0 so
+# the chunked scan path is used with carried initial_states. Attention layers
+# (which can't carryover) see only their own block, matching training context.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"  # disabled by default — model not trained for stateful init, has been net-negative across 12+ runs. Re-enable with stateful-overlap to test.
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))  # stateful-overlap: each block = overlap + score_region. Mamba state carries; attention sees overlap+score_region; only score_region scored. PR #1644 reports this matches sliding within 0.3 mBPB.
+# Warmup tokens at the start of the val stream where Mamba state is still
+# "cold" (consumed too few tokens to be informative). These are processed to
+# advance state but their losses are not counted. Default to one full block
+# so the cold-start block is always excluded. Set to 0 to score everything.
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+# Direct chunk-scan path (Task 3): bypasses Mamba2.forward and calls the
+# triton kernel mamba_chunk_scan_combined with explicit initial_states /
+# return_final_states. This is the only path that actually carries SSM state
+# across non-overlapping val blocks at chunked-scan throughput. Set to "0"
+# to fall back to the (broken) inference_params version for diagnosis.
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Compression / quantization config — int6 GPTQ-lite + Brotli-11 stack.
+# Goal: <16,000,000-byte artifact. Naive int8+zstd lands ~35MB; int6 packed
+# + Brotli-11 + tied LM head should land ~13-15MB.
+QUANT_MODE = os.environ.get("QUANT_MODE", "int6_packed").lower()  # "int6_packed", "int8" (legacy)
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))  # SDClip k for matrix tensors (int6); SOTA value from PR #1394
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))    # SDClip k for embedding-like tensors (int8); higher k = less aggressive clipping
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))  # tensors at or below this size kept fp16
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"  # PR #1890 / Q-Mamba: promote dt rows of mamba.in_proj.weight to INT8 to protect SSM recurrence from quant noise. ~16 extra bytes/row, big post-quant BPB recovery.
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"  # GPTQ-lite for embeddings: per-row optimal clip search instead of single global k. Targets rare-token rows whose distribution differs from common rows. ~0.005-0.010 BPB recovery on post-quant.
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1 = float(os.environ.get("BETA1", "0.9"))
+BETA2 = float(os.environ.get("BETA2", "0.99"))
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"  # default ON now: uses LoRA-scoped adaptation per reviewer recommendation; previous all-params bug is resolved by SCORE_FIRST_TTT_USE_LORA.
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.003"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "1"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+# LoRA-scoped TTT params (legal score-first TTT per reviewer / PR #1797)
+SCORE_FIRST_TTT_USE_LORA = os.environ.get("SCORE_FIRST_TTT_USE_LORA", "1") == "1"  # adapt only LoRA params instead of all model params. Required for legal score-first TTT (otherwise the adaptation is too unstable and was the root cause of the previous all-params getting-stuck bug).
+SCORE_FIRST_TTT_LORA_RANK = int(os.environ.get("SCORE_FIRST_TTT_LORA_RANK", "64"))  # PR #1797 uses 64-80; default to 64 for stronger legal TTT
+SCORE_FIRST_TTT_LORA_ALPHA = float(os.environ.get("SCORE_FIRST_TTT_LORA_ALPHA", "128.0"))  # alpha/rank scaling
+SCORE_FIRST_TTT_OPT = os.environ.get("SCORE_FIRST_TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+SCORE_FIRST_TTT_BETA2 = float(os.environ.get("SCORE_FIRST_TTT_BETA2", "0.99"))  # AdamW beta2 (PR #1797 uses 0.99)
+SCORE_FIRST_TTT_WD = float(os.environ.get("SCORE_FIRST_TTT_WD", "0.3"))  # AdamW weight decay
+SCORE_FIRST_TTT_NO_ALLREDUCE = os.environ.get("SCORE_FIRST_TTT_NO_ALLREDUCE", "1") == "1"  # CRITICAL: ranks process disjoint val slices, so all-reducing TTT grads leaks future tokens between ranks. Default to rank-local TTT.
+SCORE_FIRST_TTT_TARGETS = tuple(x.strip() for x in os.environ.get("SCORE_FIRST_TTT_TARGETS", "qkv,out_proj,gate_up,down,in_proj").split(",") if x.strip())
+RUN_PREQUANT_SCORE_FIRST_TTT = os.environ.get("RUN_PREQUANT_SCORE_FIRST_TTT", "0") == "1"  # keep pre-quant TTT diagnostic off by default; final score is post-quant + legal score-first TTT
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("current_defaults: EMBED_DIM=256, ATTN_LAYER_IDXS=2,5, ACTIVATION=leaky_relu2, post-quant score-first TTT on")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, prequant={RUN_PREQUANT_SCORE_FIRST_TTT}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}, targets={SCORE_FIRST_TTT_TARGETS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"quant: mode={QUANT_MODE}, k_matrix={QUANT_K_MATRIX}, k_embed={QUANT_K_EMBED}, passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, brotli={_HAS_BROTLI}")
+log0(f"lr_schedule: {LR_SCHEDULE}, warmdown_start={LR_WARMDOWN_START_FRAC} ({(1.0-LR_WARMDOWN_START_FRAC)*100:.0f}% warmdown)")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, layer_idx=None):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,  # required for inference_params cache (state-carryover eval)
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        # When inference_params is given the Mamba2 chunked scan reads the
+        # carried initial_states from the cache and writes back the final
+        # state. We hold seqlen_offset at 0 so we never enter the step path.
+        # seq_idx (B, T) int32 zeroes state transitions at chunk-aligned
+        # document boundaries.
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via the
+        triton kernel. Bypasses Mamba2.forward (whose inference_params path
+        goes through step() one token at a time, which silently no-ops the
+        chunked-scan state).
+
+        u: (B, L, d_model)
+        initial_ssm_state: (B, nheads, headdim, d_state) or None
+        prev_conv_input: (B, d_conv-1, conv_channels) or None.
+            Last d_conv-1 inputs to conv1d from previous block; None on
+            first block. With d_conv=4 this is 3 timesteps.
+        seq_idx: (B, L) int32 or None — document boundaries within block.
+            State transitions are zeroed at chunk-aligned positions where
+            seq_idx changes.
+
+        Returns: (y, final_ssm_state, last_conv_input)
+        """
+        m = self.mamba
+        B, L, _ = u.shape
+
+        # in_proj split — handle optional d_mlp path defensively
+        zxbcdt = m.in_proj(u)  # (B, L, total)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+        d_mlp = (full - expected) // 2
+
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_mlp, d_mlp, d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+        else:
+            z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+            z0 = x0_mlp = None
+
+        # Conv1d with state-passing. Mamba2's conv1d is depthwise (groups=C)
+        # with kernel d_conv. To carry state across blocks we prepend the
+        # previous block's last (d_conv-1) inputs and run with padding=0,
+        # producing exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()  # (B, C, L)
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()  # (B, C, d_conv-1)
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)  # (B, C, L + d_conv - 1)
+            xBC_conv = F.conv1d(
+                xBC_padded,
+                m.conv1d.weight,
+                m.conv1d.bias,
+                stride=1, padding=0, dilation=1,
+                groups=conv_channels,
+            )  # (B, C, L)
+        else:
+            # First block of stream — let the module's own conv handle causal
+            # padding, then trim trailing positions.
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)  # (B, L, C)
+
+        x, Bm, Cm = torch.split(
+            xBC_conv,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            dim=-1,
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+
+        A = -torch.exp(m.A_log.float())  # (nheads,)
+
+        z_for_scan = (
+            rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+        )
+
+        # Direct kernel call — this is the only path that actually carries
+        # SSM state across calls at chunked-scan throughput.
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size,
+            D=m.D,
+            z=z_for_scan,
+            dt_bias=m.dt_bias,
+            dt_softplus=True,
+            initial_states=initial_ssm_state,
+            seq_idx=seq_idx,
+            return_final_states=True,
+        )
+
+        y = rearrange(y, "b l h p -> b l (h p)")
+
+        if rmsnorm:
+            y = m.norm(y, z)
+
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Mirror of forward() that threads SSM and conv state across blocks.
+        Returns (x_out, mem, final_ssm_state, last_conv_input).
+        """
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                blk = CausalAttentionBlock(D_MODEL, ATTN_N_HEADS, FFN_MULT)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, layer_idx=i)
+                blk._is_ssm = True
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+        # Depth-scaled init for mamba_ssm's internal Mamba2.out_proj.weight.
+        # mamba_ssm's standalone Mamba2 class uses kaiming_uniform with no
+        # depth correction; depth scaling (1/sqrt(2*n_layer)) is only applied
+        # by the official MambaConfig _init_weights hook, which we don't use.
+        # Without this, `out_proj` is the only residual-output projection
+        # initialized "loud" at start of training (FFN.down and attention's
+        # out_proj are both zero-initialized in our code). Confirmed via
+        # verify_init_and_fp32.py: mamba.out_proj.weight std=0.018 vs the
+        # depth-scaled target of 0.004 — about 4.5x too large.
+        n_layer_for_init = N_UNIQUE_BLOCKS * N_UNROLLS
+        depth_init_scale = 1.0 / math.sqrt(2 * n_layer_for_init)
+        with torch.no_grad():
+            n_scaled = 0
+            for pname, p in self.named_parameters():
+                if pname.endswith("mamba.out_proj.weight"):
+                    p.mul_(depth_init_scale)
+                    n_scaled += 1
+            log0(f"depth-scaled init: scaled {n_scaled} mamba.out_proj.weight tensors by {depth_init_scale:.4f} (1/sqrt(2*{n_layer_for_init}))")
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Auto-compute seq_idx from the input ids if not provided. This is
+        # what tells Mamba2's chunk-scan kernel to zero state transitions at
+        # document boundaries (chunk-aligned). Disabled when DOC_BOUNDARY_TOKEN
+        # is negative or SEQ_IDX_ENABLED is off.
+        if seq_idx is None and SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        # State carryover: only pass inference_params to SSM blocks (attention
+        # blocks have no recurrent state to carry; they see only the current
+        # input window). When loop is active and inference_params is set, we
+        # would update the same block's state multiple times in one pass,
+        # which double-counts: explicitly forbid that combination.
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params is incompatible with depth recurrence "
+                "(would update Mamba state multiple times per forward). "
+                "Disable LOOP_START/LOOP_END for state-carryover eval."
+            )
+
+        skips = []
+        # Encoder. Inline dispatch (no closure) so torch.compile compiles
+        # each block once with stable arg shapes rather than re-specializing
+        # a wrapper per block id.
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads
+        Mamba2 SSM state and conv1d state across calls via direct kernel
+        access (mamba_chunk_scan_combined). Attention blocks see only the
+        current block (no recurrent state to carry).
+
+        ids: (B, L)
+        layer_states: dict {block_idx: (ssm_state, conv_input)} or None.
+            On first call pass None; the returned dict is fed back in for
+            the next block.
+        seq_idx_base: int — counter offset to keep doc ids monotonic across
+            blocks. The new last seq_idx value is returned so the caller
+            can pass it as seq_idx_base for the next block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — "
+                "direct-kernel state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with carryover not implemented
+
+        # Build seq_idx for this block. Monotonic across blocks via
+        # seq_idx_base — when state is being carried, doc ids must keep
+        # incrementing so a doc boundary at block boundary correctly
+        # zeroes the carried state's contribution.
+        #
+        # NOTE: empirically this offset-by-seq_idx_base behavior is what
+        # works. We tried "reset seq_idx to 0 at every block" thinking the
+        # kernel's internal seq_idx=0 start was an assertion about carried
+        # state — that interpretation produced a -0.04 BPB regression. The
+        # original behavior, which silently zeroes the carried state on
+        # block boundaries via seq_idx mismatch, is actually less harmful
+        # than letting stale state from millions of tokens ago flow into
+        # the next block's first chunk. The model never trained for non-
+        # zero initial_states, so OOD carryover is worse than fresh start.
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        # Carryover is incompatible with depth recurrence (would update the
+        # same block's state multiple times per forward).
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError(
+                "forward_with_state is incompatible with depth recurrence."
+            )
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_wd_params, no_wd_params, embed_params = [], [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            continue
+
+        # No-weight-decay convention (mamba_ssm + modded-nanogpt):
+        #   - mamba_ssm flags A_log, D, dt_bias with _no_weight_decay = True;
+        #     regularizing A_log destabilizes the SSM recurrent dynamics
+        #     (see mamba_ssm README).
+        #   - Biases conventionally exempt from wd.
+        #   - 1D params (norm.weight, scales like ssm_scale/mlp_scale/attn_scale,
+        #     learnable per-head q_gain) conventionally exempt from wd.
+        no_wd = (
+            getattr(p, "_no_weight_decay", False)
+            or name.endswith(".bias")
+            or p.ndim < 2
+        )
+        if no_wd:
+            no_wd_params.append(p)
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+            mat_params.append(p)
+        else:
+            # 2D control params (resid_mix, mem_to_model.weight, etc.) routed
+            # away from Muon but still get WD as before.
+            scalar_wd_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_wd_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": no_wd_params, "lr": SCALAR_LR, "weight_decay": 0.0, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar_wd={len(scalar_wd_params)} (AdamW wd={WEIGHT_DECAY}), "
+        f"no_wd={len(no_wd_params)} (AdamW wd=0), "
+        f"embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding with no dropped remainder items."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+def _sliding_score_records(total_tokens: int, seq_len: int, stride: int,
+                           score_start: int = 0, score_end=None):
+    """Yield full-length causal windows that score each target position once.
+
+    A record is (window_start, tail_start, tail_len). The input window is
+    val_tokens[window_start : window_start + seq_len], and only
+    [tail_start : tail_start + tail_len] positions in that window are scored.
+
+    The first prefix is scored from a normal full-length window starting at 0,
+    so Mamba/attention kernels still see the regular SEQ_LEN shape.
+    """
+    total_tokens = int(total_tokens)
+    seq_len = int(seq_len)
+    stride = int(stride)
+    if score_end is None:
+        score_end = total_tokens
+    score_start = max(0, int(score_start))
+    score_end = min(total_tokens, int(score_end))
+    if score_end <= score_start:
+        return
+
+    cur = score_start
+    if cur < min(score_end, seq_len):
+        prefix_end = min(score_end, seq_len)
+        yield 0, cur, prefix_end - cur
+        cur = prefix_end
+
+    while cur < score_end:
+        se = min(cur + stride, score_end)
+        window_start = max(0, se - seq_len)
+        if window_start + seq_len > total_tokens:
+            window_start = max(0, total_tokens - seq_len)
+        tail_start = cur - window_start
+        tail_len = se - cur
+        if tail_len > 0:
+            yield window_start, tail_start, tail_len
+        cur = se
+
+
+def _iter_sliding_score_batches(val_tokens, record_indices, seq_len: int, batch_windows: int):
+    """Batch sliding-score records by compatible tail slice."""
+    pending_x, pending_y = [], []
+    pending_key = None
+
+    def flush():
+        nonlocal pending_x, pending_y, pending_key
+        if not pending_x:
+            return None
+        xn = np.stack(pending_x)
+        yn = np.stack(pending_y)
+        tail_start, tail_len = pending_key
+        pending_x, pending_y, pending_key = [], [], None
+        return xn, yn, tail_start, tail_len
+
+    for window_start, tail_start, tail_len in record_indices:
+        key = (int(tail_start), int(tail_len))
+        if pending_key is not None and (key != pending_key or len(pending_x) >= batch_windows):
+            item = flush()
+            if item is not None:
+                yield item
+        pending_key = key
+        pending_x.append(val_tokens[window_start : window_start + seq_len])
+        pending_y.append(val_tokens[window_start + 1 : window_start + seq_len + 1])
+
+    item = flush()
+    if item is not None:
+        yield item
+
+
+def lm_loss_tail(core, ids, targets, tail_start: int, tail_len: int):
+    """LM loss restricted to already-scored tail tokens for legal TTT."""
+    hidden = core(ids, state=None, return_state=False)
+    tail_start = int(tail_start)
+    tail_len = int(tail_len)
+    hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+    y_tail = targets[:, tail_start : tail_start + tail_len]
+    logits = core.output_logits_from_hidden(hidden_tail)
+    logits = core.add_copy_logits(logits, hidden_tail, hidden, ids, query_start=tail_start)
+    return F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="mean")
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Exact sliding-window evaluation.
+
+    Scores every target token exactly once. The first prefix is scored from a
+    full SEQ_LEN window starting at 0; subsequent tokens are scored in `stride`
+    tails from windows ending at the scored segment. Remainder records are
+    sharded exactly across ranks.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+
+    records = list(_sliding_score_records(total_tokens, seq_len, stride))
+    rec_start, rec_end = _rank_bounds(len(records))
+    local_records = records[rec_start:rec_end]
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = max(1, (len(local_records) + batch_windows - 1) // batch_windows)
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+            val_tokens, local_records, seq_len, batch_windows):
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+            y_tail = y[:, tail_start : tail_start + tail_len]
+            logits = core.output_logits_from_hidden(hidden_tail)
+            logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+            loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+        cnt = float(y_tail.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+        t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * max(0, total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {len(local_records)} records/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib,
+                       block_len=None, warmup_tokens=None):
+    """
+    SSM-native state-carryover eval.
+
+    Process the val set as non-overlapping `block_len`-token blocks. The
+    Mamba2 SSM hidden state and conv1d state for every layer are threaded
+    across blocks via the direct kernel call (mamba_chunk_scan_combined
+    with initial_states / return_final_states), so a token at position p
+    sees ALL p preceding tokens via the recurrence (not just the SEQ_LEN
+    window an attention model would have). Attention layers (which can't
+    carry state) see only the current block, matching training context.
+
+    Each rank gets a contiguous slice of the val stream so state passing
+    stays causal within rank. The first `warmup_tokens` of each rank's
+    slice are processed to warm the recurrent state but their losses are
+    not scored (otherwise positions with near-empty state would be unfairly
+    counted).
+
+    If CARRYOVER_DIRECT_KERNEL is False, falls back to the inference_params
+    path (broken in current mamba_ssm builds — kept for diagnosis only).
+
+    Returns (val_loss, val_bpb).
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    warmup_blocks = warmup_tokens // block_len  # round down to block boundary
+
+    use_direct = CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None
+    if not use_direct:
+        if not _HAS_CHUNK_SCAN:
+            log0("[carryover_eval] mamba_chunk_scan_combined unavailable")
+        if rearrange is None:
+            log0("[carryover_eval] einops not importable")
+        if InferenceParams is None:
+            raise RuntimeError("no carryover path available (no chunk_scan, no InferenceParams)")
+        log0("[carryover_eval] falling back to InferenceParams path (likely broken)")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+
+    if getattr(core, "loop_enabled_external", False):
+        log0("[carryover_eval] depth recurrence active — temporarily disabled for this eval")
+        prev_loop = True
+        core.loop_enabled_external = False
+    else:
+        prev_loop = False
+
+    total_tokens = val_tokens.size - 1  # x/y consume span-1 tokens
+
+    # Stateful-overlap config (PR #1644 / reviewer guidance):
+    #   - block has length `block_len` total tokens
+    #   - first `overlap` tokens are "context" — Mamba state has carried
+    #     them via initial_states; attention re-sees them inside the block;
+    #     they are NOT scored (already counted as score_region in prior block)
+    #   - remaining `score_region = block_len - overlap` tokens are scored
+    #   - block stride = score_region (not block_len), so consecutive blocks
+    #     overlap by exactly `overlap` tokens
+    #
+    # When overlap=0, this collapses to non-overlap (legacy) behavior.
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), block_len - 1))
+    score_region = block_len - overlap
+
+    # Exact block sharding. Global block index g starts at g * score_region.
+    # Only full block_len windows are used here to keep the direct Mamba kernel
+    # shape stable. No block index is dropped across ranks.
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - block_len) // score_region + 1)
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    n_scored_blocks = max(0, n_blocks - warmup_blocks)
+
+    # State containers
+    if use_direct:
+        layer_states = None  # filled on first block by forward_with_state
+        seq_idx_base = 0     # monotonic doc-id counter across blocks
+    else:
+        inference_params = InferenceParams(max_seqlen=block_len, max_batch_size=1)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    path_label = "direct_kernel" if use_direct else "inference_params"
+    log0(
+        f"  carryover_eval: path={path_label}, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        # Block starts at global_b_idx * score_region (so consecutive blocks
+        # overlap by `overlap` tokens). We need block_len + 1 tokens total:
+        # block_len input tokens plus the next-token target.
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + block_len + 1]
+        if chunk.size < block_len + 1:
+            break
+        xn = chunk[:-1].reshape(1, block_len)
+        yn = chunk[1:].reshape(1, block_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            if use_direct:
+                hidden, layer_states, seq_idx_base = core.forward_with_state(
+                    x, layer_states, seq_idx_base=seq_idx_base
+                )
+            else:
+                hidden = core(x, inference_params=inference_params)
+            logits = core.output_logits_from_hidden(hidden)
+            logits = core.add_copy_logits(logits, hidden, hidden, x, query_start=0)
+
+            # Score only new positions. The first GLOBAL block must score from
+            # position 0 so official cold-start tokens are counted; every later
+            # block skips the overlap because those tokens were already scored.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            score_logits = logits[:, score_start:, :]
+            score_y = y[:, score_start:]
+            loss = F.cross_entropy(
+                score_logits.float().reshape(-1, score_logits.shape[-1]),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            # Bytes accounting also restricted to the positions actually scored.
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / n_blocks
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(
+        f"  carryover_eval: rank={RANK} scored={n_scored_blocks} blocks "
+        f"(warmup={warmup_blocks}), block_len={block_len}, path={path_label}, {elapsed:.1f}s"
+    )
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# LoRA infrastructure for legal score-first TTT
+# -----------------------------------------------------------------------------
+class LoRALinear(nn.Module):
+    """
+    LoRA adapter wrapping an existing nn.Linear without changing its semantics
+    at init. Output is `linear(x) + alpha/r * (x @ A^T @ B^T)`. At init B=0
+    so the wrapped output exactly matches the base linear.
+
+    The base linear's weight is held *frozen* via a registered buffer ref;
+    only the LoRA A, B matrices have requires_grad=True (per LORA_FROZEN_BASE
+    convention).
+    """
+    def __init__(self, base_linear: nn.Linear, rank: int, alpha: float):
+        super().__init__()
+        if not isinstance(base_linear, nn.Linear):
+            raise TypeError(f"LoRALinear expects nn.Linear, got {type(base_linear)}")
+        self.base = base_linear  # not registered as submodule param-wise — we freeze it externally
+        self.in_features = base_linear.in_features
+        self.out_features = base_linear.out_features
+        self.rank = int(rank)
+        self.alpha = float(alpha)
+        self.scaling = self.alpha / max(1, self.rank)
+        # A: (rank, in_features) — initialized small random
+        # B: (out_features, rank) — initialized zero so initial output unchanged
+        self.lora_A = nn.Parameter(torch.zeros(self.rank, self.in_features))
+        self.lora_B = nn.Parameter(torch.zeros(self.out_features, self.rank))
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        # B stays zero
+
+    def forward(self, x):
+        # Base path
+        base_out = self.base(x)
+        # LoRA path: x @ A^T @ B^T. Use F.linear for compute-friendliness.
+        lora_out = F.linear(F.linear(x, self.lora_A), self.lora_B)
+        return base_out + self.scaling * lora_out
+
+    def reset_lora(self):
+        """Zero out B to restore base-only behavior. A is left as-is."""
+        with torch.no_grad():
+            self.lora_B.zero_()
+
+
+def install_lora_adapters(core: nn.Module, rank: int, alpha: float,
+                           target_substrings=("qkv", "out_proj", "gate_up", "down", "in_proj")):
+    """
+    Walk the model and replace selected nn.Linear modules with LoRALinear
+    wrappers. Returns (lora_params, n_replaced). Base weights are frozen
+    (requires_grad=False) — only LoRA A,B have grads.
+
+    target_substrings: any module name *segment* matching one of these gets
+      LoRA wrapped. Defaults match attention qkv/out_proj, FFN gate_up/down,
+      and Mamba in_proj/out_proj. Mamba2 uses these modules by calling them,
+      so LoRALinear preserves both the normal and direct state-carryover paths.
+    """
+    # Snapshot the modules to replace (don't mutate during iteration)
+    to_replace = []  # list of (parent_module, attr_name, base_linear)
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if not isinstance(child, nn.Linear):
+                continue
+            full_name = f"{module_name}.{child_name}" if module_name else child_name
+            # Match if any target substring appears as a segment (last component)
+            # AND the linear is not the lm_head/tok_emb (those are too sensitive)
+            if "lm_head" in full_name or "tok_emb" in full_name or "embed_proj" in full_name:
+                continue
+            if any(t == child_name for t in target_substrings):
+                to_replace.append((module, child_name, child, full_name))
+
+    n_replaced = 0
+    lora_params = []
+    for parent, child_name, base_linear, full_name in to_replace:
+        wrapper = LoRALinear(base_linear, rank=rank, alpha=alpha)
+        # Move to same device/dtype as base
+        wrapper = wrapper.to(device=base_linear.weight.device, dtype=base_linear.weight.dtype)
+        setattr(parent, child_name, wrapper)
+        n_replaced += 1
+        lora_params.append(wrapper.lora_A)
+        lora_params.append(wrapper.lora_B)
+
+    # Freeze all non-LoRA params
+    for p in core.parameters():
+        p.requires_grad_(False)
+    # Re-enable grads on LoRA params
+    for p in lora_params:
+        p.requires_grad_(True)
+
+    return lora_params, n_replaced
+
+
+def uninstall_lora_adapters(core: nn.Module):
+    """
+    Restore base nn.Linear modules in place of LoRALinear wrappers and
+    re-enable grads on all params. Called after TTT eval to leave the
+    model in its pre-eval state for any subsequent operations (compression,
+    further evals, etc.).
+    """
+    to_restore = []
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if isinstance(child, LoRALinear):
+                to_restore.append((module, child_name, child))
+    for parent, child_name, wrapper in to_restore:
+        setattr(parent, child_name, wrapper.base)
+    for p in core.parameters():
+        p.requires_grad_(True)
+    return len(to_restore)
+
+
+def reset_all_lora(core: nn.Module):
+    """Zero out all lora_B in the model (resets to base-only behavior).
+    Used between eval phases or to clear adapter state."""
+    n = 0
+    for m in core.modules():
+        if isinstance(m, LoRALinear):
+            m.reset_lora()
+            n += 1
+    return n
+
+
+# -----------------------------------------------------------------------------
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first TTT with LoRA/adapters.
+
+    For each rank-local validation chunk:
+      1. Score each target token exactly once under no_grad.
+      2. Train adapters only on those already-scored tail tokens.
+      3. Carry adapter weights forward to the next chunk.
+
+    This fixes the previous overweighting bug where TTT trained on the full
+    overlapping windows even though only the scored tail tokens should adapt.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    if SCORE_FIRST_TTT_USE_LORA:
+        lora_params, n_replaced = install_lora_adapters(
+            core,
+            rank=SCORE_FIRST_TTT_LORA_RANK,
+            alpha=SCORE_FIRST_TTT_LORA_ALPHA,
+            target_substrings=SCORE_FIRST_TTT_TARGETS,
+        )
+        adapt_params = lora_params
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (LoRA): rank={SCORE_FIRST_TTT_LORA_RANK} "
+            f"alpha={SCORE_FIRST_TTT_LORA_ALPHA} replaced={n_replaced} linears, "
+            f"adapting {n_adapt:,} LoRA params, targets={SCORE_FIRST_TTT_TARGETS}, "
+            f"opt={SCORE_FIRST_TTT_OPT}, lr={SCORE_FIRST_TTT_LR}, "
+            f"wd={SCORE_FIRST_TTT_WD}, all_reduce={'NO' if SCORE_FIRST_TTT_NO_ALLREDUCE else 'YES'}"
+        )
+        base_state = None
+    else:
+        adapt_params = list(core.parameters())
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (FULL): chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, "
+            f"lr={SCORE_FIRST_TTT_LR}, momentum={SCORE_FIRST_TTT_MOMENTUM}, "
+            f"epochs={SCORE_FIRST_TTT_EPOCHS}, adapting {n_adapt:,} params"
+        )
+        base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    if SCORE_FIRST_TTT_OPT == "adamw":
+        ttt_opt = torch.optim.AdamW(
+            adapt_params,
+            lr=SCORE_FIRST_TTT_LR,
+            betas=(0.9, SCORE_FIRST_TTT_BETA2),
+            weight_decay=SCORE_FIRST_TTT_WD,
+        )
+    else:
+        ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                                  momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens + chunk_tokens - 1) // chunk_tokens
+    chunk_start_idx, chunk_end_idx = _rank_bounds(n_chunks)
+    local_chunks = chunk_end_idx - chunk_start_idx
+    batch_windows = max(1, 131072 // seq_len)
+    train_batch_windows = max(1, batch_windows // 2)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, local_chunks // 10)
+
+    try:
+        for chunk_idx_local, ci in enumerate(range(chunk_start_idx, chunk_end_idx)):
+            score_start = ci * chunk_tokens
+            score_end = min(score_start + chunk_tokens, total_tokens)
+            if score_end <= score_start:
+                continue
+
+            records = list(_sliding_score_records(total_tokens, seq_len, stride, score_start, score_end))
+            train_batches = []
+
+            core.eval()
+            with torch.no_grad():
+                for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+                        val_tokens, records, seq_len, batch_windows):
+                    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        hidden = core(x, state=None, return_state=False)
+                        hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+                        y_tail = y[:, tail_start : tail_start + tail_len]
+                        logits = core.output_logits_from_hidden(hidden_tail)
+                        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+                        loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+                    cnt = float(y_tail.numel())
+                    loss_sum += float(loss.detach().float().item())
+                    p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    b = bb[t_tail].astype(np.int16, copy=True)
+                    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                    tok_sum += cnt
+                    byt_sum += float(b.astype(np.float64).sum())
+                    train_batches.append((xn, yn, int(tail_start), int(tail_len)))
+
+            if train_batches:
+                core.train()
+                chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, local_chunks)))
+                for g in ttt_opt.param_groups:
+                    g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+                for _epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                    order = np.random.permutation(len(train_batches))
+                    for batch_i in order:
+                        bx, by, tail_start, tail_len = train_batches[int(batch_i)]
+                        for bi in range(0, bx.shape[0], train_batch_windows):
+                            be = min(bi + train_batch_windows, bx.shape[0])
+                            ax = torch.from_numpy(bx[bi:be]).long().to(DEVICE, non_blocking=True)
+                            ay = torch.from_numpy(by[bi:be]).long().to(DEVICE, non_blocking=True)
+
+                            ttt_opt.zero_grad(set_to_none=True)
+                            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                                adapt_loss = lm_loss_tail(core, ax, ay, tail_start, tail_len)
+                            adapt_loss.backward()
+
+                            if not SCORE_FIRST_TTT_NO_ALLREDUCE:
+                                for p in adapt_params:
+                                    if p.grad is not None:
+                                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                            if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                                nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                            ttt_opt.step()
+
+            if (chunk_idx_local + 1) % log_every_chunks == 0:
+                elapsed_e = time.perf_counter() - t0_eval
+                running_loss = loss_sum / max(tok_sum, 1.0)
+                running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+                eta = elapsed_e / (chunk_idx_local + 1) * max(0, local_chunks - chunk_idx_local - 1)
+                log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{local_chunks} "
+                     f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+        elapsed = time.perf_counter() - t0_eval
+        log0(f"  score_first_ttt: {local_chunks} chunks/rank, "
+             f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+        stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+        loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+        val_loss = loss_sum / max(tok_sum, 1.0)
+        bpt = val_loss / math.log(2.0)
+        return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+    finally:
+        if SCORE_FIRST_TTT_USE_LORA:
+            n_uninstalled = uninstall_lora_adapters(core)
+            log0(f"  score_first_ttt: uninstalled {n_uninstalled} LoRA adapters, base weights restored")
+        else:
+            with torch.no_grad():
+                for name, p in core.named_parameters():
+                    if name in base_state:
+                        p.data.copy_(base_state[name])
+        core.train()
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes an exact contiguous shard of val sequences.
+    seq_start, seq_end = _rank_bounds(total_seqs)
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = max(1, min(TTT_GLOBAL_BATCH_SEQS, max(local_seqs, 1)))
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks with exact remainder handling.
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start, seq_end = _rank_bounds(total_seqs)
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seq_end - seq_start
+    local_total_seqs = n_local_seqs
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {local_total_seqs})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Compression / quantization (int6 packed + Brotli-11)
+# -----------------------------------------------------------------------------
+def _quantize_row_sdclip(t: torch.Tensor, k: float, half_levels: int):
+    """Per-row symmetric quantization with std-based clipping.
+
+    t: (rows, cols) float
+    k: clipping coefficient (clip = k * std(row))
+    half_levels: max abs value (e.g., 31 for int6, 127 for int8)
+    Returns: (q int8 tensor, scale fp16 tensor)
+    """
+    t32 = t.float()
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    clip = (k * row_std).clamp_min(1e-8)  # (rows,)
+    scale = (clip / half_levels).clamp_min(1e-8)
+    clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+    q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels).to(torch.int8)
+    return q.contiguous(), scale.to(torch.float16).contiguous()
+
+
+def _quantize_row_optclip(t: torch.Tensor, half_levels: int,
+                           k_grid=(2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0, 24.0, 32.0, 48.0)):
+    """Per-row optimal-clip quantization (lite-GPTQ for embeddings).
+
+    For each row, sweep k_grid and pick the k that minimizes L2 reconstruction
+    error. The dominant quant-error driver for embedding tensors is rare-token
+    rows whose magnitude distribution differs from common-token rows; a single
+    global clip hurts them disproportionately. This captures most of GPTQ's
+    benefit for embeddings without needing calibration data.
+
+    NOT full GPTQ (no Hessian, no per-column error compensation). For
+    embeddings specifically the dominant error term is per-row magnitude
+    calibration, which this captures.
+    """
+    t32 = t.float()
+    rows, cols = t32.shape
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    row_abs_max = t32.abs().max(dim=1).values.clamp_min(1e-8)
+
+    best_err = torch.full((rows,), float("inf"), device=t32.device)
+    best_scale = torch.zeros((rows,), device=t32.device)
+    best_q = torch.zeros_like(t32, dtype=torch.int8)
+
+    for k in k_grid:
+        clip = (k * row_std).clamp_min(1e-8)
+        # Cap clip at row_abs_max so we don't waste levels on impossible values
+        clip = torch.minimum(clip, row_abs_max)
+        scale = (clip / half_levels).clamp_min(1e-8)
+        clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+        q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels)
+        recon = q * scale[:, None]
+        err = ((recon - t32) ** 2).sum(dim=1)
+        improved = err < best_err
+        best_err = torch.where(improved, err, best_err)
+        best_scale = torch.where(improved, scale, best_scale)
+        improved_mask = improved[:, None].expand_as(t32)
+        best_q = torch.where(improved_mask, q.to(torch.int8), best_q)
+
+    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+
+
+def _pack_int6(q_int8: torch.Tensor):
+    """Pack int8-stored int6 values (range [-31, 31]) into uint8.
+    4 values × 6 bits = 24 bits = 3 bytes."""
+    flat = q_int8.flatten().to(torch.int32) + 32  # shift to [0, 63]
+    n = flat.numel()
+    pad = (-n) % 4
+    if pad:
+        flat = torch.cat([flat, torch.zeros(pad, dtype=torch.int32, device=flat.device)])
+    g = flat.view(-1, 4)
+    a, b, c, d = g[:, 0], g[:, 1], g[:, 2], g[:, 3]
+    byte0 = ((a << 2) | (b >> 4)) & 0xFF
+    byte1 = (((b & 0xF) << 4) | (c >> 2)) & 0xFF
+    byte2 = (((c & 0x3) << 6) | d) & 0xFF
+    packed = torch.stack([byte0, byte1, byte2], dim=1).flatten().to(torch.uint8)
+    return packed.contiguous(), n
+
+
+def _unpack_int6(packed_u8: torch.Tensor, n_orig: int, shape):
+    """Inverse of _pack_int6."""
+    arr = packed_u8.to(torch.int32)
+    g = arr.view(-1, 3)
+    byte0, byte1, byte2 = g[:, 0], g[:, 1], g[:, 2]
+    a = byte0 >> 2
+    b = ((byte0 & 0x3) << 4) | (byte1 >> 4)
+    c = ((byte1 & 0xF) << 2) | (byte2 >> 6)
+    d = byte2 & 0x3F
+    unpacked = torch.stack([a, b, c, d], dim=1).flatten()[:n_orig]
+    signed = unpacked.to(torch.int32) - 32
+    return signed.view(shape).to(torch.int8)
+
+
+def _is_embedding_tensor(name: str) -> bool:
+    """Embedding-like tensors get int8 (more sensitive to quantization);
+    everything else gets int6."""
+    n = name
+    return (
+        "tok_emb" in n
+        or "lm_head" in n
+        or "embed_proj" in n
+        or ("bigram" in n and "embed" in n)
+    )
+
+
+def _compress_best(raw: bytes):
+    """Try Brotli-11 (best); fall back to zstd-22; final fallback zlib-9."""
+    if _HAS_BROTLI:
+        try:
+            return brotli.compress(raw, quality=11), "brotli11"
+        except Exception:
+            pass
+    if "zstandard" in sys.modules:
+        try:
+            cctx = sys.modules["zstandard"].ZstdCompressor(level=22)
+            return cctx.compress(raw), "zstd22"
+        except Exception:
+            pass
+    return zlib.compress(raw, 9), "zlib9"
+
+
+def _decompress(blob: bytes, scheme: str) -> bytes:
+    if scheme == "brotli11":
+        return brotli.decompress(blob)
+    if scheme == "zstd22":
+        return sys.modules["zstandard"].ZstdDecompressor().decompress(blob)
+    return zlib.decompress(blob)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- State-carryover eval (SSM-native) ---
+    # Threads Mamba2 hidden state across non-overlapping val blocks via the
+    # direct mamba_chunk_scan_combined kernel (with initial_states /
+    # return_final_states). Falls back to InferenceParams path for diagnosis
+    # if direct kernel unavailable. Compare against the sliding-window
+    # number above to see whether long-prefix recurrent state actually helps.
+    pre_ttt_co_vb = None
+    have_carry_path = (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None) \
+                       or (InferenceParams is not None)
+    if CARRYOVER_EVAL_ENABLED and have_carry_path:
+        dist.barrier()
+        log0("=" * 60)
+        log0(f"Running state-carryover eval (block_len={CARRYOVER_BLOCK_LEN}, warmup={CARRYOVER_WARMUP_TOKENS} tokens)...")
+        try:
+            co_vl, co_vb = eval_val_carryover(
+                model, val_tokens, bb, hs, ib,
+                block_len=CARRYOVER_BLOCK_LEN,
+                warmup_tokens=CARRYOVER_WARMUP_TOKENS,
+            )
+            log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+            log0(f"Carryover vs standard:    bpb={best_vb - co_vb:+.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"Carryover vs sliding:     bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+            pre_ttt_co_vb = co_vb
+        except Exception as e:
+            log0(f"[carryover_eval] FAILED: {type(e).__name__}: {e}")
+            import traceback
+            log0(traceback.format_exc())
+            log0("[carryover_eval] continuing — sliding-window number above is unaffected")
+        log0("=" * 60)
+    elif CARRYOVER_EVAL_ENABLED:
+        log0("[carryover_eval] skipped: no carryover path available (need either mamba_chunk_scan_combined or InferenceParams)")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if RUN_PREQUANT_SCORE_FIRST_TTT and SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Quantization + compression + roundtrip validation
+    # int6 GPTQ-lite (per-row SDClip) for matrices, int8 for embeddings,
+    # fp16 passthrough for small/sensitive. Brotli-11 with zstd fallback.
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0(f"Quantizing model (mode={QUANT_MODE}, k_mat={QUANT_K_MATRIX}, k_emb={QUANT_K_EMBED})...")
+    state_dict = base_model.state_dict()
+
+    # Dynamics-protected quantization (PR #1890 / Q-Mamba ICLR 2025).
+    # Mamba2.in_proj output is split into [z, x, B, C, dt]; the last `nheads`
+    # rows of in_proj.weight produce dt (the SSM time-step generator).
+    # Q-Mamba shows that uniform 6-bit PTQ destabilizes the SSM recurrence
+    # because errors in dt (and consequently A_bar = exp(dt*A)) compound over
+    # many tokens. Promoting just these dt rows to INT8 costs ~16 extra bytes
+    # per packed row (about 0.01 MB total at our scale) and recovers most of
+    # the post-quant BPB regression.
+    #
+    # We derive the row range from the live module's .nheads attribute rather
+    # than hardcoding indices, so this works across configs with different
+    # ngroups, d_state, headdim, etc. The map is keyed by the parameter name
+    # we'd see in state_dict (e.g. "blocks.0.mamba.in_proj.weight").
+    dt_row_map = {}  # name -> (dt_start, dt_end) in row indexing
+    if QUANT_PROTECT_DYNAMICS:
+        for mod_name, mod in base_model.named_modules():
+            # mamba_ssm Mamba2 modules expose .nheads, .in_proj
+            if hasattr(mod, "in_proj") and hasattr(mod, "nheads"):
+                w = getattr(mod.in_proj, "weight", None)
+                if w is None or w.ndim != 2:
+                    continue
+                total_rows = w.shape[0]
+                nheads = int(mod.nheads)
+                if nheads <= 0 or nheads >= total_rows:
+                    continue
+                weight_name = f"{mod_name}.in_proj.weight"
+                dt_row_map[weight_name] = (total_rows - nheads, total_rows)
+        log0(
+            f"  dynamics-protected rows: {len(dt_row_map)} in_proj tensors flagged "
+            f"({sum(end-start for start,end in dt_row_map.values())} total dt rows -> int8)"
+        )
+
+    # Stats counters
+    n_int6 = n_int8 = n_passthrough = n_alias = 0
+    bytes_int6 = bytes_int8 = bytes_passthrough = 0
+
+    quant_entries = {}    # name -> {"mode", ...} or {"mode": "alias", "target": canonical_name}
+    # Tied-weight dedup keyed by the ORIGINAL tensor's data_ptr/storage. We
+    # must NOT key on the CPU copy's data_ptr — CPU buffers get freed and
+    # reused across iterations, causing false-positive aliases between
+    # unrelated tensors. Original state_dict tensors share storage with
+    # live model parameters, so their data_ptrs are stable for the duration
+    # of this loop.
+    seen_ptrs = {}
+
+    for name, t_orig in state_dict.items():
+        # Check aliasing on the original tensor BEFORE making any copies.
+        # Combine data_ptr with shape to be doubly safe — two tensors that
+        # share storage AND have the same shape are genuine aliases (e.g.
+        # tied lm_head.weight ↔ tok_emb.weight). Different shapes at the
+        # same ptr would indicate a view, not a tied weight.
+        ptr_key = (t_orig.data_ptr(), tuple(t_orig.shape))
+        if ptr_key in seen_ptrs:
+            quant_entries[name] = {"mode": "alias", "target": seen_ptrs[ptr_key]}
+            n_alias += 1
+            continue
+        seen_ptrs[ptr_key] = name
+
+        t = t_orig.detach().cpu().contiguous()
+
+        # Non-float or small/sensitive: keep as fp16 (or original int)
+        if not t.is_floating_point():
+            quant_entries[name] = {"mode": "raw", "tensor": t}
+            n_passthrough += 1
+            bytes_passthrough += t.numel() * t.element_size()
+            continue
+
+        if t.numel() <= QUANT_PASSTHROUGH_NUMEL or t.ndim != 2:
+            t16 = t.to(torch.float16).contiguous()
+            quant_entries[name] = {"mode": "fp16", "tensor": t16}
+            n_passthrough += 1
+            bytes_passthrough += t16.numel() * 2
+            continue
+
+        # 2D float, large: quantize
+        is_embed = _is_embedding_tensor(name)
+        if QUANT_MODE == "int8" or is_embed:
+            # int8 with SDClip — embedding-like tensors get optimal-clip
+            # search (GPTQ-lite) when enabled, otherwise the single global k.
+            if is_embed and QUANT_OPTCLIP_EMBED:
+                q, scale = _quantize_row_optclip(t, half_levels=127)
+            else:
+                q, scale = _quantize_row_sdclip(t, k=QUANT_K_EMBED if is_embed else QUANT_K_MATRIX, half_levels=127)
+            # Store as raw int8 bytes (no need to pack — one byte per value)
+            quant_entries[name] = {
+                "mode": "int8",
+                "packed": q.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(t.numel()),
+            }
+            n_int8 += 1
+            bytes_int8 += q.numel()
+        elif name in dt_row_map:
+            # Dynamics-protected int6+int8 split: low rows int6, dt rows int8.
+            dt_start, dt_end = dt_row_map[name]
+            t_low = t[:dt_start].contiguous()        # z, x, B, C rows -> int6
+            t_dt = t[dt_start:dt_end].contiguous()   # dt rows -> int8
+
+            q_low, scale_low = _quantize_row_sdclip(t_low, k=QUANT_K_MATRIX, half_levels=31)
+            packed_low, n_orig_low = _pack_int6(q_low)
+
+            q_dt, scale_dt = _quantize_row_sdclip(t_dt, k=QUANT_K_MATRIX, half_levels=127)
+
+            quant_entries[name] = {
+                "mode": "mixed_int6_int8",
+                "packed_low": packed_low.numpy().tobytes(),
+                "scale_low": scale_low,
+                "shape_low": tuple(t_low.shape),
+                "numel_low": int(n_orig_low),
+                "packed_dt": q_dt.numpy().tobytes(),
+                "scale_dt": scale_dt,
+                "shape_dt": tuple(t_dt.shape),
+                "shape_full": tuple(t.shape),
+            }
+            n_int6 += 1  # count under int6 since the bulk is int6
+            bytes_int6 += packed_low.numel()
+            bytes_int8 += q_dt.numel()
+        else:
+            # int6 packed (4 vals per 3 bytes) with SDClip
+            q, scale = _quantize_row_sdclip(t, k=QUANT_K_MATRIX, half_levels=31)
+            packed, n_orig = _pack_int6(q)
+            quant_entries[name] = {
+                "mode": "int6",
+                "packed": packed.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(n_orig),
+            }
+            n_int6 += 1
+            bytes_int6 += packed.numel()
+
+    log0(
+        f"  quant tensors: int6={n_int6} ({bytes_int6/1e6:.2f}MB) "
+        f"int8={n_int8} ({bytes_int8/1e6:.2f}MB) "
+        f"fp16/raw={n_passthrough} ({bytes_passthrough/1e6:.2f}MB) "
+        f"alias={n_alias}"
+    )
+    raw_total = bytes_int6 + bytes_int8 + bytes_passthrough
+    log0(f"  raw quantized total before compression: {raw_total/1e6:.2f}MB")
+
+    # Serialize and compress
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_entries, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    quant_blob, scheme = _compress_best(quant_raw)
+    compressed_bytes = len(quant_blob)
+    log0(
+        f"Compressed model ({scheme}): {compressed_bytes:,} bytes "
+        f"({compressed_bytes / 1024 / 1024:.2f} MB) — "
+        f"{'UNDER' if compressed_bytes <= 16_000_000 else 'OVER'} 16MB cap"
+    )
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    quant_raw_rt = _decompress(quant_blob, scheme)
+    quant_entries_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    dequant_state = {}
+    # First pass: dequantize non-alias entries
+    for name, entry in quant_entries_rt.items():
+        mode = entry["mode"]
+        if mode == "alias":
+            continue  # second pass
+        if mode == "raw":
+            dequant_state[name] = entry["tensor"]
+        elif mode == "fp16":
+            dequant_state[name] = entry["tensor"].to(torch.bfloat16)
+        elif mode == "int8":
+            shape = entry["shape"]
+            packed = np.frombuffer(entry["packed"], dtype=np.int8)
+            q = torch.from_numpy(packed.copy()).view(shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "int6":
+            shape = entry["shape"]
+            n_orig = entry["numel"]
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed"], dtype=np.uint8).copy())
+            q = _unpack_int6(packed_u8, n_orig, shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "mixed_int6_int8":
+            # Dynamics-protected: low rows from int6, dt rows from int8.
+            shape_low = entry["shape_low"]
+            shape_dt = entry["shape_dt"]
+            shape_full = entry["shape_full"]
+            n_orig_low = entry["numel_low"]
+
+            # Decode int6 part
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed_low"], dtype=np.uint8).copy())
+            q_low = _unpack_int6(packed_u8, n_orig_low, shape_low)
+            scale_low = entry["scale_low"].float()
+            dq_low = q_low.float() * scale_low.view(shape_low[0], 1)
+
+            # Decode int8 part
+            packed_dt = np.frombuffer(entry["packed_dt"], dtype=np.int8)
+            q_dt = torch.from_numpy(packed_dt.copy()).view(shape_dt)
+            scale_dt = entry["scale_dt"].float()
+            dq_dt = q_dt.float() * scale_dt.view(shape_dt[0], 1)
+
+            # Stitch back to full shape
+            dq = torch.cat([dq_low, dq_dt], dim=0)
+            assert dq.shape == shape_full, f"mixed dequant shape mismatch: got {dq.shape}, expected {shape_full}"
+            dequant_state[name] = dq.to(torch.bfloat16)
+        else:
+            raise RuntimeError(f"unknown quant mode: {mode}")
+    # Second pass: resolve aliases
+    for name, entry in quant_entries_rt.items():
+        if entry["mode"] == "alias":
+            dequant_state[name] = dequant_state[entry["target"]]
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    q_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Final leaderboard-relevant diagnostic: dequantized artifact path +
+    # legal score-first LoRA TTT. Reload dequant weights first so any earlier
+    # eval state is clean; eval_score_first_ttt restores base weights after it.
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        base_model.load_state_dict(dequant_state, strict=True)
+        log0("=" * 60)
+        log0(f"Running POST-QUANT Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        q_sft_vl, q_sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant Score-First TTT val_loss:{q_sft_vl:.4f} val_bpb:{q_sft_vb:.4f}")
+        if q_sw_vb is not None:
+            log0(f"Post-quant Score-First TTT vs sliding: bpb={q_sw_vb - q_sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        ext = scheme  # brotli11 / zstd22 / zlib9
+        artifact_path = f"final_model.{QUANT_MODE}.{ext}.bin"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_param_golf_repair.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_param_golf_repair.py
@@ -1,0 +1,3643 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None  # state-carryover eval will be unavailable
+# Direct kernel access for proper chunked state passing — InferenceParams
+# routes through step() one token at a time and silently no-ops state
+# carryover on the chunked path. mamba_chunk_scan_combined natively supports
+# initial_states / return_final_states.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+# Brotli for compressed artifact (preferred over zstd).
+try:
+    import brotli  # type: ignore
+    _HAS_BROTLI = True
+except ImportError:
+    _HAS_BROTLI = False
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# torch._dynamo specializes on each block instance reference inside the
+# forward loop (10 distinct block objects → 10 recompiles for the dispatch
+# wrapper). Default cache_size_limit is 8, so we hit the warning and dynamo
+# falls back to eager for that frame. Bump it well above n_blocks.
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = 64
+    torch._dynamo.config.accumulated_cache_size_limit = 256
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))  # tested 128 — added ~17% throughput cost without recovering it in BPB at 10min training budget. 64 wins empirically here.
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Mamba2-specific knobs (passed to mamba_ssm.modules.mamba2.Mamba2)
+HEADDIM = int(os.environ.get("HEADDIM", "64"))   # tested 32 — slower kernel path at this size, didn't pay back in BPB
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))  # sharper than Mamba2 default 0.001
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))    # sharper than Mamba2 default 0.1
+FFN_MULT = int(os.environ.get("FFN_MULT", "2"))  # was 3 — FFN dominates the param budget; cutting to 2 saves ~8M params (~6MB compressed) at modest BPB cost
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document boundary handling for SSM training. SSMs accumulate state across
+# the entire sequence, so when multiple short docs are packed into a single
+# 8192-token training row, doc B's state is contaminated by doc A. Mamba2's
+# chunk-scan kernel accepts a `seq_idx` (B, T) int32 that zeros state
+# transitions at chunk boundaries where seq_idx changes. Reset granularity
+# is the chunk_size of the scan (256 by default), so contamination is
+# bounded to <=256 tokens after each boundary instead of unbounded.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))  # this tokenizer has bos=1 (<s>), pad=0; <s> appears every ~811 tokens in val data → real doc separator
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # genuine factoring: tok_emb is 8192x256, embed_proj 256->512. Saves ~2.1M raw on tok_emb, costs ~131K on embed_proj. Net ~1.5MB compressed savings vs EMBED_DIM=512 (which is no-op factoring).
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"  # default tied: saves 4.2M params at vocab=8192. Untied costs ~3MB compressed for ~0.005 BPB; not worth it under 16MB cap.
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]  # conservative default: your known-good single attention layer; use ATTN_LAYER_IDXS=2,5 only as an ablation
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # conservative default: your known-good SwiGLU; try leaky_relu2 only as an ablation
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))  # conservative default: restore baseline schedule; try 0.10 only as an ablation
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.20"))  # 80% warmdown (was 0.28 = 72%); EMA/SWA do not work for this SSM, so the schedule itself has to land precisely
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"  # off by default: saves ~1MB compressed (1.4M params), BPB cost ~0.002-0.005. Bigram hash gave marginal lift; not worth the bytes given the 16MB cap.
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# State carryover at eval — SSM-native: thread Mamba2 hidden state across
+# non-overlapping seq_len blocks of the val set so every scored token has the
+# entire validation prefix in its recurrent state (transformers can't do this).
+# Implementation: mamba_ssm InferenceParams cache, seqlen_offset held at 0 so
+# the chunked scan path is used with carried initial_states. Attention layers
+# (which can't carryover) see only their own block, matching training context.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"  # disabled by default — model not trained for stateful init, has been net-negative across 12+ runs. Re-enable with stateful-overlap to test.
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))  # stateful-overlap: each block = overlap + score_region. Mamba state carries; attention sees overlap+score_region; only score_region scored. PR #1644 reports this matches sliding within 0.3 mBPB.
+# Warmup tokens at the start of the val stream where Mamba state is still
+# "cold" (consumed too few tokens to be informative). These are processed to
+# advance state but their losses are not counted. Default to one full block
+# so the cold-start block is always excluded. Set to 0 to score everything.
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+# Direct chunk-scan path (Task 3): bypasses Mamba2.forward and calls the
+# triton kernel mamba_chunk_scan_combined with explicit initial_states /
+# return_final_states. This is the only path that actually carries SSM state
+# across non-overlapping val blocks at chunked-scan throughput. Set to "0"
+# to fall back to the (broken) inference_params version for diagnosis.
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Compression / quantization config — int6 GPTQ-lite + Brotli-11 stack.
+# Goal: <16,000,000-byte artifact. Naive int8+zstd lands ~35MB; int6 packed
+# + Brotli-11 + tied LM head should land ~13-15MB.
+QUANT_MODE = os.environ.get("QUANT_MODE", "int6_packed").lower()  # "int6_packed", "int8" (legacy)
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))  # SDClip k for matrix tensors (int6); SOTA value from PR #1394
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))    # SDClip k for embedding-like tensors (int8); higher k = less aggressive clipping
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "0"))  # quantize all 2D float tensors by default; keeps 1D/3D fp16 and helps stay under 16MB
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"  # PR #1890 / Q-Mamba: promote dt rows of mamba.in_proj.weight to INT8 to protect SSM recurrence from quant noise. ~16 extra bytes/row, big post-quant BPB recovery.
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"  # GPTQ-lite for embeddings: per-row optimal clip search instead of single global k. Targets rare-token rows whose distribution differs from common rows. ~0.005-0.010 BPB recovery on post-quant.
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1 = float(os.environ.get("BETA1", "0.9"))
+BETA2 = float(os.environ.get("BETA2", "0.95"))  # restore baseline optimizer default; use BETA2=0.99 only as an ablation
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"  # conservative default OFF; enable explicitly after validating baseline + post-quant sliding
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.003"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "1"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+# LoRA-scoped TTT params (legal score-first TTT per reviewer / PR #1797)
+SCORE_FIRST_TTT_USE_LORA = os.environ.get("SCORE_FIRST_TTT_USE_LORA", "1") == "1"  # adapt only LoRA params instead of all model params. Required for legal score-first TTT (otherwise the adaptation is too unstable and was the root cause of the previous all-params getting-stuck bug).
+SCORE_FIRST_TTT_LORA_RANK = int(os.environ.get("SCORE_FIRST_TTT_LORA_RANK", "32"))  # conservative default for eval-time cost; try 64 only after smoke testing
+SCORE_FIRST_TTT_LORA_ALPHA = float(os.environ.get("SCORE_FIRST_TTT_LORA_ALPHA", "64.0"))  # alpha/rank scaling
+SCORE_FIRST_TTT_OPT = os.environ.get("SCORE_FIRST_TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+SCORE_FIRST_TTT_BETA2 = float(os.environ.get("SCORE_FIRST_TTT_BETA2", "0.99"))  # AdamW beta2 (PR #1797 uses 0.99)
+SCORE_FIRST_TTT_WD = float(os.environ.get("SCORE_FIRST_TTT_WD", "0.1"))  # AdamW weight decay
+SCORE_FIRST_TTT_NO_ALLREDUCE = os.environ.get("SCORE_FIRST_TTT_NO_ALLREDUCE", "1") == "1"  # CRITICAL: ranks process disjoint val slices, so all-reducing TTT grads leaks future tokens between ranks. Default to rank-local TTT.
+SCORE_FIRST_TTT_TARGETS = tuple(x.strip() for x in os.environ.get("SCORE_FIRST_TTT_TARGETS", "qkv,out_proj,gate_up,down").split(",") if x.strip())
+SCORE_FIRST_TTT_WRAP_MAMBA = os.environ.get("SCORE_FIRST_TTT_WRAP_MAMBA", "0") == "1"  # default false: mamba_ssm.forward reads .weight directly and naive LoRA wrappers crash/deopt
+RUN_PREQUANT_SCORE_FIRST_TTT = os.environ.get("RUN_PREQUANT_SCORE_FIRST_TTT", "0") == "1"  # keep pre-quant TTT diagnostic off by default; final score is post-quant + legal score-first TTT
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("current_defaults: conservative restore: ATTN_LAYER_IDXS=6, ACTIVATION=swiglu, SCORE_FIRST_TTT off, QUANT_PASSTHROUGH_NUMEL=0")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, prequant={RUN_PREQUANT_SCORE_FIRST_TTT}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}, targets={SCORE_FIRST_TTT_TARGETS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"quant: mode={QUANT_MODE}, k_matrix={QUANT_K_MATRIX}, k_embed={QUANT_K_EMBED}, passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, brotli={_HAS_BROTLI}")
+log0(f"lr_schedule: {LR_SCHEDULE}, warmdown_start={LR_WARMDOWN_START_FRAC} ({(1.0-LR_WARMDOWN_START_FRAC)*100:.0f}% warmdown)")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, layer_idx=None):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,  # required for inference_params cache (state-carryover eval)
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        # When inference_params is given the Mamba2 chunked scan reads the
+        # carried initial_states from the cache and writes back the final
+        # state. We hold seqlen_offset at 0 so we never enter the step path.
+        # seq_idx (B, T) int32 zeroes state transitions at chunk-aligned
+        # document boundaries.
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via the
+        triton kernel. Bypasses Mamba2.forward (whose inference_params path
+        goes through step() one token at a time, which silently no-ops the
+        chunked-scan state).
+
+        u: (B, L, d_model)
+        initial_ssm_state: (B, nheads, headdim, d_state) or None
+        prev_conv_input: (B, d_conv-1, conv_channels) or None.
+            Last d_conv-1 inputs to conv1d from previous block; None on
+            first block. With d_conv=4 this is 3 timesteps.
+        seq_idx: (B, L) int32 or None — document boundaries within block.
+            State transitions are zeroed at chunk-aligned positions where
+            seq_idx changes.
+
+        Returns: (y, final_ssm_state, last_conv_input)
+        """
+        m = self.mamba
+        B, L, _ = u.shape
+
+        # in_proj split — handle optional d_mlp path defensively
+        zxbcdt = m.in_proj(u)  # (B, L, total)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+        d_mlp = (full - expected) // 2
+
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_mlp, d_mlp, d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+        else:
+            z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+            z0 = x0_mlp = None
+
+        # Conv1d with state-passing. Mamba2's conv1d is depthwise (groups=C)
+        # with kernel d_conv. To carry state across blocks we prepend the
+        # previous block's last (d_conv-1) inputs and run with padding=0,
+        # producing exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()  # (B, C, L)
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()  # (B, C, d_conv-1)
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)  # (B, C, L + d_conv - 1)
+            xBC_conv = F.conv1d(
+                xBC_padded,
+                m.conv1d.weight,
+                m.conv1d.bias,
+                stride=1, padding=0, dilation=1,
+                groups=conv_channels,
+            )  # (B, C, L)
+        else:
+            # First block of stream — let the module's own conv handle causal
+            # padding, then trim trailing positions.
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)  # (B, L, C)
+
+        x, Bm, Cm = torch.split(
+            xBC_conv,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            dim=-1,
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+
+        A = -torch.exp(m.A_log.float())  # (nheads,)
+
+        z_for_scan = (
+            rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+        )
+
+        # Direct kernel call — this is the only path that actually carries
+        # SSM state across calls at chunked-scan throughput.
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size,
+            D=m.D,
+            z=z_for_scan,
+            dt_bias=m.dt_bias,
+            dt_softplus=True,
+            initial_states=initial_ssm_state,
+            seq_idx=seq_idx,
+            return_final_states=True,
+        )
+
+        y = rearrange(y, "b l h p -> b l (h p)")
+
+        if rmsnorm:
+            y = m.norm(y, z)
+
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Mirror of forward() that threads SSM and conv state across blocks.
+        Returns (x_out, mem, final_ssm_state, last_conv_input).
+        """
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                blk = CausalAttentionBlock(D_MODEL, ATTN_N_HEADS, FFN_MULT)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, layer_idx=i)
+                blk._is_ssm = True
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+        # Depth-scaled init for mamba_ssm's internal Mamba2.out_proj.weight.
+        # mamba_ssm's standalone Mamba2 class uses kaiming_uniform with no
+        # depth correction; depth scaling (1/sqrt(2*n_layer)) is only applied
+        # by the official MambaConfig _init_weights hook, which we don't use.
+        # Without this, `out_proj` is the only residual-output projection
+        # initialized "loud" at start of training (FFN.down and attention's
+        # out_proj are both zero-initialized in our code). Confirmed via
+        # verify_init_and_fp32.py: mamba.out_proj.weight std=0.018 vs the
+        # depth-scaled target of 0.004 — about 4.5x too large.
+        n_layer_for_init = N_UNIQUE_BLOCKS * N_UNROLLS
+        depth_init_scale = 1.0 / math.sqrt(2 * n_layer_for_init)
+        with torch.no_grad():
+            n_scaled = 0
+            for pname, p in self.named_parameters():
+                if pname.endswith("mamba.out_proj.weight"):
+                    p.mul_(depth_init_scale)
+                    n_scaled += 1
+            log0(f"depth-scaled init: scaled {n_scaled} mamba.out_proj.weight tensors by {depth_init_scale:.4f} (1/sqrt(2*{n_layer_for_init}))")
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Auto-compute seq_idx from the input ids if not provided. This is
+        # what tells Mamba2's chunk-scan kernel to zero state transitions at
+        # document boundaries (chunk-aligned). Disabled when DOC_BOUNDARY_TOKEN
+        # is negative or SEQ_IDX_ENABLED is off.
+        if seq_idx is None and SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        # State carryover: only pass inference_params to SSM blocks (attention
+        # blocks have no recurrent state to carry; they see only the current
+        # input window). When loop is active and inference_params is set, we
+        # would update the same block's state multiple times in one pass,
+        # which double-counts: explicitly forbid that combination.
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params is incompatible with depth recurrence "
+                "(would update Mamba state multiple times per forward). "
+                "Disable LOOP_START/LOOP_END for state-carryover eval."
+            )
+
+        skips = []
+        # Encoder. Inline dispatch (no closure) so torch.compile compiles
+        # each block once with stable arg shapes rather than re-specializing
+        # a wrapper per block id.
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads
+        Mamba2 SSM state and conv1d state across calls via direct kernel
+        access (mamba_chunk_scan_combined). Attention blocks see only the
+        current block (no recurrent state to carry).
+
+        ids: (B, L)
+        layer_states: dict {block_idx: (ssm_state, conv_input)} or None.
+            On first call pass None; the returned dict is fed back in for
+            the next block.
+        seq_idx_base: int — counter offset to keep doc ids monotonic across
+            blocks. The new last seq_idx value is returned so the caller
+            can pass it as seq_idx_base for the next block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — "
+                "direct-kernel state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with carryover not implemented
+
+        # Build seq_idx for this block. Monotonic across blocks via
+        # seq_idx_base — when state is being carried, doc ids must keep
+        # incrementing so a doc boundary at block boundary correctly
+        # zeroes the carried state's contribution.
+        #
+        # NOTE: empirically this offset-by-seq_idx_base behavior is what
+        # works. We tried "reset seq_idx to 0 at every block" thinking the
+        # kernel's internal seq_idx=0 start was an assertion about carried
+        # state — that interpretation produced a -0.04 BPB regression. The
+        # original behavior, which silently zeroes the carried state on
+        # block boundaries via seq_idx mismatch, is actually less harmful
+        # than letting stale state from millions of tokens ago flow into
+        # the next block's first chunk. The model never trained for non-
+        # zero initial_states, so OOD carryover is worse than fresh start.
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        # Carryover is incompatible with depth recurrence (would update the
+        # same block's state multiple times per forward).
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError(
+                "forward_with_state is incompatible with depth recurrence."
+            )
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_wd_params, no_wd_params, embed_params = [], [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            continue
+
+        # No-weight-decay convention (mamba_ssm + modded-nanogpt):
+        #   - mamba_ssm flags A_log, D, dt_bias with _no_weight_decay = True;
+        #     regularizing A_log destabilizes the SSM recurrent dynamics
+        #     (see mamba_ssm README).
+        #   - Biases conventionally exempt from wd.
+        #   - 1D params (norm.weight, scales like ssm_scale/mlp_scale/attn_scale,
+        #     learnable per-head q_gain) conventionally exempt from wd.
+        no_wd = (
+            getattr(p, "_no_weight_decay", False)
+            or name.endswith(".bias")
+            or p.ndim < 2
+        )
+        if no_wd:
+            no_wd_params.append(p)
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+            mat_params.append(p)
+        else:
+            # 2D control params (resid_mix, mem_to_model.weight, etc.) routed
+            # away from Muon but still get WD as before.
+            scalar_wd_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_wd_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": no_wd_params, "lr": SCALAR_LR, "weight_decay": 0.0, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar_wd={len(scalar_wd_params)} (AdamW wd={WEIGHT_DECAY}), "
+        f"no_wd={len(no_wd_params)} (AdamW wd=0), "
+        f"embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding with no dropped remainder items."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+def _sliding_score_records(total_tokens: int, seq_len: int, stride: int,
+                           score_start: int = 0, score_end=None):
+    """Yield full-length causal windows that score each target position once.
+
+    A record is (window_start, tail_start, tail_len). The input window is
+    val_tokens[window_start : window_start + seq_len], and only
+    [tail_start : tail_start + tail_len] positions in that window are scored.
+
+    The first prefix is scored from a normal full-length window starting at 0,
+    so Mamba/attention kernels still see the regular SEQ_LEN shape.
+    """
+    total_tokens = int(total_tokens)
+    seq_len = int(seq_len)
+    stride = int(stride)
+    if score_end is None:
+        score_end = total_tokens
+    score_start = max(0, int(score_start))
+    score_end = min(total_tokens, int(score_end))
+    if score_end <= score_start:
+        return
+
+    cur = score_start
+    if cur < min(score_end, seq_len):
+        prefix_end = min(score_end, seq_len)
+        yield 0, cur, prefix_end - cur
+        cur = prefix_end
+
+    while cur < score_end:
+        se = min(cur + stride, score_end)
+        window_start = max(0, se - seq_len)
+        if window_start + seq_len > total_tokens:
+            window_start = max(0, total_tokens - seq_len)
+        tail_start = cur - window_start
+        tail_len = se - cur
+        if tail_len > 0:
+            yield window_start, tail_start, tail_len
+        cur = se
+
+
+def _iter_sliding_score_batches(val_tokens, record_indices, seq_len: int, batch_windows: int):
+    """Batch sliding-score records by compatible tail slice."""
+    pending_x, pending_y = [], []
+    pending_key = None
+
+    def flush():
+        nonlocal pending_x, pending_y, pending_key
+        if not pending_x:
+            return None
+        xn = np.stack(pending_x)
+        yn = np.stack(pending_y)
+        tail_start, tail_len = pending_key
+        pending_x, pending_y, pending_key = [], [], None
+        return xn, yn, tail_start, tail_len
+
+    for window_start, tail_start, tail_len in record_indices:
+        key = (int(tail_start), int(tail_len))
+        if pending_key is not None and (key != pending_key or len(pending_x) >= batch_windows):
+            item = flush()
+            if item is not None:
+                yield item
+        pending_key = key
+        pending_x.append(val_tokens[window_start : window_start + seq_len])
+        pending_y.append(val_tokens[window_start + 1 : window_start + seq_len + 1])
+
+    item = flush()
+    if item is not None:
+        yield item
+
+
+def lm_loss_tail(core, ids, targets, tail_start: int, tail_len: int):
+    """LM loss restricted to already-scored tail tokens for legal TTT."""
+    hidden = core(ids, state=None, return_state=False)
+    tail_start = int(tail_start)
+    tail_len = int(tail_len)
+    hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+    y_tail = targets[:, tail_start : tail_start + tail_len]
+    logits = core.output_logits_from_hidden(hidden_tail)
+    logits = core.add_copy_logits(logits, hidden_tail, hidden, ids, query_start=tail_start)
+    return F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="mean")
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Exact sliding-window evaluation.
+
+    Scores every target token exactly once. The first prefix is scored from a
+    full SEQ_LEN window starting at 0; subsequent tokens are scored in `stride`
+    tails from windows ending at the scored segment. Remainder records are
+    sharded exactly across ranks.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+
+    records = list(_sliding_score_records(total_tokens, seq_len, stride))
+    rec_start, rec_end = _rank_bounds(len(records))
+    local_records = records[rec_start:rec_end]
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = max(1, (len(local_records) + batch_windows - 1) // batch_windows)
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+            val_tokens, local_records, seq_len, batch_windows):
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+            y_tail = y[:, tail_start : tail_start + tail_len]
+            logits = core.output_logits_from_hidden(hidden_tail)
+            logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+            loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+        cnt = float(y_tail.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+        t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * max(0, total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {len(local_records)} records/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib,
+                       block_len=None, warmup_tokens=None):
+    """
+    SSM-native state-carryover eval.
+
+    Process the val set as non-overlapping `block_len`-token blocks. The
+    Mamba2 SSM hidden state and conv1d state for every layer are threaded
+    across blocks via the direct kernel call (mamba_chunk_scan_combined
+    with initial_states / return_final_states), so a token at position p
+    sees ALL p preceding tokens via the recurrence (not just the SEQ_LEN
+    window an attention model would have). Attention layers (which can't
+    carry state) see only the current block, matching training context.
+
+    Each rank gets a contiguous slice of the val stream so state passing
+    stays causal within rank. The first `warmup_tokens` of each rank's
+    slice are processed to warm the recurrent state but their losses are
+    not scored (otherwise positions with near-empty state would be unfairly
+    counted).
+
+    If CARRYOVER_DIRECT_KERNEL is False, falls back to the inference_params
+    path (broken in current mamba_ssm builds — kept for diagnosis only).
+
+    Returns (val_loss, val_bpb).
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    warmup_blocks = warmup_tokens // block_len  # round down to block boundary
+
+    use_direct = CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None
+    if not use_direct:
+        if not _HAS_CHUNK_SCAN:
+            log0("[carryover_eval] mamba_chunk_scan_combined unavailable")
+        if rearrange is None:
+            log0("[carryover_eval] einops not importable")
+        if InferenceParams is None:
+            raise RuntimeError("no carryover path available (no chunk_scan, no InferenceParams)")
+        log0("[carryover_eval] falling back to InferenceParams path (likely broken)")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+
+    if getattr(core, "loop_enabled_external", False):
+        log0("[carryover_eval] depth recurrence active — temporarily disabled for this eval")
+        prev_loop = True
+        core.loop_enabled_external = False
+    else:
+        prev_loop = False
+
+    total_tokens = val_tokens.size - 1  # x/y consume span-1 tokens
+
+    # Stateful-overlap config (PR #1644 / reviewer guidance):
+    #   - block has length `block_len` total tokens
+    #   - first `overlap` tokens are "context" — Mamba state has carried
+    #     them via initial_states; attention re-sees them inside the block;
+    #     they are NOT scored (already counted as score_region in prior block)
+    #   - remaining `score_region = block_len - overlap` tokens are scored
+    #   - block stride = score_region (not block_len), so consecutive blocks
+    #     overlap by exactly `overlap` tokens
+    #
+    # When overlap=0, this collapses to non-overlap (legacy) behavior.
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), block_len - 1))
+    score_region = block_len - overlap
+
+    # Exact block sharding. Global block index g starts at g * score_region.
+    # Only full block_len windows are used here to keep the direct Mamba kernel
+    # shape stable. No block index is dropped across ranks.
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - block_len) // score_region + 1)
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    n_scored_blocks = max(0, n_blocks - warmup_blocks)
+
+    # State containers
+    if use_direct:
+        layer_states = None  # filled on first block by forward_with_state
+        seq_idx_base = 0     # monotonic doc-id counter across blocks
+    else:
+        inference_params = InferenceParams(max_seqlen=block_len, max_batch_size=1)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    path_label = "direct_kernel" if use_direct else "inference_params"
+    log0(
+        f"  carryover_eval: path={path_label}, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        # Block starts at global_b_idx * score_region (so consecutive blocks
+        # overlap by `overlap` tokens). We need block_len + 1 tokens total:
+        # block_len input tokens plus the next-token target.
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + block_len + 1]
+        if chunk.size < block_len + 1:
+            break
+        xn = chunk[:-1].reshape(1, block_len)
+        yn = chunk[1:].reshape(1, block_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            if use_direct:
+                hidden, layer_states, seq_idx_base = core.forward_with_state(
+                    x, layer_states, seq_idx_base=seq_idx_base
+                )
+            else:
+                hidden = core(x, inference_params=inference_params)
+            logits = core.output_logits_from_hidden(hidden)
+            logits = core.add_copy_logits(logits, hidden, hidden, x, query_start=0)
+
+            # Score only new positions. The first GLOBAL block must score from
+            # position 0 so official cold-start tokens are counted; every later
+            # block skips the overlap because those tokens were already scored.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            score_logits = logits[:, score_start:, :]
+            score_y = y[:, score_start:]
+            loss = F.cross_entropy(
+                score_logits.float().reshape(-1, score_logits.shape[-1]),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            # Bytes accounting also restricted to the positions actually scored.
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / n_blocks
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(
+        f"  carryover_eval: rank={RANK} scored={n_scored_blocks} blocks "
+        f"(warmup={warmup_blocks}), block_len={block_len}, path={path_label}, {elapsed:.1f}s"
+    )
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# LoRA infrastructure for legal score-first TTT
+# -----------------------------------------------------------------------------
+class LoRALinear(nn.Module):
+    """
+    LoRA adapter wrapping an existing nn.Linear without changing its semantics
+    at init. Output is `linear(x) + alpha/r * (x @ A^T @ B^T)`. At init B=0
+    so the wrapped output exactly matches the base linear.
+
+    The base linear's weight is held *frozen* via a registered buffer ref;
+    only the LoRA A, B matrices have requires_grad=True (per LORA_FROZEN_BASE
+    convention).
+    """
+    def __init__(self, base_linear: nn.Linear, rank: int, alpha: float):
+        super().__init__()
+        if not isinstance(base_linear, nn.Linear):
+            raise TypeError(f"LoRALinear expects nn.Linear, got {type(base_linear)}")
+        self.base = base_linear  # not registered as submodule param-wise — we freeze it externally
+        self.in_features = base_linear.in_features
+        self.out_features = base_linear.out_features
+        self.rank = int(rank)
+        self.alpha = float(alpha)
+        self.scaling = self.alpha / max(1, self.rank)
+        # A: (rank, in_features) — initialized small random
+        # B: (out_features, rank) — initialized zero so initial output unchanged
+        self.lora_A = nn.Parameter(torch.zeros(self.rank, self.in_features))
+        self.lora_B = nn.Parameter(torch.zeros(self.out_features, self.rank))
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        # B stays zero
+
+    @property
+    def weight(self):
+        # Expose an effective weight so modules that read `.weight` directly
+        # do not crash if accidentally wrapped. Gradients still flow to LoRA.
+        return self.base.weight + self.scaling * (self.lora_B @ self.lora_A).to(self.base.weight.dtype)
+
+    @property
+    def bias(self):
+        return self.base.bias
+
+    def forward(self, x):
+        # Use the effective weight path. This is slightly more expensive than
+        # two matmuls but is robust for modules that expect .weight/.bias.
+        return F.linear(x, self.weight, self.bias)
+
+    def reset_lora(self):
+        """Zero out B to restore base-only behavior. A is left as-is."""
+        with torch.no_grad():
+            self.lora_B.zero_()
+
+
+def install_lora_adapters(core: nn.Module, rank: int, alpha: float,
+                           target_substrings=("qkv", "out_proj", "gate_up", "down", "in_proj")):
+    """
+    Walk the model and replace selected nn.Linear modules with LoRALinear
+    wrappers. Returns (lora_params, n_replaced). Base weights are frozen
+    (requires_grad=False) — only LoRA A,B have grads.
+
+    target_substrings: any module name *segment* matching one of these gets
+      LoRA wrapped. Defaults match attention qkv/out_proj, FFN gate_up/down,
+      Mamba internals are skipped by default; enable SCORE_FIRST_TTT_WRAP_MAMBA=1
+      only for a smoke-tested ablation.
+    """
+    # Snapshot the modules to replace (don't mutate during iteration)
+    to_replace = []  # list of (parent_module, attr_name, base_linear)
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if not isinstance(child, nn.Linear):
+                continue
+            full_name = f"{module_name}.{child_name}" if module_name else child_name
+            # Match if any target substring appears as a segment (last component)
+            # AND the linear is not the lm_head/tok_emb/embed projections.
+            if "lm_head" in full_name or "tok_emb" in full_name or "embed_proj" in full_name:
+                continue
+            # Critical crash fix: mamba_ssm.Mamba2.forward reads in_proj/out_proj.weight
+            # directly in its fused path. The LoRALinear properties above make accidental
+            # wrapping survivable, but by default we keep Mamba internals unwrapped because
+            # it is slower and was the source of the previous run's AttributeError.
+            if (not SCORE_FIRST_TTT_WRAP_MAMBA) and (".mamba." in full_name or full_name.startswith("mamba.")):
+                continue
+            if any(t == child_name for t in target_substrings):
+                to_replace.append((module, child_name, child, full_name))
+
+    n_replaced = 0
+    lora_params = []
+    for parent, child_name, base_linear, full_name in to_replace:
+        wrapper = LoRALinear(base_linear, rank=rank, alpha=alpha)
+        # Move adapter to the same device, but keep LoRA A/B in fp32 for
+        # AdamW stability. The forward path casts the effective delta to the
+        # base weight dtype.
+        wrapper = wrapper.to(device=base_linear.weight.device)
+        setattr(parent, child_name, wrapper)
+        n_replaced += 1
+        lora_params.append(wrapper.lora_A)
+        lora_params.append(wrapper.lora_B)
+
+    # Freeze all non-LoRA params
+    for p in core.parameters():
+        p.requires_grad_(False)
+    # Re-enable grads on LoRA params
+    for p in lora_params:
+        p.requires_grad_(True)
+
+    return lora_params, n_replaced
+
+
+def uninstall_lora_adapters(core: nn.Module):
+    """
+    Restore base nn.Linear modules in place of LoRALinear wrappers and
+    re-enable grads on all params. Called after TTT eval to leave the
+    model in its pre-eval state for any subsequent operations (compression,
+    further evals, etc.).
+    """
+    to_restore = []
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if isinstance(child, LoRALinear):
+                to_restore.append((module, child_name, child))
+    for parent, child_name, wrapper in to_restore:
+        setattr(parent, child_name, wrapper.base)
+    for p in core.parameters():
+        p.requires_grad_(True)
+    return len(to_restore)
+
+
+def reset_all_lora(core: nn.Module):
+    """Zero out all lora_B in the model (resets to base-only behavior).
+    Used between eval phases or to clear adapter state."""
+    n = 0
+    for m in core.modules():
+        if isinstance(m, LoRALinear):
+            m.reset_lora()
+            n += 1
+    return n
+
+
+# -----------------------------------------------------------------------------
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first TTT with LoRA/adapters.
+
+    For each rank-local validation chunk:
+      1. Score each target token exactly once under no_grad.
+      2. Train adapters only on those already-scored tail tokens.
+      3. Carry adapter weights forward to the next chunk.
+
+    This fixes the previous overweighting bug where TTT trained on the full
+    overlapping windows even though only the scored tail tokens should adapt.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    if SCORE_FIRST_TTT_USE_LORA:
+        lora_params, n_replaced = install_lora_adapters(
+            core,
+            rank=SCORE_FIRST_TTT_LORA_RANK,
+            alpha=SCORE_FIRST_TTT_LORA_ALPHA,
+            target_substrings=SCORE_FIRST_TTT_TARGETS,
+        )
+        adapt_params = lora_params
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (LoRA): rank={SCORE_FIRST_TTT_LORA_RANK} "
+            f"alpha={SCORE_FIRST_TTT_LORA_ALPHA} replaced={n_replaced} linears, "
+            f"adapting {n_adapt:,} LoRA params, targets={SCORE_FIRST_TTT_TARGETS}, "
+            f"opt={SCORE_FIRST_TTT_OPT}, lr={SCORE_FIRST_TTT_LR}, "
+            f"wd={SCORE_FIRST_TTT_WD}, all_reduce={'NO' if SCORE_FIRST_TTT_NO_ALLREDUCE else 'YES'}"
+        )
+        base_state = None
+    else:
+        adapt_params = list(core.parameters())
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (FULL): chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, "
+            f"lr={SCORE_FIRST_TTT_LR}, momentum={SCORE_FIRST_TTT_MOMENTUM}, "
+            f"epochs={SCORE_FIRST_TTT_EPOCHS}, adapting {n_adapt:,} params"
+        )
+        base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    if SCORE_FIRST_TTT_OPT == "adamw":
+        ttt_opt = torch.optim.AdamW(
+            adapt_params,
+            lr=SCORE_FIRST_TTT_LR,
+            betas=(0.9, SCORE_FIRST_TTT_BETA2),
+            weight_decay=SCORE_FIRST_TTT_WD,
+        )
+    else:
+        ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                                  momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens + chunk_tokens - 1) // chunk_tokens
+    chunk_start_idx, chunk_end_idx = _rank_bounds(n_chunks)
+    local_chunks = chunk_end_idx - chunk_start_idx
+    batch_windows = max(1, 131072 // seq_len)
+    train_batch_windows = max(1, batch_windows // 2)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, local_chunks // 10)
+
+    try:
+        for chunk_idx_local, ci in enumerate(range(chunk_start_idx, chunk_end_idx)):
+            score_start = ci * chunk_tokens
+            score_end = min(score_start + chunk_tokens, total_tokens)
+            if score_end <= score_start:
+                continue
+
+            records = list(_sliding_score_records(total_tokens, seq_len, stride, score_start, score_end))
+            train_batches = []
+
+            core.eval()
+            with torch.no_grad():
+                for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+                        val_tokens, records, seq_len, batch_windows):
+                    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        hidden = core(x, state=None, return_state=False)
+                        hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+                        y_tail = y[:, tail_start : tail_start + tail_len]
+                        logits = core.output_logits_from_hidden(hidden_tail)
+                        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+                        loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+                    cnt = float(y_tail.numel())
+                    loss_sum += float(loss.detach().float().item())
+                    p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    b = bb[t_tail].astype(np.int16, copy=True)
+                    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                    tok_sum += cnt
+                    byt_sum += float(b.astype(np.float64).sum())
+                    train_batches.append((xn, yn, int(tail_start), int(tail_len)))
+
+            if train_batches:
+                core.train()
+                chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, local_chunks)))
+                for g in ttt_opt.param_groups:
+                    g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+                for _epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                    order = np.random.permutation(len(train_batches))
+                    for batch_i in order:
+                        bx, by, tail_start, tail_len = train_batches[int(batch_i)]
+                        for bi in range(0, bx.shape[0], train_batch_windows):
+                            be = min(bi + train_batch_windows, bx.shape[0])
+                            ax = torch.from_numpy(bx[bi:be]).long().to(DEVICE, non_blocking=True)
+                            ay = torch.from_numpy(by[bi:be]).long().to(DEVICE, non_blocking=True)
+
+                            ttt_opt.zero_grad(set_to_none=True)
+                            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                                adapt_loss = lm_loss_tail(core, ax, ay, tail_start, tail_len)
+                            adapt_loss.backward()
+
+                            if not SCORE_FIRST_TTT_NO_ALLREDUCE:
+                                for p in adapt_params:
+                                    if p.grad is not None:
+                                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                            if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                                nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                            ttt_opt.step()
+
+            if (chunk_idx_local + 1) % log_every_chunks == 0:
+                elapsed_e = time.perf_counter() - t0_eval
+                running_loss = loss_sum / max(tok_sum, 1.0)
+                running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+                eta = elapsed_e / (chunk_idx_local + 1) * max(0, local_chunks - chunk_idx_local - 1)
+                log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{local_chunks} "
+                     f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+        elapsed = time.perf_counter() - t0_eval
+        log0(f"  score_first_ttt: {local_chunks} chunks/rank, "
+             f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+        stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+        loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+        val_loss = loss_sum / max(tok_sum, 1.0)
+        bpt = val_loss / math.log(2.0)
+        return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+    finally:
+        if SCORE_FIRST_TTT_USE_LORA:
+            n_uninstalled = uninstall_lora_adapters(core)
+            log0(f"  score_first_ttt: uninstalled {n_uninstalled} LoRA adapters, base weights restored")
+        else:
+            with torch.no_grad():
+                for name, p in core.named_parameters():
+                    if name in base_state:
+                        p.data.copy_(base_state[name])
+        core.train()
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes an exact contiguous shard of val sequences.
+    seq_start, seq_end = _rank_bounds(total_seqs)
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = max(1, min(TTT_GLOBAL_BATCH_SEQS, max(local_seqs, 1)))
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks with exact remainder handling.
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start, seq_end = _rank_bounds(total_seqs)
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seq_end - seq_start
+    local_total_seqs = n_local_seqs
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {local_total_seqs})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Compression / quantization (int6 packed + Brotli-11)
+# -----------------------------------------------------------------------------
+def _quantize_row_sdclip(t: torch.Tensor, k: float, half_levels: int):
+    """Per-row symmetric quantization with std-based clipping.
+
+    t: (rows, cols) float
+    k: clipping coefficient (clip = k * std(row))
+    half_levels: max abs value (e.g., 31 for int6, 127 for int8)
+    Returns: (q int8 tensor, scale fp16 tensor)
+    """
+    t32 = t.float()
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    clip = (k * row_std).clamp_min(1e-8)  # (rows,)
+    scale = (clip / half_levels).clamp_min(1e-8)
+    clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+    q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels).to(torch.int8)
+    return q.contiguous(), scale.to(torch.float16).contiguous()
+
+
+def _quantize_row_optclip(t: torch.Tensor, half_levels: int,
+                           k_grid=(2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0, 24.0, 32.0, 48.0)):
+    """Per-row optimal-clip quantization (lite-GPTQ for embeddings).
+
+    For each row, sweep k_grid and pick the k that minimizes L2 reconstruction
+    error. The dominant quant-error driver for embedding tensors is rare-token
+    rows whose magnitude distribution differs from common-token rows; a single
+    global clip hurts them disproportionately. This captures most of GPTQ's
+    benefit for embeddings without needing calibration data.
+
+    NOT full GPTQ (no Hessian, no per-column error compensation). For
+    embeddings specifically the dominant error term is per-row magnitude
+    calibration, which this captures.
+    """
+    t32 = t.float()
+    rows, cols = t32.shape
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    row_abs_max = t32.abs().max(dim=1).values.clamp_min(1e-8)
+
+    best_err = torch.full((rows,), float("inf"), device=t32.device)
+    best_scale = torch.zeros((rows,), device=t32.device)
+    best_q = torch.zeros_like(t32, dtype=torch.int8)
+
+    for k in k_grid:
+        clip = (k * row_std).clamp_min(1e-8)
+        # Cap clip at row_abs_max so we don't waste levels on impossible values
+        clip = torch.minimum(clip, row_abs_max)
+        scale = (clip / half_levels).clamp_min(1e-8)
+        clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+        q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels)
+        recon = q * scale[:, None]
+        err = ((recon - t32) ** 2).sum(dim=1)
+        improved = err < best_err
+        best_err = torch.where(improved, err, best_err)
+        best_scale = torch.where(improved, scale, best_scale)
+        improved_mask = improved[:, None].expand_as(t32)
+        best_q = torch.where(improved_mask, q.to(torch.int8), best_q)
+
+    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+
+
+def _pack_int6(q_int8: torch.Tensor):
+    """Pack int8-stored int6 values (range [-31, 31]) into uint8.
+    4 values × 6 bits = 24 bits = 3 bytes."""
+    flat = q_int8.flatten().to(torch.int32) + 32  # shift to [0, 63]
+    n = flat.numel()
+    pad = (-n) % 4
+    if pad:
+        flat = torch.cat([flat, torch.zeros(pad, dtype=torch.int32, device=flat.device)])
+    g = flat.view(-1, 4)
+    a, b, c, d = g[:, 0], g[:, 1], g[:, 2], g[:, 3]
+    byte0 = ((a << 2) | (b >> 4)) & 0xFF
+    byte1 = (((b & 0xF) << 4) | (c >> 2)) & 0xFF
+    byte2 = (((c & 0x3) << 6) | d) & 0xFF
+    packed = torch.stack([byte0, byte1, byte2], dim=1).flatten().to(torch.uint8)
+    return packed.contiguous(), n
+
+
+def _unpack_int6(packed_u8: torch.Tensor, n_orig: int, shape):
+    """Inverse of _pack_int6."""
+    arr = packed_u8.to(torch.int32)
+    g = arr.view(-1, 3)
+    byte0, byte1, byte2 = g[:, 0], g[:, 1], g[:, 2]
+    a = byte0 >> 2
+    b = ((byte0 & 0x3) << 4) | (byte1 >> 4)
+    c = ((byte1 & 0xF) << 2) | (byte2 >> 6)
+    d = byte2 & 0x3F
+    unpacked = torch.stack([a, b, c, d], dim=1).flatten()[:n_orig]
+    signed = unpacked.to(torch.int32) - 32
+    return signed.view(shape).to(torch.int8)
+
+
+def _is_embedding_tensor(name: str) -> bool:
+    """Embedding-like tensors get int8 (more sensitive to quantization);
+    everything else gets int6."""
+    n = name
+    return (
+        "tok_emb" in n
+        or "lm_head" in n
+        or "embed_proj" in n
+        or ("bigram" in n and "embed" in n)
+    )
+
+
+def _compress_best(raw: bytes):
+    """Try Brotli-11 (best); fall back to zstd-22; final fallback zlib-9."""
+    if _HAS_BROTLI:
+        try:
+            return brotli.compress(raw, quality=11), "brotli11"
+        except Exception:
+            pass
+    if "zstandard" in sys.modules:
+        try:
+            cctx = sys.modules["zstandard"].ZstdCompressor(level=22)
+            return cctx.compress(raw), "zstd22"
+        except Exception:
+            pass
+    return zlib.compress(raw, 9), "zlib9"
+
+
+def _decompress(blob: bytes, scheme: str) -> bytes:
+    if scheme == "brotli11":
+        return brotli.decompress(blob)
+    if scheme == "zstd22":
+        return sys.modules["zstandard"].ZstdDecompressor().decompress(blob)
+    return zlib.decompress(blob)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "10"))  # keep training inside 600s; 100-step checks overshot by ~8s
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- State-carryover eval (SSM-native) ---
+    # Threads Mamba2 hidden state across non-overlapping val blocks via the
+    # direct mamba_chunk_scan_combined kernel (with initial_states /
+    # return_final_states). Falls back to InferenceParams path for diagnosis
+    # if direct kernel unavailable. Compare against the sliding-window
+    # number above to see whether long-prefix recurrent state actually helps.
+    pre_ttt_co_vb = None
+    have_carry_path = (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None) \
+                       or (InferenceParams is not None)
+    if CARRYOVER_EVAL_ENABLED and have_carry_path:
+        dist.barrier()
+        log0("=" * 60)
+        log0(f"Running state-carryover eval (block_len={CARRYOVER_BLOCK_LEN}, warmup={CARRYOVER_WARMUP_TOKENS} tokens)...")
+        try:
+            co_vl, co_vb = eval_val_carryover(
+                model, val_tokens, bb, hs, ib,
+                block_len=CARRYOVER_BLOCK_LEN,
+                warmup_tokens=CARRYOVER_WARMUP_TOKENS,
+            )
+            log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+            log0(f"Carryover vs standard:    bpb={best_vb - co_vb:+.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"Carryover vs sliding:     bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+            pre_ttt_co_vb = co_vb
+        except Exception as e:
+            log0(f"[carryover_eval] FAILED: {type(e).__name__}: {e}")
+            import traceback
+            log0(traceback.format_exc())
+            log0("[carryover_eval] continuing — sliding-window number above is unaffected")
+        log0("=" * 60)
+    elif CARRYOVER_EVAL_ENABLED:
+        log0("[carryover_eval] skipped: no carryover path available (need either mamba_chunk_scan_combined or InferenceParams)")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if RUN_PREQUANT_SCORE_FIRST_TTT and SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Quantization + compression + roundtrip validation
+    # int6 GPTQ-lite (per-row SDClip) for matrices, int8 for embeddings,
+    # fp16 passthrough for small/sensitive. Brotli-11 with zstd fallback.
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0(f"Quantizing model (mode={QUANT_MODE}, k_mat={QUANT_K_MATRIX}, k_emb={QUANT_K_EMBED})...")
+    state_dict = base_model.state_dict()
+
+    # Dynamics-protected quantization (PR #1890 / Q-Mamba ICLR 2025).
+    # Mamba2.in_proj output is split into [z, x, B, C, dt]; the last `nheads`
+    # rows of in_proj.weight produce dt (the SSM time-step generator).
+    # Q-Mamba shows that uniform 6-bit PTQ destabilizes the SSM recurrence
+    # because errors in dt (and consequently A_bar = exp(dt*A)) compound over
+    # many tokens. Promoting just these dt rows to INT8 costs ~16 extra bytes
+    # per packed row (about 0.01 MB total at our scale) and recovers most of
+    # the post-quant BPB regression.
+    #
+    # We derive the row range from the live module's .nheads attribute rather
+    # than hardcoding indices, so this works across configs with different
+    # ngroups, d_state, headdim, etc. The map is keyed by the parameter name
+    # we'd see in state_dict (e.g. "blocks.0.mamba.in_proj.weight").
+    dt_row_map = {}  # name -> (dt_start, dt_end) in row indexing
+    if QUANT_PROTECT_DYNAMICS:
+        for mod_name, mod in base_model.named_modules():
+            # mamba_ssm Mamba2 modules expose .nheads, .in_proj
+            if hasattr(mod, "in_proj") and hasattr(mod, "nheads"):
+                w = getattr(mod.in_proj, "weight", None)
+                if w is None or w.ndim != 2:
+                    continue
+                total_rows = w.shape[0]
+                nheads = int(mod.nheads)
+                if nheads <= 0 or nheads >= total_rows:
+                    continue
+                weight_name = f"{mod_name}.in_proj.weight"
+                dt_row_map[weight_name] = (total_rows - nheads, total_rows)
+        log0(
+            f"  dynamics-protected rows: {len(dt_row_map)} in_proj tensors flagged "
+            f"({sum(end-start for start,end in dt_row_map.values())} total dt rows -> int8)"
+        )
+
+    # Stats counters
+    n_int6 = n_int8 = n_passthrough = n_alias = 0
+    bytes_int6 = bytes_int8 = bytes_passthrough = 0
+
+    quant_entries = {}    # name -> {"mode", ...} or {"mode": "alias", "target": canonical_name}
+    # Tied-weight dedup keyed by the ORIGINAL tensor's data_ptr/storage. We
+    # must NOT key on the CPU copy's data_ptr — CPU buffers get freed and
+    # reused across iterations, causing false-positive aliases between
+    # unrelated tensors. Original state_dict tensors share storage with
+    # live model parameters, so their data_ptrs are stable for the duration
+    # of this loop.
+    seen_ptrs = {}
+
+    for name, t_orig in state_dict.items():
+        # Check aliasing on the original tensor BEFORE making any copies.
+        # Combine data_ptr with shape to be doubly safe — two tensors that
+        # share storage AND have the same shape are genuine aliases (e.g.
+        # tied lm_head.weight ↔ tok_emb.weight). Different shapes at the
+        # same ptr would indicate a view, not a tied weight.
+        ptr_key = (t_orig.data_ptr(), tuple(t_orig.shape))
+        if ptr_key in seen_ptrs:
+            quant_entries[name] = {"mode": "alias", "target": seen_ptrs[ptr_key]}
+            n_alias += 1
+            continue
+        seen_ptrs[ptr_key] = name
+
+        t = t_orig.detach().cpu().contiguous()
+
+        # Non-float or small/sensitive: keep as fp16 (or original int)
+        if not t.is_floating_point():
+            quant_entries[name] = {"mode": "raw", "tensor": t}
+            n_passthrough += 1
+            bytes_passthrough += t.numel() * t.element_size()
+            continue
+
+        if t.numel() <= QUANT_PASSTHROUGH_NUMEL or t.ndim != 2:
+            t16 = t.to(torch.float16).contiguous()
+            quant_entries[name] = {"mode": "fp16", "tensor": t16}
+            n_passthrough += 1
+            bytes_passthrough += t16.numel() * 2
+            continue
+
+        # 2D float, large: quantize
+        is_embed = _is_embedding_tensor(name)
+        if QUANT_MODE == "int8" or is_embed:
+            # int8 with SDClip — embedding-like tensors get optimal-clip
+            # search (GPTQ-lite) when enabled, otherwise the single global k.
+            if is_embed and QUANT_OPTCLIP_EMBED:
+                q, scale = _quantize_row_optclip(t, half_levels=127)
+            else:
+                q, scale = _quantize_row_sdclip(t, k=QUANT_K_EMBED if is_embed else QUANT_K_MATRIX, half_levels=127)
+            # Store as raw int8 bytes (no need to pack — one byte per value)
+            quant_entries[name] = {
+                "mode": "int8",
+                "packed": q.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(t.numel()),
+            }
+            n_int8 += 1
+            bytes_int8 += q.numel()
+        elif name in dt_row_map:
+            # Dynamics-protected int6+int8 split: low rows int6, dt rows int8.
+            dt_start, dt_end = dt_row_map[name]
+            t_low = t[:dt_start].contiguous()        # z, x, B, C rows -> int6
+            t_dt = t[dt_start:dt_end].contiguous()   # dt rows -> int8
+
+            q_low, scale_low = _quantize_row_sdclip(t_low, k=QUANT_K_MATRIX, half_levels=31)
+            packed_low, n_orig_low = _pack_int6(q_low)
+
+            q_dt, scale_dt = _quantize_row_sdclip(t_dt, k=QUANT_K_MATRIX, half_levels=127)
+
+            quant_entries[name] = {
+                "mode": "mixed_int6_int8",
+                "packed_low": packed_low.numpy().tobytes(),
+                "scale_low": scale_low,
+                "shape_low": tuple(t_low.shape),
+                "numel_low": int(n_orig_low),
+                "packed_dt": q_dt.numpy().tobytes(),
+                "scale_dt": scale_dt,
+                "shape_dt": tuple(t_dt.shape),
+                "shape_full": tuple(t.shape),
+            }
+            n_int6 += 1  # count under int6 since the bulk is int6
+            bytes_int6 += packed_low.numel()
+            bytes_int8 += q_dt.numel()
+        else:
+            # int6 packed (4 vals per 3 bytes) with SDClip
+            q, scale = _quantize_row_sdclip(t, k=QUANT_K_MATRIX, half_levels=31)
+            packed, n_orig = _pack_int6(q)
+            quant_entries[name] = {
+                "mode": "int6",
+                "packed": packed.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(n_orig),
+            }
+            n_int6 += 1
+            bytes_int6 += packed.numel()
+
+    log0(
+        f"  quant tensors: int6={n_int6} ({bytes_int6/1e6:.2f}MB) "
+        f"int8={n_int8} ({bytes_int8/1e6:.2f}MB) "
+        f"fp16/raw={n_passthrough} ({bytes_passthrough/1e6:.2f}MB) "
+        f"alias={n_alias}"
+    )
+    raw_total = bytes_int6 + bytes_int8 + bytes_passthrough
+    log0(f"  raw quantized total before compression: {raw_total/1e6:.2f}MB")
+
+    # Serialize and compress
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_entries, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    quant_blob, scheme = _compress_best(quant_raw)
+    compressed_bytes = len(quant_blob)
+    log0(
+        f"Compressed model ({scheme}): {compressed_bytes:,} bytes "
+        f"({compressed_bytes / 1024 / 1024:.2f} MB) — "
+        f"{'UNDER' if compressed_bytes <= 16_000_000 else 'OVER'} 16MB cap"
+    )
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    quant_raw_rt = _decompress(quant_blob, scheme)
+    quant_entries_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    dequant_state = {}
+    # First pass: dequantize non-alias entries
+    for name, entry in quant_entries_rt.items():
+        mode = entry["mode"]
+        if mode == "alias":
+            continue  # second pass
+        if mode == "raw":
+            dequant_state[name] = entry["tensor"]
+        elif mode == "fp16":
+            dequant_state[name] = entry["tensor"].to(torch.bfloat16)
+        elif mode == "int8":
+            shape = entry["shape"]
+            packed = np.frombuffer(entry["packed"], dtype=np.int8)
+            q = torch.from_numpy(packed.copy()).view(shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "int6":
+            shape = entry["shape"]
+            n_orig = entry["numel"]
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed"], dtype=np.uint8).copy())
+            q = _unpack_int6(packed_u8, n_orig, shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "mixed_int6_int8":
+            # Dynamics-protected: low rows from int6, dt rows from int8.
+            shape_low = entry["shape_low"]
+            shape_dt = entry["shape_dt"]
+            shape_full = entry["shape_full"]
+            n_orig_low = entry["numel_low"]
+
+            # Decode int6 part
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed_low"], dtype=np.uint8).copy())
+            q_low = _unpack_int6(packed_u8, n_orig_low, shape_low)
+            scale_low = entry["scale_low"].float()
+            dq_low = q_low.float() * scale_low.view(shape_low[0], 1)
+
+            # Decode int8 part
+            packed_dt = np.frombuffer(entry["packed_dt"], dtype=np.int8)
+            q_dt = torch.from_numpy(packed_dt.copy()).view(shape_dt)
+            scale_dt = entry["scale_dt"].float()
+            dq_dt = q_dt.float() * scale_dt.view(shape_dt[0], 1)
+
+            # Stitch back to full shape
+            dq = torch.cat([dq_low, dq_dt], dim=0)
+            assert dq.shape == shape_full, f"mixed dequant shape mismatch: got {dq.shape}, expected {shape_full}"
+            dequant_state[name] = dq.to(torch.bfloat16)
+        else:
+            raise RuntimeError(f"unknown quant mode: {mode}")
+    # Second pass: resolve aliases
+    for name, entry in quant_entries_rt.items():
+        if entry["mode"] == "alias":
+            dequant_state[name] = dequant_state[entry["target"]]
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    q_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Final leaderboard-relevant diagnostic: dequantized artifact path +
+    # legal score-first LoRA TTT. Reload dequant weights first so any earlier
+    # eval state is clean; eval_score_first_ttt restores base weights after it.
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        base_model.load_state_dict(dequant_state, strict=True)
+        log0("=" * 60)
+        log0(f"Running POST-QUANT Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        q_sft_vl, q_sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant Score-First TTT val_loss:{q_sft_vl:.4f} val_bpb:{q_sft_vb:.4f}")
+        if q_sw_vb is not None:
+            log0(f"Post-quant Score-First TTT vs sliding: bpb={q_sw_vb - q_sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        ext = scheme  # brotli11 / zstd22 / zlib9
+        artifact_path = f"final_model.{QUANT_MODE}.{ext}.bin"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall.py
@@ -1,0 +1,2017 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp1024"
+TOK_PATH = "./data/tokenizers/fineweb_1024_bpe.model"
+VOCAB_SIZE = 1024
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "128"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "3,7").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.50"))
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA (legacy, off by default — use SWA)
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.999"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.015"))
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.005"))
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.006"))
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.04"))
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "7"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=6 ssm_smoke_test.py"
+    )
+if WORLD_SIZE != 7:
+    raise RuntimeError(f"Expected WORLD_SIZE=7, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp1024", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj, consistently ~0.5-1% better than GELU."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        # Gate and up projection in a single fused linear
+        self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+        self.down = nn.Linear(hidden, d_model, bias=False)
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        gu = self.gate_up(x)
+        gate, up = gu.chunk(2, dim=-1)
+        return self.down(F.silu(gate) * up)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Full causal attention block for precise recall across entire context."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+        self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+        self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+        skips = []
+        layer = 0
+        for u in range(self.n_unrolls):
+            for block in self.blocks:
+                if FFN_FREQ_MODE == "unroll":
+                    run_ffn = (u % max(FFN_EVERY, 1)) == 0
+                else:
+                    run_ffn = (layer % max(FFN_EVERY, 1)) == 0
+                if layer < self.n_enc:
+                    x, mem = block(x, x0, mem, run_ffn=run_ffn)
+                    skips.append(x)
+                else:
+                    di = layer - self.n_enc
+                    if di < self.n_skip and skips:
+                        x = x + self.skip_weights[di][None, None, :] * skips.pop()
+                    x, mem = block(x, x0, mem, run_ffn=run_ffn)
+                layer += 1
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+    y = targets.reshape(-1)
+    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    for name, p in model.named_parameters():
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+        flat_y = y_tail.reshape(-1)
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = 0.60  # replay previously seen tokens after this fraction of wall time
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192.py
@@ -1,0 +1,2329 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_assoc_memory.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_assoc_memory.py
@@ -1,0 +1,2452 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Associative SSM memory attention config
+# A selected block keeps full token attention, but also builds an SSM-generated
+# key/value memory stream. Queries attend to both current-token K/V and
+# SSM-memory K/V, so the SSM acts as a learned compressed memory writer.
+ASSOC_MEM_ENABLED = os.environ.get("ASSOC_MEM_ENABLED", "0") == "1"
+ASSOC_MEM_IDXS = [int(x) for x in os.environ.get("ASSOC_MEM_IDXS", "6").split(",") if x.strip()]
+ASSOC_MEM_DIM = int(os.environ.get("ASSOC_MEM_DIM", "256"))
+ASSOC_MEM_N_HEADS = int(os.environ.get("ASSOC_MEM_N_HEADS", str(ATTN_N_HEADS)))
+ASSOC_MEM_GATE_INIT = float(os.environ.get("ASSOC_MEM_GATE_INIT", "-2.0"))
+ASSOC_MEM_DIRECT_SSM = os.environ.get("ASSOC_MEM_DIRECT_SSM", "0") == "1"
+ASSOC_MEM_ZERO_TOKEN_OUT = os.environ.get("ASSOC_MEM_ZERO_TOKEN_OUT", "1") == "1"
+ASSOC_MEM_ZERO_MEM_OUT = os.environ.get("ASSOC_MEM_ZERO_MEM_OUT", "1") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+    "mem_gate",
+    "token_attn_scale",
+    "mem_attn_scale",
+    "mem_direct_scale",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(
+    f"assoc_mem: enabled={ASSOC_MEM_ENABLED}, idxs={ASSOC_MEM_IDXS}, "
+    f"mem_dim={ASSOC_MEM_DIM}, heads={ASSOC_MEM_N_HEADS}, "
+    f"gate_init={ASSOC_MEM_GATE_INIT}, direct_ssm={ASSOC_MEM_DIRECT_SSM}"
+)
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class AssociativeMemoryAttentionBlock(nn.Module):
+    """
+    Full attention checkpoint augmented with an SSM-generated associative memory.
+
+    Token attention gives exact recall over current hidden states.
+    The SSM memory writer builds a causal key/value stream from the same input.
+    Attention queries both token K/V and SSM-memory K/V.
+    """
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, n_heads=8, ffn_mult=3):
+        super().__init__()
+        if d_model % n_heads != 0:
+            raise ValueError(f"d_model={d_model} must be divisible by n_heads={n_heads}")
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.use_direct_ssm = ASSOC_MEM_DIRECT_SSM
+
+        # Token attention path.
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        if ASSOC_MEM_ZERO_TOKEN_OUT:
+            nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        # Associative SSM memory writer.
+        self.mem_norm = RMSNorm(d_model)
+        self.mem_in_proj = nn.Linear(d_model, memory_dim, bias=False)
+        self.mem_ssm = Mamba2(
+            d_model=memory_dim,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.mem_kv_proj = nn.Linear(memory_dim, 2 * d_model, bias=False)
+        self.mem_out_proj = nn.Linear(d_model, d_model, bias=False)
+        if ASSOC_MEM_ZERO_MEM_OUT:
+            nn.init.zeros_(self.mem_out_proj.weight)
+
+        if self.use_direct_ssm:
+            self.mem_direct_proj = nn.Linear(memory_dim, d_model, bias=False)
+            nn.init.zeros_(self.mem_direct_proj.weight)
+
+        # Merge controls. Memory starts small so known-good token attention is preserved.
+        self.token_attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mem_attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mem_gate = nn.Parameter(torch.full((d_model,), ASSOC_MEM_GATE_INIT))
+        if self.use_direct_ssm:
+            self.mem_direct_scale = nn.Parameter(torch.ones(d_model))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+
+        # Token K/V exact recall path.
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k_tok, v_tok = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k_tok = F.rms_norm(k_tok, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        tok_out = F.scaled_dot_product_attention(q, k_tok, v_tok, is_causal=True)
+        tok_out = tok_out.transpose(1, 2).reshape(B, T, D)
+        tok_out = self.out_proj(tok_out)
+
+        # SSM-generated associative memory K/V path.
+        mem_in = self.mem_in_proj(self.mem_norm(x))
+        mem_state = self.mem_ssm(mem_in)
+        if isinstance(mem_state, tuple):
+            mem_state = mem_state[0]
+        mem_kv = self.mem_kv_proj(mem_state).reshape(B, T, 2, self.n_heads, self.head_dim)
+        k_mem, v_mem = mem_kv.permute(2, 0, 3, 1, 4)
+        k_mem = F.rms_norm(k_mem, (self.head_dim,))
+        mem_out = F.scaled_dot_product_attention(q, k_mem, v_mem, is_causal=True)
+        mem_out = mem_out.transpose(1, 2).reshape(B, T, D)
+        mem_out = self.mem_out_proj(mem_out)
+
+        gate = torch.sigmoid(self.mem_gate.to(x.dtype))[None, None, :]
+        x = x + self.token_attn_scale[None, None, :] * tok_out
+        x = x + gate * self.mem_attn_scale[None, None, :] * mem_out
+
+        if self.use_direct_ssm:
+            x = x + gate * self.mem_direct_scale[None, None, :] * self.mem_direct_proj(mem_state)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem
+
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention / associative-memory attention layers.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        assoc_set = set(ASSOC_MEM_IDXS) if ASSOC_MEM_ENABLED else set()
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in assoc_set:
+                layers.append(AssociativeMemoryAttentionBlock(
+                    D_MODEL, D_STATE, ASSOC_MEM_DIM, CONV_KERNEL, ASSOC_MEM_N_HEADS, FFN_MULT))
+            elif i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name or "mem_ssm" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_bias_ttt_eval_loop.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_bias_ttt_eval_loop.py
@@ -1,0 +1,2270 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Eval-only score-first LoRA TTT config.
+# This script loads a checkpoint/artifact and adapts only LoRA adapters on
+# already-scored validation chunks.
+TTT_LORA_ENABLED = os.environ.get("TTT_LORA_ENABLED", "1") == "1"
+TTT_LORA_RANK = int(os.environ.get("TTT_LORA_RANK", "4"))
+TTT_LORA_ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "8.0"))
+TTT_LORA_STD = float(os.environ.get("TTT_LORA_STD", "0.01"))
+TTT_LORA_QKV = os.environ.get("TTT_LORA_QKV", "1") == "1"
+TTT_LORA_OUT = os.environ.get("TTT_LORA_OUT", "1") == "1"
+
+# Score-first adapter TTT runtime settings.
+ARTIFACT_PATH = os.environ.get("ARTIFACT_PATH", "/workspace/parameter-golf/final_model.int8.ptz")
+RUN_BASELINE = os.environ.get("RUN_BASELINE", "1") == "1"
+TTT_CHUNK_TOKENS = int(os.environ.get("TTT_CHUNK_TOKENS", "262144"))
+TTT_TRAIN_WINDOWS = int(os.environ.get("TTT_TRAIN_WINDOWS", "4"))
+TTT_EPOCHS = int(os.environ.get("TTT_EPOCHS", "1"))
+TTT_ADAPTER_LR = float(os.environ.get("TTT_ADAPTER_LR", "5e-4"))
+TTT_ADAPTER_WD = float(os.environ.get("TTT_ADAPTER_WD", "0.0"))
+TTT_LORA_DECAY = float(os.environ.get("TTT_LORA_DECAY", "0.995"))
+TTT_GRAD_CLIP = float(os.environ.get("TTT_GRAD_CLIP", "1.0"))
+TTT_OPT = os.environ.get("TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+TTT_MAX_CHUNKS = int(os.environ.get("TTT_MAX_CHUNKS", "0"))  # 0 = all
+
+# Score-first logit-bias TTT.
+# This is a tiny 8192-dim adapter: logits = base_logits + vocab_bias.
+# It learns local token/document frequency from already-scored chunks.
+TTT_BIAS_ENABLED = os.environ.get("TTT_BIAS_ENABLED", "1") == "1"
+TTT_BIAS_LR = float(os.environ.get("TTT_BIAS_LR", "0.05"))
+TTT_BIAS_WD = float(os.environ.get("TTT_BIAS_WD", "0.0"))
+TTT_BIAS_DECAY = float(os.environ.get("TTT_BIAS_DECAY", "0.995"))
+TTT_BIAS_GRAD_CLIP = float(os.environ.get("TTT_BIAS_GRAD_CLIP", "5.0"))
+TTT_BIAS_CENTER = os.environ.get("TTT_BIAS_CENTER", "1") == "1"
+TTT_BIAS_OPT = os.environ.get("TTT_BIAS_OPT", "adamw").lower()  # "adamw" or "sgd"
+
+# Force depth recurrence at eval-time for checkpoints trained/evaluated with recurrence on.
+# Needed because training script toggles loop_enabled_external during training,
+# but a fresh eval-only model starts with it disabled.
+FORCE_LOOP_ENABLED = os.environ.get("FORCE_LOOP_ENABLED", "0") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Eval-time LoRA adapters. Zero-B init means loaded checkpoint behavior
+        # is exactly preserved before TTT adaptation.
+        self.ttt_lora_rank = TTT_LORA_RANK if TTT_LORA_ENABLED else 0
+        self.ttt_lora_scale = TTT_LORA_ALPHA / max(TTT_LORA_RANK, 1)
+        if self.ttt_lora_rank > 0 and TTT_LORA_QKV:
+            self.qkv_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.qkv_lora_B = nn.Parameter(torch.zeros(3 * d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.qkv_lora_A, std=TTT_LORA_STD)
+        else:
+            self.qkv_lora_A = None
+            self.qkv_lora_B = None
+
+        if self.ttt_lora_rank > 0 and TTT_LORA_OUT:
+            self.out_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.out_lora_B = nn.Parameter(torch.zeros(d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.out_lora_A, std=TTT_LORA_STD)
+        else:
+            self.out_lora_A = None
+            self.out_lora_B = None
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv_raw = self.qkv(normed)
+        if self.qkv_lora_A is not None:
+            qkv_delta = F.linear(F.linear(normed, self.qkv_lora_A), self.qkv_lora_B)
+            qkv_raw = qkv_raw + self.ttt_lora_scale * qkv_delta
+        qkv = qkv_raw.reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        out = self.out_proj(attn_out)
+        if self.out_lora_A is not None:
+            out_delta = F.linear(F.linear(attn_out, self.out_lora_A), self.out_lora_B)
+            out = out + self.ttt_lora_scale * out_delta
+        x = x + self.attn_scale[None, None, :] * out
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Eval-only checkpoint loading + score-first LoRA TTT
+# -----------------------------------------------------------------------------
+def _try_torch_load_bytes(raw: bytes):
+    import io
+    try:
+        return torch.load(io.BytesIO(raw), map_location="cpu")
+    except Exception:
+        return None
+
+
+def load_checkpoint_state(path: str):
+    """
+    Loads either:
+      - raw torch state_dict / {"state_dict": ...}
+      - compressed int8 artifact from this script:
+          {"quantized": ..., "scales": ..., "passthrough": ...}
+    """
+    import io
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"ARTIFACT_PATH not found: {path}")
+
+    raw = p.read_bytes()
+    obj = _try_torch_load_bytes(raw)
+
+    if obj is None:
+        # Try zstd, then zlib.
+        if _COMPRESSOR == "zstd":
+            try:
+                dctx = zstandard.ZstdDecompressor()
+                obj = torch.load(io.BytesIO(dctx.decompress(raw)), map_location="cpu")
+            except Exception:
+                obj = None
+        if obj is None:
+            try:
+                obj = torch.load(io.BytesIO(zlib.decompress(raw)), map_location="cpu")
+            except Exception as e:
+                raise RuntimeError(f"Could not load checkpoint/artifact {path}: {e}") from e
+
+    if isinstance(obj, dict) and "state_dict" in obj:
+        obj = obj["state_dict"]
+
+    if isinstance(obj, dict) and "quantized" in obj and "scales" in obj and "passthrough" in obj:
+        state = {}
+        for name, q in obj["quantized"].items():
+            s = obj["scales"][name]
+            if s.ndim > 0:
+                state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in obj["passthrough"].items():
+            state[name] = t
+        return state
+
+    if not isinstance(obj, dict):
+        raise RuntimeError(f"Unsupported checkpoint object type: {type(obj)}")
+    return obj
+
+
+def get_lora_params(model: nn.Module):
+    params = []
+    names = []
+    for name, p in model.named_parameters():
+        is_lora = (
+            "qkv_lora_A" in name or "qkv_lora_B" in name or
+            "out_lora_A" in name or "out_lora_B" in name
+        )
+        p.requires_grad_(is_lora)
+        if is_lora:
+            params.append(p)
+            names.append(name)
+    return names, params
+
+
+@torch.no_grad()
+def reset_lora_adapters(model: nn.Module):
+    for name, p in model.named_parameters():
+        if "lora_B" in name:
+            p.zero_()
+
+
+@torch.no_grad()
+def decay_lora_adapters(model: nn.Module, decay: float):
+    if decay >= 1.0:
+        return
+    for name, p in model.named_parameters():
+        if "lora_" in name:
+            p.mul_(decay)
+
+
+@torch.no_grad()
+def decay_vocab_bias(vocab_bias, decay: float):
+    if vocab_bias is None or decay >= 1.0:
+        return
+    vocab_bias.mul_(decay)
+    if TTT_BIAS_CENTER:
+        vocab_bias.sub_(vocab_bias.mean())
+
+
+def logits_from_hidden(core, hidden, vocab_bias=None):
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    if vocab_bias is not None:
+        logits = logits + vocab_bias.to(dtype=logits.dtype, device=logits.device)[None, :]
+    return logits
+
+
+def score_window_batch(core, xn, yn, bb, hs, ib, stride, vocab_bias=None):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    with torch.no_grad():
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, -stride:, :]
+            flat_y = y[:, -stride:].reshape(-1)
+            logits = logits_from_hidden(core, hidden_tail, vocab_bias=vocab_bias)
+            loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+    cnt = float(flat_y.numel())
+    p_tail = xn[:, -stride:].reshape(-1)
+    t_tail = yn[:, -stride:].reshape(-1)
+    b = bb[t_tail].astype(np.int16, copy=True)
+    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+    byt = float(b.astype(np.float64).sum())
+    return float(loss.detach().float().item()), cnt, byt
+
+
+def adapt_window_batch(core, xn, yn, stride, vocab_bias=None, bias_only=False):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    if bias_only:
+        # Freeze base compute entirely; only gradient is through vocab_bias.
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                hidden = core(x, state=None, return_state=False)
+                hidden_tail = hidden[:, -stride:, :]
+                base_logits = logits_from_hidden(core, hidden_tail, vocab_bias=None).detach()
+        flat_y = y[:, -stride:].reshape(-1)
+        logits = base_logits.float() + vocab_bias.float()[None, :]
+        loss = F.cross_entropy(logits, flat_y, reduction="mean")
+    else:
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, -stride:, :]
+            flat_y = y[:, -stride:].reshape(-1)
+            logits = logits_from_hidden(core, hidden_tail, vocab_bias=vocab_bias)
+            loss = F.cross_entropy(logits.float(), flat_y, reduction="mean")
+    return loss
+
+
+def make_windows(val_tokens, window_ids, seq_len, stride):
+    x_list, y_list = [], []
+    max_tok = val_tokens.size
+    for w in window_ids:
+        pos = int(w) * stride
+        if pos + seq_len + 1 <= max_tok:
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+    if not x_list:
+        return None, None
+    return np.stack(x_list), np.stack(y_list)
+
+
+def eval_score_first_lora_ttt(core, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first adapter TTT:
+      1. Score a contiguous range of sliding windows with current LoRA state.
+      2. Update only LoRA params using tail-token CE on already-scored windows.
+      3. Carry LoRA params to the next chunk.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core.train()  # adapters update; dropout absent
+    reset_lora_adapters(core)
+    lora_names, lora_params = get_lora_params(core)
+    n_lora = sum(p.numel() for p in lora_params)
+    log0(
+        f"LoRA TTT: params={len(lora_params)} ({n_lora:,}), rank={TTT_LORA_RANK}, "
+        f"alpha={TTT_LORA_ALPHA}, chunk_tokens={TTT_CHUNK_TOKENS}, "
+        f"train_windows/rank={TTT_TRAIN_WINDOWS}, epochs={TTT_EPOCHS}, "
+        f"lr={TTT_ADAPTER_LR}, decay={TTT_LORA_DECAY}, opt={TTT_OPT}"
+    )
+    if MASTER_PROCESS and len(lora_names) > 0:
+        log0("  lora preview: " + ", ".join(lora_names[:8]) + ("..." if len(lora_names) > 8 else ""))
+
+    # Optional vocab logit-bias adapter. This is often the cheapest useful
+    # TTT state: 8192 params that learn local token frequency after each scored chunk.
+    vocab_bias = None
+    bias_opt = None
+    if TTT_BIAS_ENABLED:
+        vocab_bias = nn.Parameter(torch.zeros(VOCAB_SIZE, device=DEVICE, dtype=torch.float32))
+        if TTT_BIAS_OPT == "sgd":
+            bias_opt = torch.optim.SGD([vocab_bias], lr=TTT_BIAS_LR, momentum=0.0, weight_decay=TTT_BIAS_WD)
+        else:
+            bias_opt = torch.optim.AdamW([vocab_bias], lr=TTT_BIAS_LR, betas=(0.9, 0.95), weight_decay=TTT_BIAS_WD)
+        log0(
+            f"Logit-bias TTT: enabled=True, params={VOCAB_SIZE}, lr={TTT_BIAS_LR}, "
+            f"decay={TTT_BIAS_DECAY}, opt={TTT_BIAS_OPT}, center={TTT_BIAS_CENTER}"
+        )
+
+    if len(lora_params) == 0 and not TTT_BIAS_ENABLED:
+        raise RuntimeError("No TTT params found. Enable LoRA and/or TTT_BIAS_ENABLED.")
+
+    opt = None
+    if len(lora_params) > 0:
+        if TTT_OPT == "sgd":
+            opt = torch.optim.SGD(lora_params, lr=TTT_ADAPTER_LR, momentum=0.0, weight_decay=TTT_ADAPTER_WD)
+        else:
+            opt = torch.optim.AdamW(lora_params, lr=TTT_ADAPTER_LR, betas=(0.9, 0.95), weight_decay=TTT_ADAPTER_WD)
+
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+    total_windows = max(0, (total_tokens - seq_len) // stride + 1)
+    windows_per_chunk = max(1, TTT_CHUNK_TOKENS // stride)
+    n_chunks = (total_windows + windows_per_chunk - 1) // windows_per_chunk
+    if TTT_MAX_CHUNKS > 0:
+        n_chunks = min(n_chunks, TTT_MAX_CHUNKS)
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every = max(1, n_chunks // 10)
+
+    for ci in range(n_chunks):
+        w0 = ci * windows_per_chunk
+        w1 = min((ci + 1) * windows_per_chunk, total_windows)
+        n_local = max(0, w1 - w0)
+
+        # Score first: split this same global chunk across ranks.
+        local_start = w0 + (n_local * RANK) // WORLD_SIZE
+        local_end = w0 + (n_local * (RANK + 1)) // WORLD_SIZE
+
+        core.eval()
+        for wb in range(local_start, local_end, batch_windows):
+            we = min(wb + batch_windows, local_end)
+            ids = list(range(wb, we))
+            xn, yn = make_windows(val_tokens, ids, seq_len, stride)
+            if xn is None:
+                continue
+            l, c, b = score_window_batch(core, xn, yn, bb, hs, ib, stride, vocab_bias=vocab_bias)
+            loss_sum += l
+            tok_sum += c
+            byt_sum += b
+
+        # Then adapt on already-scored windows from this chunk only.
+        if TTT_TRAIN_WINDOWS > 0:
+            core.train()
+            n_train_total = max(TTT_TRAIN_WINDOWS * WORLD_SIZE, WORLD_SIZE)
+            sample_ids = np.linspace(w0, max(w0, w1 - 1), num=n_train_total, dtype=np.int64)
+            sample_ids = sample_ids[RANK::WORLD_SIZE][:TTT_TRAIN_WINDOWS]
+            sample_ids = [int(s) for s in sample_ids if local_start <= int(s) < local_end or w0 <= int(s) < w1]
+            if sample_ids:
+                xn, yn = make_windows(val_tokens, sample_ids, seq_len, stride)
+                if xn is not None:
+                    for _ in range(TTT_EPOCHS):
+                        # Update LoRA params, if enabled.
+                        if len(lora_params) > 0 and opt is not None:
+                            opt.zero_grad(set_to_none=True)
+                            loss = adapt_window_batch(core, xn, yn, stride, vocab_bias=vocab_bias, bias_only=False)
+                            loss.backward()
+                            for p in lora_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                            if TTT_GRAD_CLIP > 0:
+                                nn.utils.clip_grad_norm_(lora_params, TTT_GRAD_CLIP)
+                            opt.step()
+
+                        # Update vocab bias separately with frozen base logits.
+                        if TTT_BIAS_ENABLED and bias_opt is not None:
+                            bias_opt.zero_grad(set_to_none=True)
+                            bias_loss = adapt_window_batch(core, xn, yn, stride, vocab_bias=vocab_bias, bias_only=True)
+                            bias_loss.backward()
+                            if vocab_bias.grad is not None:
+                                dist.all_reduce(vocab_bias.grad, op=dist.ReduceOp.AVG)
+                            if TTT_BIAS_GRAD_CLIP > 0 and vocab_bias.grad is not None:
+                                vocab_bias.grad.clamp_(-TTT_BIAS_GRAD_CLIP, TTT_BIAS_GRAD_CLIP)
+                            bias_opt.step()
+                            with torch.no_grad():
+                                if TTT_BIAS_CENTER:
+                                    vocab_bias.sub_(vocab_bias.mean())
+                    decay_lora_adapters(core, TTT_LORA_DECAY)
+                    decay_vocab_bias(vocab_bias, TTT_BIAS_DECAY)
+
+        if (ci + 1) % log_every == 0 or ci == 0 or ci == n_chunks - 1:
+            elapsed = time.perf_counter() - t0_eval
+            stats_now = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+            dist.all_reduce(stats_now, op=dist.ReduceOp.SUM)
+            rs_loss, rs_tok, rs_byt = float(stats_now[0]), float(stats_now[1]), float(stats_now[2])
+            run_loss = rs_loss / max(rs_tok, 1.0)
+            run_bpb = (run_loss / math.log(2.0)) * (rs_tok / max(rs_byt, 1.0))
+            eta = elapsed / max(ci + 1, 1) * (n_chunks - ci - 1)
+            log0(f"  lora_ttt: chunk {ci+1}/{n_chunks} running_bpb:{run_bpb:.4f} eta:{eta:.0f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"LoRA TTT done: chunks={n_chunks}, scored_tokens={tok_sum:.0f}, elapsed={elapsed:.1f}s")
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        # Safe even though weights will be overwritten for base params.
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    log0(f"Loading checkpoint/artifact: {ARTIFACT_PATH}")
+    state = load_checkpoint_state(ARTIFACT_PATH)
+    missing, unexpected = base_model.load_state_dict(state, strict=False)
+    missing_non_lora = [k for k in missing if "lora_" not in k]
+    unexpected_non_lora = [k for k in unexpected if "lora_" not in k]
+    if missing_non_lora:
+        log0(f"WARNING: non-LoRA missing keys: {missing_non_lora[:12]}{'...' if len(missing_non_lora) > 12 else ''}")
+    if unexpected_non_lora:
+        log0(f"WARNING: unexpected keys: {unexpected_non_lora[:12]}{'...' if len(unexpected_non_lora) > 12 else ''}")
+    log0(f"Missing LoRA keys initialized fresh: {len([k for k in missing if 'lora_' in k])}")
+
+    if FORCE_LOOP_ENABLED:
+        if base_model.loop_enc_seq is None or base_model.loop_dec_seq is None:
+            raise RuntimeError(
+                "FORCE_LOOP_ENABLED=1 but recurrence sequences are not configured. "
+                "Pass LOOP_START and LOOP_END, e.g. LOOP_START=5 LOOP_END=5."
+            )
+        base_model.loop_enabled_external = True
+        log0(
+            f"FORCE_LOOP_ENABLED=1: using recurrence "
+            f"enc={base_model.loop_enc_seq} dec={base_model.loop_dec_seq}"
+        )
+    else:
+        log0("FORCE_LOOP_ENABLED=0: recurrence disabled for eval")
+
+    # Freeze base and enable LoRA params only.
+    lora_names, lora_params = get_lora_params(base_model)
+    log0(f"Trainable LoRA params: {len(lora_params)} tensors, {sum(p.numel() for p in lora_params):,} params")
+
+    model_for_eval = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            model_for_eval = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            model_for_eval = base_model
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+    else:
+        log0("torch_compile: disabled")
+
+    # Optional baseline before TTT.
+    if RUN_BASELINE:
+        vl, vb = eval_val(model_for_eval, val_tokens, bb, hs, ib)
+        log0(f"Loaded baseline standard val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            sw_vl, sw_vb = eval_val_sliding(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Loaded baseline sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+
+    dist.barrier()
+    log0("=" * 60)
+    log0("Running score-first attention-LoRA TTT...")
+    ttt_vl, ttt_vb = eval_score_first_lora_ttt(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+    log0(f"Score-first LoRA TTT val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+    log0("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_copy_untied.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_copy_untied.py
@@ -1,0 +1,2421 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "1") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_dynamic_ttt_eval_loop.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_dynamic_ttt_eval_loop.py
@@ -1,0 +1,2375 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Eval-only score-first LoRA TTT config.
+# This script loads a checkpoint/artifact and adapts only LoRA adapters on
+# already-scored validation chunks.
+TTT_LORA_ENABLED = os.environ.get("TTT_LORA_ENABLED", "1") == "1"
+TTT_LORA_RANK = int(os.environ.get("TTT_LORA_RANK", "4"))
+TTT_LORA_ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "8.0"))
+TTT_LORA_STD = float(os.environ.get("TTT_LORA_STD", "0.01"))
+TTT_LORA_QKV = os.environ.get("TTT_LORA_QKV", "1") == "1"
+TTT_LORA_OUT = os.environ.get("TTT_LORA_OUT", "1") == "1"
+
+# Score-first adapter TTT runtime settings.
+ARTIFACT_PATH = os.environ.get("ARTIFACT_PATH", "/workspace/parameter-golf/final_model.int8.ptz")
+RUN_BASELINE = os.environ.get("RUN_BASELINE", "1") == "1"
+TTT_CHUNK_TOKENS = int(os.environ.get("TTT_CHUNK_TOKENS", "262144"))
+TTT_TRAIN_WINDOWS = int(os.environ.get("TTT_TRAIN_WINDOWS", "4"))
+TTT_EPOCHS = int(os.environ.get("TTT_EPOCHS", "1"))
+TTT_ADAPTER_LR = float(os.environ.get("TTT_ADAPTER_LR", "5e-4"))
+TTT_ADAPTER_WD = float(os.environ.get("TTT_ADAPTER_WD", "0.0"))
+TTT_LORA_DECAY = float(os.environ.get("TTT_LORA_DECAY", "0.995"))
+TTT_GRAD_CLIP = float(os.environ.get("TTT_GRAD_CLIP", "1.0"))
+TTT_OPT = os.environ.get("TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+TTT_MAX_CHUNKS = int(os.environ.get("TTT_MAX_CHUNKS", "0"))  # 0 = all
+
+# Score-first logit-bias TTT.
+# This is a tiny 8192-dim adapter: logits = base_logits + vocab_bias.
+# It learns local token/document frequency from already-scored chunks.
+TTT_BIAS_ENABLED = os.environ.get("TTT_BIAS_ENABLED", "1") == "1"
+TTT_BIAS_LR = float(os.environ.get("TTT_BIAS_LR", "0.05"))
+TTT_BIAS_WD = float(os.environ.get("TTT_BIAS_WD", "0.0"))
+TTT_BIAS_DECAY = float(os.environ.get("TTT_BIAS_DECAY", "0.995"))
+TTT_BIAS_GRAD_CLIP = float(os.environ.get("TTT_BIAS_GRAD_CLIP", "5.0"))
+TTT_BIAS_CENTER = os.environ.get("TTT_BIAS_CENTER", "1") == "1"
+TTT_BIAS_OPT = os.environ.get("TTT_BIAS_OPT", "adamw").lower()  # "adamw" or "sgd"
+
+# Dynamic / continuous-thought TTT.
+# Always do TTT_MIN_STEPS after scoring a chunk. If the scored chunk is harder
+# than the moving average, spend up to TTT_MAX_STEPS, stopping early when
+# adaptation stops improving. This stays score-first because all updates happen
+# after the chunk has already been scored.
+TTT_DYNAMIC_ENABLED = os.environ.get("TTT_DYNAMIC_ENABLED", "0") == "1"
+TTT_MIN_STEPS = int(os.environ.get("TTT_MIN_STEPS", "1"))
+TTT_MAX_STEPS = int(os.environ.get("TTT_MAX_STEPS", "4"))
+TTT_SCORE_EMA_BETA = float(os.environ.get("TTT_SCORE_EMA_BETA", "0.95"))
+TTT_DYNAMIC_SCORE_MARGIN = float(os.environ.get("TTT_DYNAMIC_SCORE_MARGIN", "0.02"))
+TTT_DYNAMIC_ADAPT_MARGIN = float(os.environ.get("TTT_DYNAMIC_ADAPT_MARGIN", "0.02"))
+TTT_MIN_IMPROVEMENT = float(os.environ.get("TTT_MIN_IMPROVEMENT", "0.001"))
+TTT_EXTRA_CHUNK_FRAC_CAP = float(os.environ.get("TTT_EXTRA_CHUNK_FRAC_CAP", "0.35"))
+TTT_DYNAMIC_LOG = os.environ.get("TTT_DYNAMIC_LOG", "1") == "1"
+
+# Force depth recurrence at eval-time for checkpoints trained/evaluated with recurrence on.
+# Needed because training script toggles loop_enabled_external during training,
+# but a fresh eval-only model starts with it disabled.
+FORCE_LOOP_ENABLED = os.environ.get("FORCE_LOOP_ENABLED", "0") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Eval-time LoRA adapters. Zero-B init means loaded checkpoint behavior
+        # is exactly preserved before TTT adaptation.
+        self.ttt_lora_rank = TTT_LORA_RANK if TTT_LORA_ENABLED else 0
+        self.ttt_lora_scale = TTT_LORA_ALPHA / max(TTT_LORA_RANK, 1)
+        if self.ttt_lora_rank > 0 and TTT_LORA_QKV:
+            self.qkv_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.qkv_lora_B = nn.Parameter(torch.zeros(3 * d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.qkv_lora_A, std=TTT_LORA_STD)
+        else:
+            self.qkv_lora_A = None
+            self.qkv_lora_B = None
+
+        if self.ttt_lora_rank > 0 and TTT_LORA_OUT:
+            self.out_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.out_lora_B = nn.Parameter(torch.zeros(d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.out_lora_A, std=TTT_LORA_STD)
+        else:
+            self.out_lora_A = None
+            self.out_lora_B = None
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv_raw = self.qkv(normed)
+        if self.qkv_lora_A is not None:
+            qkv_delta = F.linear(F.linear(normed, self.qkv_lora_A), self.qkv_lora_B)
+            qkv_raw = qkv_raw + self.ttt_lora_scale * qkv_delta
+        qkv = qkv_raw.reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        out = self.out_proj(attn_out)
+        if self.out_lora_A is not None:
+            out_delta = F.linear(F.linear(attn_out, self.out_lora_A), self.out_lora_B)
+            out = out + self.ttt_lora_scale * out_delta
+        x = x + self.attn_scale[None, None, :] * out
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Eval-only checkpoint loading + score-first LoRA TTT
+# -----------------------------------------------------------------------------
+def _try_torch_load_bytes(raw: bytes):
+    import io
+    try:
+        return torch.load(io.BytesIO(raw), map_location="cpu")
+    except Exception:
+        return None
+
+
+def load_checkpoint_state(path: str):
+    """
+    Loads either:
+      - raw torch state_dict / {"state_dict": ...}
+      - compressed int8 artifact from this script:
+          {"quantized": ..., "scales": ..., "passthrough": ...}
+    """
+    import io
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"ARTIFACT_PATH not found: {path}")
+
+    raw = p.read_bytes()
+    obj = _try_torch_load_bytes(raw)
+
+    if obj is None:
+        # Try zstd, then zlib.
+        if _COMPRESSOR == "zstd":
+            try:
+                dctx = zstandard.ZstdDecompressor()
+                obj = torch.load(io.BytesIO(dctx.decompress(raw)), map_location="cpu")
+            except Exception:
+                obj = None
+        if obj is None:
+            try:
+                obj = torch.load(io.BytesIO(zlib.decompress(raw)), map_location="cpu")
+            except Exception as e:
+                raise RuntimeError(f"Could not load checkpoint/artifact {path}: {e}") from e
+
+    if isinstance(obj, dict) and "state_dict" in obj:
+        obj = obj["state_dict"]
+
+    if isinstance(obj, dict) and "quantized" in obj and "scales" in obj and "passthrough" in obj:
+        state = {}
+        for name, q in obj["quantized"].items():
+            s = obj["scales"][name]
+            if s.ndim > 0:
+                state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in obj["passthrough"].items():
+            state[name] = t
+        return state
+
+    if not isinstance(obj, dict):
+        raise RuntimeError(f"Unsupported checkpoint object type: {type(obj)}")
+    return obj
+
+
+def get_lora_params(model: nn.Module):
+    params = []
+    names = []
+    for name, p in model.named_parameters():
+        is_lora = (
+            "qkv_lora_A" in name or "qkv_lora_B" in name or
+            "out_lora_A" in name or "out_lora_B" in name
+        )
+        p.requires_grad_(is_lora)
+        if is_lora:
+            params.append(p)
+            names.append(name)
+    return names, params
+
+
+@torch.no_grad()
+def reset_lora_adapters(model: nn.Module):
+    for name, p in model.named_parameters():
+        if "lora_B" in name:
+            p.zero_()
+
+
+@torch.no_grad()
+def decay_lora_adapters(model: nn.Module, decay: float):
+    if decay >= 1.0:
+        return
+    for name, p in model.named_parameters():
+        if "lora_" in name:
+            p.mul_(decay)
+
+
+@torch.no_grad()
+def decay_vocab_bias(vocab_bias, decay: float):
+    if vocab_bias is None or decay >= 1.0:
+        return
+    vocab_bias.mul_(decay)
+    if TTT_BIAS_CENTER:
+        vocab_bias.sub_(vocab_bias.mean())
+
+
+def logits_from_hidden(core, hidden, vocab_bias=None):
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    if vocab_bias is not None:
+        logits = logits + vocab_bias.to(dtype=logits.dtype, device=logits.device)[None, :]
+    return logits
+
+
+def score_window_batch(core, xn, yn, bb, hs, ib, stride, vocab_bias=None):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    with torch.no_grad():
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, -stride:, :]
+            flat_y = y[:, -stride:].reshape(-1)
+            logits = logits_from_hidden(core, hidden_tail, vocab_bias=vocab_bias)
+            loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+    cnt = float(flat_y.numel())
+    p_tail = xn[:, -stride:].reshape(-1)
+    t_tail = yn[:, -stride:].reshape(-1)
+    b = bb[t_tail].astype(np.int16, copy=True)
+    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+    byt = float(b.astype(np.float64).sum())
+    return float(loss.detach().float().item()), cnt, byt
+
+
+def adapt_window_batch(core, xn, yn, stride, vocab_bias=None, bias_only=False):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    if bias_only:
+        # Freeze base compute entirely; only gradient is through vocab_bias.
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                hidden = core(x, state=None, return_state=False)
+                hidden_tail = hidden[:, -stride:, :]
+                base_logits = logits_from_hidden(core, hidden_tail, vocab_bias=None).detach()
+        flat_y = y[:, -stride:].reshape(-1)
+        logits = base_logits.float() + vocab_bias.float()[None, :]
+        loss = F.cross_entropy(logits, flat_y, reduction="mean")
+    else:
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, -stride:, :]
+            flat_y = y[:, -stride:].reshape(-1)
+            logits = logits_from_hidden(core, hidden_tail, vocab_bias=vocab_bias)
+            loss = F.cross_entropy(logits.float(), flat_y, reduction="mean")
+    return loss
+
+
+def make_windows(val_tokens, window_ids, seq_len, stride):
+    x_list, y_list = [], []
+    max_tok = val_tokens.size
+    for w in window_ids:
+        pos = int(w) * stride
+        if pos + seq_len + 1 <= max_tok:
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+    if not x_list:
+        return None, None
+    return np.stack(x_list), np.stack(y_list)
+
+
+def eval_score_first_lora_ttt(core, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first adapter TTT with optional dynamic compute.
+
+    For each validation chunk:
+      1. Score chunk with current adapters/bias. These are final scores.
+      2. Adapt only on already-scored windows from that chunk.
+      3. If dynamic is enabled, do extra adaptation steps only for hard chunks,
+         stopping early when improvement is too small.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core.train()  # adapters update; dropout absent
+    reset_lora_adapters(core)
+    lora_names, lora_params = get_lora_params(core)
+    n_lora = sum(p.numel() for p in lora_params)
+    log0(
+        f"LoRA TTT: params={len(lora_params)} ({n_lora:,}), rank={TTT_LORA_RANK}, "
+        f"alpha={TTT_LORA_ALPHA}, chunk_tokens={TTT_CHUNK_TOKENS}, "
+        f"train_windows/rank={TTT_TRAIN_WINDOWS}, static_epochs={TTT_EPOCHS}, "
+        f"lr={TTT_ADAPTER_LR}, decay={TTT_LORA_DECAY}, opt={TTT_OPT}"
+    )
+    if TTT_DYNAMIC_ENABLED:
+        log0(
+            f"Dynamic TTT: min_steps={TTT_MIN_STEPS}, max_steps={TTT_MAX_STEPS}, "
+            f"score_margin={TTT_DYNAMIC_SCORE_MARGIN}, adapt_margin={TTT_DYNAMIC_ADAPT_MARGIN}, "
+            f"min_improvement={TTT_MIN_IMPROVEMENT}, extra_cap={TTT_EXTRA_CHUNK_FRAC_CAP}"
+        )
+    if MASTER_PROCESS and len(lora_names) > 0:
+        log0("  lora preview: " + ", ".join(lora_names[:8]) + ("..." if len(lora_names) > 8 else ""))
+
+    # Optional vocab logit-bias adapter. This is often the cheapest useful
+    # TTT state: 8192 params that learn local token frequency after each scored chunk.
+    vocab_bias = None
+    bias_opt = None
+    if TTT_BIAS_ENABLED:
+        vocab_bias = nn.Parameter(torch.zeros(VOCAB_SIZE, device=DEVICE, dtype=torch.float32))
+        if TTT_BIAS_OPT == "sgd":
+            bias_opt = torch.optim.SGD([vocab_bias], lr=TTT_BIAS_LR, momentum=0.0, weight_decay=TTT_BIAS_WD)
+        else:
+            bias_opt = torch.optim.AdamW([vocab_bias], lr=TTT_BIAS_LR, betas=(0.9, 0.95), weight_decay=TTT_BIAS_WD)
+        log0(
+            f"Logit-bias TTT: enabled=True, params={VOCAB_SIZE}, lr={TTT_BIAS_LR}, "
+            f"decay={TTT_BIAS_DECAY}, opt={TTT_BIAS_OPT}, center={TTT_BIAS_CENTER}"
+        )
+
+    if len(lora_params) == 0 and not TTT_BIAS_ENABLED:
+        raise RuntimeError("No TTT params found. Enable LoRA and/or TTT_BIAS_ENABLED.")
+
+    opt = None
+    if len(lora_params) > 0:
+        if TTT_OPT == "sgd":
+            opt = torch.optim.SGD(lora_params, lr=TTT_ADAPTER_LR, momentum=0.0, weight_decay=TTT_ADAPTER_WD)
+        else:
+            opt = torch.optim.AdamW(lora_params, lr=TTT_ADAPTER_LR, betas=(0.9, 0.95), weight_decay=TTT_ADAPTER_WD)
+
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+    total_windows = max(0, (total_tokens - seq_len) // stride + 1)
+    windows_per_chunk = max(1, TTT_CHUNK_TOKENS // stride)
+    n_chunks = (total_windows + windows_per_chunk - 1) // windows_per_chunk
+    if TTT_MAX_CHUNKS > 0:
+        n_chunks = min(n_chunks, TTT_MAX_CHUNKS)
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every = max(1, n_chunks // 10)
+
+    score_loss_ema = None
+    extra_chunks_used = 0
+    total_adapt_steps = 0
+
+    for ci in range(n_chunks):
+        w0 = ci * windows_per_chunk
+        w1 = min((ci + 1) * windows_per_chunk, total_windows)
+        n_local = max(0, w1 - w0)
+
+        # Score first: split this same global chunk across ranks.
+        local_start = w0 + (n_local * RANK) // WORLD_SIZE
+        local_end = w0 + (n_local * (RANK + 1)) // WORLD_SIZE
+
+        chunk_loss_sum = 0.0
+        chunk_tok_sum = 0.0
+        chunk_byt_sum = 0.0
+
+        core.eval()
+        for wb in range(local_start, local_end, batch_windows):
+            we = min(wb + batch_windows, local_end)
+            ids = list(range(wb, we))
+            xn, yn = make_windows(val_tokens, ids, seq_len, stride)
+            if xn is None:
+                continue
+            l, c, b = score_window_batch(core, xn, yn, bb, hs, ib, stride, vocab_bias=vocab_bias)
+            loss_sum += l
+            tok_sum += c
+            byt_sum += b
+            chunk_loss_sum += l
+            chunk_tok_sum += c
+            chunk_byt_sum += b
+
+        # Aggregate chunk score to decide whether to spend extra thought.
+        chunk_stats = torch.tensor([chunk_loss_sum, chunk_tok_sum, chunk_byt_sum], device=DEVICE, dtype=torch.float64)
+        dist.all_reduce(chunk_stats, op=dist.ReduceOp.SUM)
+        g_chunk_loss = float(chunk_stats[0])
+        g_chunk_tok = float(chunk_stats[1])
+        chunk_score_loss = g_chunk_loss / max(g_chunk_tok, 1.0)
+
+        prev_ema = score_loss_ema
+        if score_loss_ema is None:
+            score_loss_ema = chunk_score_loss
+        else:
+            score_loss_ema = (
+                TTT_SCORE_EMA_BETA * score_loss_ema
+                + (1.0 - TTT_SCORE_EMA_BETA) * chunk_score_loss
+            )
+
+        extra_budget = max(0, int(round(TTT_EXTRA_CHUNK_FRAC_CAP * n_chunks)))
+        hard_chunk = (
+            TTT_DYNAMIC_ENABLED
+            and prev_ema is not None
+            and chunk_score_loss > (prev_ema + TTT_DYNAMIC_SCORE_MARGIN)
+            and extra_chunks_used < extra_budget
+        )
+
+        if TTT_DYNAMIC_ENABLED:
+            max_steps_this = TTT_MAX_STEPS if hard_chunk else TTT_MIN_STEPS
+            min_steps_this = TTT_MIN_STEPS
+        else:
+            max_steps_this = TTT_EPOCHS
+            min_steps_this = TTT_EPOCHS
+
+        actual_steps = 0
+        last_metric = None
+        last_improvement = None
+
+        # Then adapt on already-scored windows from this chunk only.
+        if TTT_TRAIN_WINDOWS > 0 and max_steps_this > 0:
+            core.train()
+            n_train_total = max(TTT_TRAIN_WINDOWS * WORLD_SIZE, WORLD_SIZE)
+            sample_ids = np.linspace(w0, max(w0, w1 - 1), num=n_train_total, dtype=np.int64)
+            sample_ids = sample_ids[RANK::WORLD_SIZE][:TTT_TRAIN_WINDOWS]
+            sample_ids = [int(s) for s in sample_ids if local_start <= int(s) < local_end or w0 <= int(s) < w1]
+            if sample_ids:
+                xn, yn = make_windows(val_tokens, sample_ids, seq_len, stride)
+                if xn is not None:
+                    for step_idx in range(max_steps_this):
+                        metrics = []
+
+                        # Update LoRA params, if enabled.
+                        if len(lora_params) > 0 and opt is not None:
+                            opt.zero_grad(set_to_none=True)
+                            loss = adapt_window_batch(core, xn, yn, stride, vocab_bias=vocab_bias, bias_only=False)
+                            loss.backward()
+                            metrics.append(float(loss.detach().float().item()))
+                            for p in lora_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                            if TTT_GRAD_CLIP > 0:
+                                nn.utils.clip_grad_norm_(lora_params, TTT_GRAD_CLIP)
+                            opt.step()
+
+                        # Update vocab bias separately with frozen base logits.
+                        if TTT_BIAS_ENABLED and bias_opt is not None:
+                            bias_opt.zero_grad(set_to_none=True)
+                            bias_loss = adapt_window_batch(core, xn, yn, stride, vocab_bias=vocab_bias, bias_only=True)
+                            bias_loss.backward()
+                            metrics.append(float(bias_loss.detach().float().item()))
+                            if vocab_bias.grad is not None:
+                                dist.all_reduce(vocab_bias.grad, op=dist.ReduceOp.AVG)
+                            if TTT_BIAS_GRAD_CLIP > 0 and vocab_bias.grad is not None:
+                                vocab_bias.grad.clamp_(-TTT_BIAS_GRAD_CLIP, TTT_BIAS_GRAD_CLIP)
+                            bias_opt.step()
+                            with torch.no_grad():
+                                if TTT_BIAS_CENTER:
+                                    vocab_bias.sub_(vocab_bias.mean())
+
+                        actual_steps += 1
+                        total_adapt_steps += 1
+
+                        metric = sum(metrics) / max(len(metrics), 1)
+                        if last_metric is not None:
+                            last_improvement = last_metric - metric
+                        last_metric = metric
+
+                        # Dynamic early stop after the mandatory minimum.
+                        if TTT_DYNAMIC_ENABLED and actual_steps >= min_steps_this:
+                            target = (prev_ema if prev_ema is not None else chunk_score_loss) + TTT_DYNAMIC_ADAPT_MARGIN
+                            if not hard_chunk:
+                                break
+                            if metric <= target:
+                                break
+                            if last_improvement is not None and last_improvement < TTT_MIN_IMPROVEMENT:
+                                break
+
+                    if actual_steps > TTT_MIN_STEPS:
+                        extra_chunks_used += 1
+
+                    decay_lora_adapters(core, TTT_LORA_DECAY)
+                    decay_vocab_bias(vocab_bias, TTT_BIAS_DECAY)
+
+        if (ci + 1) % log_every == 0 or ci == 0 or ci == n_chunks - 1:
+            elapsed = time.perf_counter() - t0_eval
+            stats_now = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+            dist.all_reduce(stats_now, op=dist.ReduceOp.SUM)
+            rs_loss, rs_tok, rs_byt = float(stats_now[0]), float(stats_now[1]), float(stats_now[2])
+            run_loss = rs_loss / max(rs_tok, 1.0)
+            run_bpb = (run_loss / math.log(2.0)) * (rs_tok / max(rs_byt, 1.0))
+            eta = elapsed / max(ci + 1, 1) * (n_chunks - ci - 1)
+            dyn = ""
+            if TTT_DYNAMIC_ENABLED and TTT_DYNAMIC_LOG:
+                dyn = (
+                    f" chunk_loss:{chunk_score_loss:.4f} ema:{score_loss_ema:.4f} "
+                    f"hard:{int(hard_chunk)} steps:{actual_steps} extra:{extra_chunks_used}"
+                )
+            log0(f"  lora_ttt: chunk {ci+1}/{n_chunks} running_bpb:{run_bpb:.4f}{dyn} eta:{eta:.0f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    elapsed = time.perf_counter() - t0_eval
+    log0(
+        f"LoRA/Bias TTT done: chunks={n_chunks}, scored_tokens={tok_sum:.0f}, "
+        f"adapt_steps={total_adapt_steps}, extra_chunks={extra_chunks_used}, elapsed={elapsed:.1f}s"
+    )
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        # Safe even though weights will be overwritten for base params.
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    log0(f"Loading checkpoint/artifact: {ARTIFACT_PATH}")
+    state = load_checkpoint_state(ARTIFACT_PATH)
+    missing, unexpected = base_model.load_state_dict(state, strict=False)
+    missing_non_lora = [k for k in missing if "lora_" not in k]
+    unexpected_non_lora = [k for k in unexpected if "lora_" not in k]
+    if missing_non_lora:
+        log0(f"WARNING: non-LoRA missing keys: {missing_non_lora[:12]}{'...' if len(missing_non_lora) > 12 else ''}")
+    if unexpected_non_lora:
+        log0(f"WARNING: unexpected keys: {unexpected_non_lora[:12]}{'...' if len(unexpected_non_lora) > 12 else ''}")
+    log0(f"Missing LoRA keys initialized fresh: {len([k for k in missing if 'lora_' in k])}")
+
+    if FORCE_LOOP_ENABLED:
+        if base_model.loop_enc_seq is None or base_model.loop_dec_seq is None:
+            raise RuntimeError(
+                "FORCE_LOOP_ENABLED=1 but recurrence sequences are not configured. "
+                "Pass LOOP_START and LOOP_END, e.g. LOOP_START=5 LOOP_END=5."
+            )
+        base_model.loop_enabled_external = True
+        log0(
+            f"FORCE_LOOP_ENABLED=1: using recurrence "
+            f"enc={base_model.loop_enc_seq} dec={base_model.loop_dec_seq}"
+        )
+    else:
+        log0("FORCE_LOOP_ENABLED=0: recurrence disabled for eval")
+
+    # Freeze base and enable LoRA params only.
+    lora_names, lora_params = get_lora_params(base_model)
+    log0(f"Trainable LoRA params: {len(lora_params)} tensors, {sum(p.numel() for p in lora_params):,} params")
+
+    model_for_eval = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            model_for_eval = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            model_for_eval = base_model
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+    else:
+        log0("torch_compile: disabled")
+
+    # Optional baseline before TTT.
+    if RUN_BASELINE:
+        vl, vb = eval_val(model_for_eval, val_tokens, bb, hs, ib)
+        log0(f"Loaded baseline standard val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            sw_vl, sw_vb = eval_val_sliding(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Loaded baseline sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+
+    dist.barrier()
+    log0("=" * 60)
+    log0("Running score-first attention-LoRA TTT...")
+    ttt_vl, ttt_vb = eval_score_first_lora_ttt(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+    log0(f"Score-first LoRA TTT val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+    log0("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullffn_muonffnattn_adamwmamba.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullffn_muonffnattn_adamwmamba.py
@@ -1,0 +1,2940 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+
+# Selective optimizer split for full-FFN hybrid:
+#   Muon only for large dense FFN + attention matrices.
+#   AdamW for every Mamba parameter, embeddings/bigram, and small/control params.
+# This keeps the strong full-FFN architecture while avoiding Muon geometry on SSM internals.
+SELECTIVE_MAMBA_ADAMW_OPT = os.environ.get("SELECTIVE_MAMBA_ADAMW_OPT", "1") == "1"
+FFN_MUON_LR_MULT = float(os.environ.get("FFN_MUON_LR_MULT", "1.0"))
+ATTN_MUON_LR_MULT = float(os.environ.get("ATTN_MUON_LR_MULT", "1.0"))
+FFN_MUON_WD = float(os.environ.get("FFN_MUON_WD", str(WEIGHT_DECAY)))
+ATTN_MUON_WD = float(os.environ.get("ATTN_MUON_WD", str(WEIGHT_DECAY)))
+MAMBA_IN_ADAM_LR = float(os.environ.get("MAMBA_IN_ADAM_LR", "0.006"))
+MAMBA_IN_ADAM_WD = float(os.environ.get("MAMBA_IN_ADAM_WD", "0.0"))
+MAMBA_OUT_ADAM_LR = float(os.environ.get("MAMBA_OUT_ADAM_LR", "0.006"))
+MAMBA_OUT_ADAM_WD = float(os.environ.get("MAMBA_OUT_ADAM_WD", "0.02"))
+MAMBA_OTHER_ADAM_LR = float(os.environ.get("MAMBA_OTHER_ADAM_LR", "0.003"))
+MAMBA_OTHER_ADAM_WD = float(os.environ.get("MAMBA_OTHER_ADAM_WD", "0.0"))
+MAMBA_DYN_ADAM_LR = float(os.environ.get("MAMBA_DYN_ADAM_LR", "0.002"))
+MAMBA_DYN_ADAM_WD = float(os.environ.get("MAMBA_DYN_ADAM_WD", "0.0"))
+BIGRAM_ADAM_LR = float(os.environ.get("BIGRAM_ADAM_LR", "0.015"))
+BIGRAM_ADAM_WD = float(os.environ.get("BIGRAM_ADAM_WD", "0.02"))
+OTHER_MATRIX_ADAM_LR = float(os.environ.get("OTHER_MATRIX_ADAM_LR", "0.02"))
+OTHER_MATRIX_ADAM_WD = float(os.environ.get("OTHER_MATRIX_ADAM_WD", str(WEIGHT_DECAY)))
+CONTROL_ADAM_LR = float(os.environ.get("CONTROL_ADAM_LR", str(SCALAR_LR)))
+CONTROL_ADAM_WD = float(os.environ.get("CONTROL_ADAM_WD", "0.0"))
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("fullffn_muonffnattn_adamwmamba_defaults: uploaded/full-FFN clean architecture; Muon only for FFN+attention, AdamW for all Mamba; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(
+    f"selective_mamba_adamw_opt: enabled={SELECTIVE_MAMBA_ADAMW_OPT}, "
+    f"ffn_muon_lr={MATRIX_LR*FFN_MUON_LR_MULT}, attn_muon_lr={MATRIX_LR*ATTN_MUON_LR_MULT}, "
+    f"mamba_in/out_adam_lr={MAMBA_IN_ADAM_LR}/{MAMBA_OUT_ADAM_LR}, "
+    f"mamba_dyn_lr={MAMBA_DYN_ADAM_LR}, bigram_lr={BIGRAM_ADAM_LR}, other_matrix_lr={OTHER_MATRIX_ADAM_LR}"
+)
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    """
+    Full-FFN selective optimizer:
+      - Muon only for FFN gate_up/down and attention qkv/out_proj matrices.
+      - AdamW for all Mamba parameters, bigram, embeddings, small/control params.
+
+    This intentionally avoids Muon on Mamba in_proj/out_proj/A/D/dt/conv rows, which
+    are heterogeneous recurrent-state parameters rather than ordinary dense MLP maps.
+    """
+    if not SELECTIVE_MAMBA_ADAMW_OPT:
+        # Original coarse split retained for exact baseline reproduction.
+        mat_params, scalar_params, embed_params = [], [], []
+        muon_eligible_2d = 0
+        muon_eligible_nd = 0
+        _seen_data_ptrs = set()
+        for name, p in model.named_parameters():
+            dp = p.data_ptr()
+            if dp in _seen_data_ptrs:
+                continue
+            _seen_data_ptrs.add(dp)
+            if name in ("tok_emb.weight", "lm_head.weight"):
+                embed_params.append(p)
+            else:
+                is_control = any(c in name for c in CTRL_PATTERNS)
+                if p.ndim == 2 and not is_control:
+                    muon_eligible_2d += 1
+                elif p.ndim > 2 and not is_control:
+                    muon_eligible_nd += 1
+                if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                    mat_params.append(p)
+                else:
+                    scalar_params.append(p)
+
+        optimizer_muon = Muon(
+            mat_params,
+            lr=MATRIX_LR,
+            momentum=MUON_MOMENTUM,
+            backend_steps=MUON_BACKEND_STEPS,
+            nesterov=MUON_NESTEROV,
+            weight_decay=WEIGHT_DECAY,
+        ) if len(mat_params) > 0 else None
+        optimizer_adamw = torch.optim.AdamW(
+            [
+                {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+                {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+            ],
+            betas=(BETA1, BETA2), eps=ADAM_EPS, fused=True,
+        )
+        log0(
+            f"Optimizer split: matrix={len(mat_params)} (Muon), "
+            f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+        )
+        log0(
+            f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+            f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+        )
+        return optimizer_adamw, optimizer_muon, mat_params
+
+    roles = {
+        "ffn_muon": [],
+        "attn_muon": [],
+        "mamba_in": [],
+        "mamba_out": [],
+        "mamba_dyn": [],
+        "mamba_other": [],
+        "bigram": [],
+        "embed": [],
+        "other_matrix": [],
+        "control": [],
+    }
+    _seen_data_ptrs = set()
+
+    def add(role, p):
+        roles[role].append(p)
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # tied lm_head/tok_emb
+        _seen_data_ptrs.add(dp)
+
+        is_control = any(c in name for c in CTRL_PATTERNS) or p.ndim < 2 or name.endswith(".bias")
+        is_mamba = ".mamba." in name
+        is_mamba_dyn = is_mamba and (name.endswith("A_log") or name.endswith("D") or name.endswith("dt_bias"))
+        is_mamba_in = is_mamba and name.endswith("in_proj.weight")
+        is_mamba_out = is_mamba and name.endswith("out_proj.weight")
+        is_ffn_matrix = (".ffn." in name and (name.endswith("gate_up.weight") or name.endswith("down.weight")))
+        is_attn_matrix = ((name.endswith("qkv.weight") or name.endswith("out_proj.weight")) and (".mamba." not in name))
+        is_bigram = name.startswith("bigram.")
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            add("embed", p)
+        elif is_mamba_dyn:
+            add("mamba_dyn", p)
+        elif is_mamba_in:
+            add("mamba_in", p)
+        elif is_mamba_out:
+            add("mamba_out", p)
+        elif is_mamba:
+            add("mamba_other", p)
+        elif is_ffn_matrix:
+            add("ffn_muon", p)
+        elif is_attn_matrix:
+            add("attn_muon", p)
+        elif is_bigram:
+            add("bigram", p)
+        elif is_control:
+            add("control", p)
+        elif p.ndim >= 2:
+            add("other_matrix", p)
+        else:
+            add("control", p)
+
+    muon_groups = []
+    if roles["ffn_muon"]:
+        lr = MATRIX_LR * FFN_MUON_LR_MULT
+        muon_groups.append({
+            "params": roles["ffn_muon"], "lr": lr, "base_lr": lr,
+            "weight_decay": FFN_MUON_WD,
+            "role": "ffn_muon",
+        })
+    if roles["attn_muon"]:
+        lr = MATRIX_LR * ATTN_MUON_LR_MULT
+        muon_groups.append({
+            "params": roles["attn_muon"], "lr": lr, "base_lr": lr,
+            "weight_decay": ATTN_MUON_WD,
+            "role": "attn_muon",
+        })
+
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adam_groups = []
+    def adam_group(role, lr, wd):
+        if roles[role]:
+            adam_groups.append({
+                "params": roles[role], "lr": lr, "base_lr": lr,
+                "weight_decay": wd, "role": role,
+            })
+
+    adam_group("mamba_in", MAMBA_IN_ADAM_LR, MAMBA_IN_ADAM_WD)
+    adam_group("mamba_out", MAMBA_OUT_ADAM_LR, MAMBA_OUT_ADAM_WD)
+    adam_group("mamba_dyn", MAMBA_DYN_ADAM_LR, MAMBA_DYN_ADAM_WD)
+    adam_group("mamba_other", MAMBA_OTHER_ADAM_LR, MAMBA_OTHER_ADAM_WD)
+    adam_group("bigram", BIGRAM_ADAM_LR, BIGRAM_ADAM_WD)
+    adam_group("other_matrix", OTHER_MATRIX_ADAM_LR, OTHER_MATRIX_ADAM_WD)
+    adam_group("control", CONTROL_ADAM_LR, CONTROL_ADAM_WD)
+    adam_group("embed", EMBED_LR, WEIGHT_DECAY)
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    mat_params = roles["ffn_muon"] + roles["attn_muon"]
+    role_counts = {k: len(v) for k, v in roles.items()}
+    adam_role_counts = {g.get("role", "?"): len(g["params"]) for g in adam_groups}
+    muon_role_counts = {g.get("role", "?"): len(g["params"]) for g in muon_groups}
+    log0(
+        f"Optimizer split: selective full-FFN; muon_matrices={len(mat_params)} "
+        f"(groups={muon_role_counts}), adamw_groups={adam_role_counts}"
+    )
+    log0(f"Optimizer role counts: {', '.join(f'{k}={v}' for k, v in role_counts.items())}")
+    log0(
+        f"Muon config: FFN/attention only, backend_steps={MUON_BACKEND_STEPS}, "
+        f"ffn_lr={MATRIX_LR*FFN_MUON_LR_MULT}, attn_lr={MATRIX_LR*ATTN_MUON_LR_MULT}; "
+        f"Mamba AdamW in/out/dyn={MAMBA_IN_ADAM_LR}/{MAMBA_OUT_ADAM_LR}/{MAMBA_DYN_ADAM_LR}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullmuon_final_compress.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullmuon_final_compress.py
@@ -1,0 +1,3114 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+import lzma
+import io
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path.
+# Final compression attempt for the proven Option-A full-Muon baseline:
+#   - Full-FFN clean architecture and optimizer are unchanged.
+#   - FFN gate_up is aggressively packed INT3.
+#   - FFN down is packed INT4.
+#   - Mamba matrices are packed INT4 with Mamba2 dt rows stored as protected INT8 sidecars.
+#   - Attention qkv/out are packed INT5.
+#   - Embeddings/bigram/embed projections are packed INT6 with optional opt-clip.
+#   - Small/control tensors stay fp16.
+#   - Container compression: LZMA-9 extreme.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+QUANT_FORMAT = os.environ.get("QUANT_FORMAT", "fullmuon_aggressive_lzma").lower()
+QUANT_BITS_MATRIX = int(os.environ.get("QUANT_BITS_MATRIX", "5"))
+QUANT_BITS_FFN_GATE = int(os.environ.get("QUANT_BITS_FFN_GATE", "3"))
+QUANT_BITS_FFN_DOWN = int(os.environ.get("QUANT_BITS_FFN_DOWN", "4"))
+QUANT_BITS_MAMBA = int(os.environ.get("QUANT_BITS_MAMBA", "4"))
+QUANT_BITS_ATTN = int(os.environ.get("QUANT_BITS_ATTN", "5"))
+QUANT_BITS_EMBED = int(os.environ.get("QUANT_BITS_EMBED", "6"))
+QUANT_PACK_ALL = os.environ.get("QUANT_PACK_ALL", "1") == "1"
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))
+QUANT_K_FFN_GATE = float(os.environ.get("QUANT_K_FFN_GATE", str(QUANT_K_MATRIX)))
+QUANT_K_FFN_DOWN = float(os.environ.get("QUANT_K_FFN_DOWN", str(QUANT_K_MATRIX)))
+QUANT_K_MAMBA = float(os.environ.get("QUANT_K_MAMBA", str(QUANT_K_MATRIX)))
+QUANT_K_ATTN = float(os.environ.get("QUANT_K_ATTN", str(QUANT_K_MATRIX)))
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))
+QUANT_SCALE_FLOOR_MULT = float(os.environ.get("QUANT_SCALE_FLOOR_MULT", "1.0"))
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"
+QUANT_OPTCLIP_STEPS = int(os.environ.get("QUANT_OPTCLIP_STEPS", "8"))
+QUANT_OPTCLIP_MIN_FRAC = float(os.environ.get("QUANT_OPTCLIP_MIN_FRAC", "0.55"))
+QUANT_OPTCLIP_MAX_FRAC = float(os.environ.get("QUANT_OPTCLIP_MAX_FRAC", "1.00"))
+QUANT_PRUNE_ONES_FRAC = float(os.environ.get("QUANT_PRUNE_ONES_FRAC", "0.0"))
+QUANT_AUTO_PRUNE_TO_BYTES = os.environ.get("QUANT_AUTO_PRUNE_TO_BYTES", "1") == "1"
+QUANT_TARGET_BYTES = int(os.environ.get("QUANT_TARGET_BYTES", "15850000"))
+QUANT_AUTO_PRUNE_FRACS = [float(x) for x in os.environ.get("QUANT_AUTO_PRUNE_FRACS", "0,0.25,0.40,0.55,0.70,0.85").split(",") if x.strip()]
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", "9"))
+QUANT_LZMA_EXTREME = os.environ.get("QUANT_LZMA_EXTREME", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compression_defaults: Option-A full-Muon baseline + aggressive role-bit packed LZMA artifact")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"compression_quant: format={QUANT_FORMAT}, pack_all={QUANT_PACK_ALL}, "
+    f"bits(ffn_gate/down={QUANT_BITS_FFN_GATE}/{QUANT_BITS_FFN_DOWN}, "
+    f"mamba={QUANT_BITS_MAMBA}, attn={QUANT_BITS_ATTN}, embed={QUANT_BITS_EMBED}, other={QUANT_BITS_MATRIX}), "
+    f"passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, "
+    f"k(ffn_gate/down={QUANT_K_FFN_GATE}/{QUANT_K_FFN_DOWN}, mamba={QUANT_K_MAMBA}, "
+    f"attn={QUANT_K_ATTN}, embed={QUANT_K_EMBED}, other={QUANT_K_MATRIX}), "
+    f"scale_floor_mult={QUANT_SCALE_FLOOR_MULT}, protect_dynamics={QUANT_PROTECT_DYNAMICS}, "
+    f"optclip_embed={QUANT_OPTCLIP_EMBED}, prune_ones_frac={QUANT_PRUNE_ONES_FRAC}, "
+    f"auto_prune={QUANT_AUTO_PRUNE_TO_BYTES}, target_bytes={QUANT_TARGET_BYTES}, "
+    f"lzma_preset={QUANT_LZMA_PRESET}, extreme={QUANT_LZMA_EXTREME}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Aggressive role-bit packed + LZMA compression path.
+        # -----------------------------------------------------------------------
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        if QUANT_FORMAT not in ("fullmuon_aggressive_lzma", "hybrid_aggressive_lzma"):
+            raise RuntimeError(
+                f"Unsupported QUANT_FORMAT={QUANT_FORMAT}; use fullmuon_aggressive_lzma"
+            )
+
+        def _is_embedding_like(n: str) -> bool:
+            return (
+                n == "tok_emb.weight" or n == "lm_head.weight" or
+                n.startswith("bigram.embed") or n.startswith("bigram.proj") or
+                "embed" in n
+            )
+
+        def _is_ffn_gate(n: str) -> bool:
+            return ".ffn.gate_up.weight" in n
+
+        def _is_ffn_down(n: str) -> bool:
+            return ".ffn.down.weight" in n
+
+        def _is_attn_weight(n: str) -> bool:
+            return (".qkv.weight" in n) or (".out_proj.weight" in n and ".mamba." not in n)
+
+        def _is_mamba_weight(n: str) -> bool:
+            return ".mamba." in n
+
+        def _qmax_for_bits(bits: int) -> int:
+            if bits < 2 or bits > 8:
+                raise ValueError(f"bits must be in [2,8], got {bits}")
+            return (1 << (bits - 1)) - 1
+
+        def _role_bits_k(name: str):
+            if _is_ffn_gate(name):
+                return QUANT_BITS_FFN_GATE, QUANT_K_FFN_GATE, "ffn_gate"
+            if _is_ffn_down(name):
+                return QUANT_BITS_FFN_DOWN, QUANT_K_FFN_DOWN, "ffn_down"
+            if _is_mamba_weight(name):
+                return QUANT_BITS_MAMBA, QUANT_K_MAMBA, "mamba"
+            if _is_attn_weight(name):
+                return QUANT_BITS_ATTN, QUANT_K_ATTN, "attention"
+            if _is_embedding_like(name):
+                return QUANT_BITS_EMBED, QUANT_K_EMBED, "embedding"
+            return QUANT_BITS_MATRIX, QUANT_K_MATRIX, "other_matrix"
+
+        def _pack_signed_q(q: torch.Tensor, bits: int):
+            """Pack signed symmetric q values [-qmax, qmax] into b bytes per 8 values."""
+            qmax = _qmax_for_bits(bits)
+            shape = tuple(q.shape)
+            flat = (q.to(torch.int16).reshape(-1).cpu() + qmax).clamp(0, (1 << bits) - 1).to(torch.uint8)
+            n = int(flat.numel())
+            if bits == 8:
+                return flat.contiguous(), shape, n, bits, qmax
+            pad = (-n) % 8
+            if pad:
+                flat = torch.cat([flat, torch.zeros(pad, dtype=torch.uint8)])
+            x = flat.view(-1, 8).to(torch.int64)
+            word = torch.zeros(x.shape[0], dtype=torch.int64)
+            for i in range(8):
+                word |= (x[:, i] << (bits * i))
+            out = torch.empty((x.shape[0], bits), dtype=torch.uint8)
+            for j in range(bits):
+                out[:, j] = ((word >> (8 * j)) & 0xFF).to(torch.uint8)
+            return out.contiguous().view(-1), shape, n, bits, qmax
+
+        def _unpack_signed_q(packed: torch.Tensor, shape, n: int, bits: int, qmax: int):
+            if bits == 8:
+                flat = packed.cpu().contiguous().view(-1)[:n].to(torch.int16)
+                return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+            b = packed.cpu().contiguous().view(-1, bits).to(torch.int64)
+            word = torch.zeros(b.shape[0], dtype=torch.int64)
+            for j in range(bits):
+                word |= (b[:, j] << (8 * j))
+            vals = []
+            mask = (1 << bits) - 1
+            for i in range(8):
+                vals.append(((word >> (bits * i)) & mask).to(torch.int16))
+            flat = torch.stack(vals, dim=1).reshape(-1)[:n]
+            return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+
+        def _mamba_dt_rows(name: str, rows: int):
+            if not (QUANT_PROTECT_DYNAMICS and name.endswith("mamba.in_proj.weight")):
+                return None
+            n_dt = max(1, (2 * D_MODEL) // max(1, HEADDIM))
+            n_dt = min(n_dt, rows)
+            return torch.arange(rows - n_dt, rows, dtype=torch.long)
+
+        def _quantize_rows(t32: torch.Tensor, bits: int, k: float, optclip: bool = False):
+            qmax = float(_qmax_for_bits(bits))
+            if t32.ndim == 2:
+                rows = t32.shape[0]
+                max_abs = t32.abs().amax(dim=1).clamp_min(1e-8)
+                std_abs = t32.float().std(dim=1).clamp_min(1e-8)
+                base_clip = torch.minimum(max_abs, std_abs * float(k)).clamp_min(1e-8)
+                if optclip and QUANT_OPTCLIP_STEPS > 1:
+                    best_err = torch.full((rows,), float("inf"), dtype=torch.float32)
+                    best_q = None
+                    best_scale = None
+                    fracs = torch.linspace(
+                        float(QUANT_OPTCLIP_MIN_FRAC),
+                        float(QUANT_OPTCLIP_MAX_FRAC),
+                        steps=int(QUANT_OPTCLIP_STEPS),
+                        dtype=torch.float32,
+                    )
+                    for frac in fracs:
+                        clip_abs = (base_clip * float(frac)).clamp_min(1e-8)
+                        scale_f = (clip_abs / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax)
+                        q_try = torch.round(torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None]) / scale_f[:, None]).clamp(-qmax, qmax)
+                        err = (q_try * scale_f[:, None] - t32).pow(2).mean(dim=1)
+                        mask = err < best_err
+                        if best_q is None:
+                            best_q = q_try.to(torch.int8)
+                            best_scale = scale_f
+                            best_err = err
+                        else:
+                            best_q[mask] = q_try[mask].to(torch.int8)
+                            best_scale[mask] = scale_f[mask]
+                            best_err[mask] = err[mask]
+                    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+                scale = (base_clip / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax).to(torch.float16).contiguous()
+                q = torch.round(torch.clamp(t32, -base_clip[:, None], base_clip[:, None]) / scale.float()[:, None]).clamp(-qmax, qmax).to(torch.int8).contiguous()
+                return q, scale
+            else:
+                max_abs = float(t32.abs().max().item()) if t32.numel() else 0.0
+                std_abs = float(t32.float().std().item()) if t32.numel() else 0.0
+                clip_abs = max(1e-8, min(max_abs, std_abs * float(k)) if std_abs > 0 else max_abs)
+                qmaxf = qmax
+                scale = max(clip_abs / qmaxf, float(QUANT_SCALE_FLOOR_MULT) / qmaxf)
+                q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale).clamp(-qmaxf, qmaxf).to(torch.int8).contiguous()
+                return q, torch.tensor(scale, dtype=torch.float16)
+
+        def _quantize_float_tensor(name: str, t: torch.Tensor):
+            t32 = t.float().cpu().contiguous()
+            bits, k, role = _role_bits_k(name)
+            q, scale = _quantize_rows(t32, bits, k, optclip=(_is_embedding_like(name) and QUANT_OPTCLIP_EMBED and t32.ndim == 2))
+            override = None
+            rows_to_override = _mamba_dt_rows(name, t32.shape[0] if t32.ndim == 2 else 0)
+            if rows_to_override is not None and rows_to_override.numel() > 0:
+                q8, s8 = _quantize_rows(t32[rows_to_override], 8, QUANT_K_MAMBA, optclip=False)
+                override = {
+                    "rows": rows_to_override.to(torch.int32),
+                    "q": q8.contiguous(),
+                    "scale": s8.contiguous(),
+                    "bits": 8,
+                    "qmax": 127,
+                }
+            return q, scale, bits, role, override
+
+        def _prune_low_error_ones(q_map, scale_map, prune_frac: float):
+            if prune_frac <= 0:
+                return 0, 0
+            errs = []
+            total_ones = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                counts = (q.abs() == 1).sum(dim=1).cpu()
+                if int(counts.sum().item()) == 0:
+                    continue
+                row_err = s.float().pow(2).cpu()
+                errs.append(torch.repeat_interleave(row_err, counts))
+                total_ones += int(counts.sum().item())
+            if total_ones == 0 or not errs:
+                return 0, 0
+            n_prune_target = int(max(0, min(total_ones, round(total_ones * float(prune_frac)))))
+            if n_prune_target <= 0:
+                return total_ones, 0
+            all_err = torch.cat(errs)
+            kth = max(1, min(n_prune_target, all_err.numel()))
+            threshold = float(torch.kthvalue(all_err, kth).values.item())
+            pruned = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                row_mask = (s.float().pow(2) <= threshold).view(-1, *([1] * (q.ndim - 1)))
+                mask = (q.abs() == 1) & row_mask
+                pruned += int(mask.sum().item())
+                q[mask] = 0
+            return total_ones, pruned
+
+        def _build_quant_blob(q_entries, scale_entries, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac: float):
+            q_map = {k: v.clone() for k, v in q_entries.items()}
+            total_ones, pruned = _prune_low_error_ones(q_map, scale_entries, prune_frac)
+            packed_quantized, byte_quantized = {}, {}
+            stats = {
+                "packed_tensors": 0, "byte_tensors": 0, "packed_bytes": 0, "byte_q_numel": 0,
+                "fp_numel": sum(v.numel() for v in passthrough.values()),
+                "role_numel": {}, "role_packed_bytes": {},
+                "total_ones": total_ones, "pruned": pruned,
+            }
+            for name, q in q_map.items():
+                bits = int(bits_entries[name])
+                role = role_entries[name]
+                stats["role_numel"][role] = stats["role_numel"].get(role, 0) + int(q.numel())
+                if QUANT_PACK_ALL and bits < 8:
+                    packed, shape, n, bits2, qmax = _pack_signed_q(q, bits)
+                    packed_quantized[name] = {"data": packed, "shape": shape, "numel": int(n), "bits": int(bits2), "qmax": int(qmax), "role": role}
+                    stats["packed_tensors"] += 1
+                    stats["packed_bytes"] += int(packed.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(packed.numel())
+                else:
+                    byte_quantized[name] = q.contiguous()
+                    stats["byte_tensors"] += 1
+                    stats["byte_q_numel"] += int(q.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(q.numel())
+            quant_obj = {
+                "format": QUANT_FORMAT,
+                "quantized": byte_quantized,
+                "packed_quantized": packed_quantized,
+                "scales": scale_entries,
+                "row_overrides": overrides,
+                "passthrough": passthrough,
+                "aliases": aliases,
+                "meta": {
+                    "bits": {
+                        "ffn_gate": QUANT_BITS_FFN_GATE,
+                        "ffn_down": QUANT_BITS_FFN_DOWN,
+                        "mamba": QUANT_BITS_MAMBA,
+                        "attention": QUANT_BITS_ATTN,
+                        "embed": QUANT_BITS_EMBED,
+                        "other": QUANT_BITS_MATRIX,
+                    },
+                    "pack_all": QUANT_PACK_ALL,
+                    "scale_floor_mult": QUANT_SCALE_FLOOR_MULT,
+                    "protect_dynamics": QUANT_PROTECT_DYNAMICS,
+                    "optclip_embed": QUANT_OPTCLIP_EMBED,
+                    "prune_ones_frac": prune_frac,
+                },
+            }
+            buf = io.BytesIO()
+            torch.save(quant_obj, buf)
+            raw = buf.getvalue()
+            lzma_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+            blob = lzma.compress(raw, preset=lzma_preset)
+            return quant_obj, raw, blob, stats
+
+        log0("Quantizing model with aggressive role-bit packing + LZMA...")
+        state_dict = base_model.state_dict()
+        q_entries, scales, bits_entries, role_entries, passthrough, aliases, overrides = {}, {}, {}, {}, {}, {}, {}
+        base_stats = {"alias": 0, "passthrough": 0, "quantized": 0, "role_numel": {}}
+
+        tied_lm_weight = (
+            "tok_emb.weight" in state_dict and "lm_head.weight" in state_dict and
+            state_dict["tok_emb.weight"].shape == state_dict["lm_head.weight"].shape
+        )
+
+        for name, t in state_dict.items():
+            if tied_lm_weight and name == "lm_head.weight":
+                aliases[name] = "tok_emb.weight"
+                base_stats["alias"] += 1
+                continue
+            tcpu = t.detach().cpu().contiguous()
+            if (not tcpu.is_floating_point()) or tcpu.numel() <= QUANT_PASSTHROUGH_NUMEL:
+                if tcpu.is_floating_point() and tcpu.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = tcpu.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = tcpu
+                base_stats["passthrough"] += 1
+                continue
+            q, scale, bits, role, override = _quantize_float_tensor(name, tcpu)
+            q_entries[name] = q
+            scales[name] = scale
+            bits_entries[name] = int(bits)
+            role_entries[name] = role
+            if override is not None:
+                overrides[name] = override
+            base_stats["quantized"] += 1
+            base_stats["role_numel"][role] = base_stats["role_numel"].get(role, 0) + int(q.numel())
+
+        candidate_fracs = [QUANT_PRUNE_ONES_FRAC]
+        if QUANT_AUTO_PRUNE_TO_BYTES:
+            candidate_fracs = sorted(set(candidate_fracs + QUANT_AUTO_PRUNE_FRACS))
+        best_tuple = None
+        for frac in candidate_fracs:
+            quant_obj_c, raw_c, blob_c, stats_c = _build_quant_blob(
+                q_entries, scales, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac=float(frac)
+            )
+            log0(
+                f"Quant candidate prune={float(frac):.3f}: compressed={len(blob_c):,} bytes, "
+                f"raw={len(raw_c):,}, packed_bytes={stats_c['packed_bytes']:,}, byte_q={stats_c['byte_q_numel']:,}, "
+                f"ones={stats_c['total_ones']:,}, pruned={stats_c['pruned']:,}"
+            )
+            if best_tuple is None:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+            if len(blob_c) <= QUANT_TARGET_BYTES:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+                break
+            if len(blob_c) < len(best_tuple[2]):
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+
+        quant_obj, quant_raw, quant_blob, q_stats, selected_prune = best_tuple
+        compressed_bytes = len(quant_blob)
+        raw_bytes = len(quant_raw)
+        q_raw_bytes = (
+            q_stats["byte_q_numel"] + q_stats["packed_bytes"] +
+            sum(v.numel() * v.element_size() for v in scales.values()) +
+            sum(v.numel() * v.element_size() for v in passthrough.values()) +
+            sum(ov["q"].numel() * ov["q"].element_size() + ov["scale"].numel() * ov["scale"].element_size() + ov["rows"].numel() * ov["rows"].element_size() for ov in overrides.values())
+        )
+        log0(
+            f"Selected quant prune={selected_prune:.3f}: byte_q_tensors={q_stats['byte_tensors']}, "
+            f"packed_q_tensors={q_stats['packed_tensors']}, passthrough={base_stats['passthrough']}, alias={base_stats['alias']}, "
+            f"packed_bytes={q_stats['packed_bytes']:,}, byte_q_numel={q_stats['byte_q_numel']:,}, "
+            f"approx_payload={q_raw_bytes/1024/1024:.2f} MiB"
+        )
+        log0(f"Role quantized numel: {base_stats['role_numel']}")
+        log0(f"Role packed/byte payload bytes: {q_stats['role_packed_bytes']}")
+        log0(f"Serialized raw torch.save: {raw_bytes:,} bytes ({raw_bytes/1024/1024:.2f} MiB)")
+        log0(f"Compressed model (lzma{QUANT_LZMA_PRESET}{'+extreme' if QUANT_LZMA_EXTREME else ''}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MiB)")
+        if compressed_bytes <= 16_000_000:
+            log0("Artifact size check: UNDER 16,000,000-byte cap before code bytes")
+        else:
+            log0("Artifact size check: OVER 16,000,000-byte cap before code bytes")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate.
+        quant_obj_rt = torch.load(io.BytesIO(lzma.decompress(quant_blob)), map_location="cpu")
+        dequant_state = {}
+        for name, q in quant_obj_rt.get("quantized", {}).items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, pack_obj in quant_obj_rt.get("packed_quantized", {}).items():
+            q = _unpack_signed_q(
+                pack_obj["data"], tuple(pack_obj["shape"]), int(pack_obj["numel"]),
+                int(pack_obj["bits"]), int(pack_obj["qmax"])
+            )
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, ov in quant_obj_rt.get("row_overrides", {}).items():
+            if name in dequant_state:
+                rows = ov["rows"].long()
+                q8 = ov["q"].float()
+                s8 = ov["scale"].float()
+                dequant_state[name][rows] = (q8 * s8.view(-1, *([1] * (q8.ndim - 1)))).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+        for name, src_name in quant_obj_rt.get("aliases", {}).items():
+            dequant_state[name] = dequant_state[src_name]
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        if MASTER_PROCESS:
+            artifact_path = f"final_model.{QUANT_FORMAT}.lzma"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullmuon_final_compress_trustclip.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_fullmuon_final_compress_trustclip.py
@@ -1,0 +1,3215 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+import lzma
+import io
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path.
+# Final compression attempt for the proven Option-A full-Muon baseline:
+#   - Full-FFN clean architecture and optimizer are unchanged.
+#   - FFN gate_up is aggressively packed INT3.
+#   - FFN down is packed INT4.
+#   - Mamba matrices are packed INT4 with Mamba2 dt rows stored as protected INT8 sidecars.
+#   - Attention qkv/out are packed INT5.
+#   - Embeddings/bigram/embed projections are packed INT6 with optional opt-clip.
+#   - Small/control tensors stay fp16.
+#   - Container compression: LZMA-9 extreme.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+QUANT_FORMAT = os.environ.get("QUANT_FORMAT", "fullmuon_aggressive_lzma").lower()
+QUANT_BITS_MATRIX = int(os.environ.get("QUANT_BITS_MATRIX", "5"))
+QUANT_BITS_FFN_GATE = int(os.environ.get("QUANT_BITS_FFN_GATE", "3"))
+QUANT_BITS_FFN_DOWN = int(os.environ.get("QUANT_BITS_FFN_DOWN", "4"))
+QUANT_BITS_MAMBA = int(os.environ.get("QUANT_BITS_MAMBA", "4"))
+QUANT_BITS_ATTN = int(os.environ.get("QUANT_BITS_ATTN", "5"))
+QUANT_BITS_EMBED = int(os.environ.get("QUANT_BITS_EMBED", "6"))
+QUANT_PACK_ALL = os.environ.get("QUANT_PACK_ALL", "1") == "1"
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))
+QUANT_K_FFN_GATE = float(os.environ.get("QUANT_K_FFN_GATE", str(QUANT_K_MATRIX)))
+QUANT_K_FFN_DOWN = float(os.environ.get("QUANT_K_FFN_DOWN", str(QUANT_K_MATRIX)))
+QUANT_K_MAMBA = float(os.environ.get("QUANT_K_MAMBA", str(QUANT_K_MATRIX)))
+QUANT_K_ATTN = float(os.environ.get("QUANT_K_ATTN", str(QUANT_K_MATRIX)))
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))
+QUANT_SCALE_FLOOR_MULT = float(os.environ.get("QUANT_SCALE_FLOOR_MULT", "1.0"))
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"
+QUANT_OPTCLIP_STEPS = int(os.environ.get("QUANT_OPTCLIP_STEPS", "8"))
+QUANT_OPTCLIP_MIN_FRAC = float(os.environ.get("QUANT_OPTCLIP_MIN_FRAC", "0.55"))
+QUANT_OPTCLIP_MAX_FRAC = float(os.environ.get("QUANT_OPTCLIP_MAX_FRAC", "1.00"))
+QUANT_PRUNE_ONES_FRAC = float(os.environ.get("QUANT_PRUNE_ONES_FRAC", "0.0"))
+QUANT_AUTO_PRUNE_TO_BYTES = os.environ.get("QUANT_AUTO_PRUNE_TO_BYTES", "1") == "1"
+QUANT_TARGET_BYTES = int(os.environ.get("QUANT_TARGET_BYTES", "15850000"))
+QUANT_AUTO_PRUNE_FRACS = [float(x) for x in os.environ.get("QUANT_AUTO_PRUNE_FRACS", "0,0.25,0.40,0.55,0.70,0.85").split(",") if x.strip()]
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", "9"))
+QUANT_LZMA_EXTREME = os.environ.get("QUANT_LZMA_EXTREME", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Per-role Muon update trust clipping. This clips the *actual applied step*
+# RMS relative to the parameter RMS, after Newton-Schulz and rectangular
+# scaling. It is meant to keep the proven full-Muon baseline but prevent
+# occasional oversized matrix moves, especially in SSM projections.
+MUON_TRUST_CLIP_ENABLED = os.environ.get("MUON_TRUST_CLIP_ENABLED", "1") == "1"
+MUON_TRUST_FFN = float(os.environ.get("MUON_TRUST_FFN", "0.020"))
+MUON_TRUST_ATTN = float(os.environ.get("MUON_TRUST_ATTN", "0.015"))
+MUON_TRUST_MAMBA_IN = float(os.environ.get("MUON_TRUST_MAMBA_IN", "0.008"))
+MUON_TRUST_MAMBA_OUT = float(os.environ.get("MUON_TRUST_MAMBA_OUT", "0.008"))
+MUON_TRUST_EMBED_PROJ = float(os.environ.get("MUON_TRUST_EMBED_PROJ", "0.010"))
+MUON_TRUST_BIGRAM = float(os.environ.get("MUON_TRUST_BIGRAM", "0.010"))
+MUON_TRUST_GENERIC = float(os.environ.get("MUON_TRUST_GENERIC", "0.010"))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compression_defaults: Option-A full-Muon baseline + aggressive role-bit packed LZMA artifact")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"compression_quant: format={QUANT_FORMAT}, pack_all={QUANT_PACK_ALL}, "
+    f"bits(ffn_gate/down={QUANT_BITS_FFN_GATE}/{QUANT_BITS_FFN_DOWN}, "
+    f"mamba={QUANT_BITS_MAMBA}, attn={QUANT_BITS_ATTN}, embed={QUANT_BITS_EMBED}, other={QUANT_BITS_MATRIX}), "
+    f"passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, "
+    f"k(ffn_gate/down={QUANT_K_FFN_GATE}/{QUANT_K_FFN_DOWN}, mamba={QUANT_K_MAMBA}, "
+    f"attn={QUANT_K_ATTN}, embed={QUANT_K_EMBED}, other={QUANT_K_MATRIX}), "
+    f"scale_floor_mult={QUANT_SCALE_FLOOR_MULT}, protect_dynamics={QUANT_PROTECT_DYNAMICS}, "
+    f"optclip_embed={QUANT_OPTCLIP_EMBED}, prune_ones_frac={QUANT_PRUNE_ONES_FRAC}, "
+    f"auto_prune={QUANT_AUTO_PRUNE_TO_BYTES}, target_bytes={QUANT_TARGET_BYTES}, "
+    f"lzma_preset={QUANT_LZMA_PRESET}, extreme={QUANT_LZMA_EXTREME}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"muon_trust_clip: enabled={MUON_TRUST_CLIP_ENABLED}, "
+    f"ffn={MUON_TRUST_FFN}, attn={MUON_TRUST_ATTN}, "
+    f"mamba_in/out={MUON_TRUST_MAMBA_IN}/{MUON_TRUST_MAMBA_OUT}, "
+    f"embed_proj={MUON_TRUST_EMBED_PROJ}, bigram={MUON_TRUST_BIGRAM}, generic={MUON_TRUST_GENERIC}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+
+    Optional per-role trust clipping clips the *actual applied step* RMS:
+        rms(lr * update) <= trust_ratio * rms(weight)
+    This preserves Muon's direction while limiting destabilizing matrix jumps.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0,
+                 trust_clip_enabled: bool = False):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr,
+                 role="generic", trust_ratio=0.0,
+                 trust_clip_enabled=trust_clip_enabled),
+        )
+
+    @staticmethod
+    def _apply_trust_clip(update: torch.Tensor, weight: torch.Tensor, lr: float, trust_ratio: float) -> torch.Tensor:
+        if trust_ratio <= 0.0 or lr <= 0.0:
+            return update
+        # Clip the applied delta, not the pre-lr update. This is invariant to
+        # schedule multiplier and role LR.
+        upd_rms = update.float().pow(2).mean().sqrt()
+        if not torch.isfinite(upd_rms) or upd_rms <= 0:
+            return update
+        w_rms = weight.float().pow(2).mean().sqrt().clamp_min(1e-8)
+        max_update_rms = (trust_ratio * w_rms) / max(float(lr), 1e-12)
+        scale = torch.clamp(max_update_rms / upd_rms.clamp_min(1e-12), max=1.0)
+        return update * scale.to(dtype=update.dtype)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            trust_enabled = bool(group.get("trust_clip_enabled", False))
+            trust_ratio = float(group.get("trust_ratio", 0.0)) if trust_enabled else 0.0
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                if trust_ratio > 0.0:
+                    upd = self._apply_trust_clip(upd, p, lr, trust_ratio)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def muon_role_for_name(name: str) -> str:
+    if ".mamba.in_proj.weight" in name:
+        return "mamba_in"
+    if ".mamba.out_proj.weight" in name:
+        return "mamba_out"
+    if ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+        return "ffn"
+    if ".qkv.weight" in name or (".out_proj.weight" in name and ".mamba." not in name):
+        return "attn"
+    if "bigram." in name:
+        return "bigram"
+    if "embed_proj" in name:
+        return "embed_proj"
+    return "generic"
+
+
+def muon_trust_ratio_for_role(role: str) -> float:
+    return {
+        "ffn": MUON_TRUST_FFN,
+        "attn": MUON_TRUST_ATTN,
+        "mamba_in": MUON_TRUST_MAMBA_IN,
+        "mamba_out": MUON_TRUST_MAMBA_OUT,
+        "embed_proj": MUON_TRUST_EMBED_PROJ,
+        "bigram": MUON_TRUST_BIGRAM,
+        "generic": MUON_TRUST_GENERIC,
+    }.get(role, MUON_TRUST_GENERIC)
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    role_to_params = {"ffn": [], "attn": [], "mamba_in": [], "mamba_out": [], "embed_proj": [], "bigram": [], "generic": []}
+    role_counts = {k: 0 for k in role_to_params}
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                role = muon_role_for_name(name)
+                role_to_params.setdefault(role, []).append(p)
+                role_counts[role] = role_counts.get(role, 0) + 1
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    muon_groups = []
+    for role, params in role_to_params.items():
+        if not params:
+            continue
+        muon_groups.append({
+            "params": params,
+            "lr": MATRIX_LR,
+            "base_lr": MATRIX_LR,
+            "momentum": MUON_MOMENTUM,
+            "backend_steps": MUON_BACKEND_STEPS,
+            "nesterov": MUON_NESTEROV,
+            "weight_decay": WEIGHT_DECAY,
+            "role": role,
+            "trust_ratio": muon_trust_ratio_for_role(role),
+            "trust_clip_enabled": MUON_TRUST_CLIP_ENABLED,
+        })
+
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+        trust_clip_enabled=MUON_TRUST_CLIP_ENABLED,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon/{len(muon_groups)} role groups), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}, "
+        f"trust_clip={MUON_TRUST_CLIP_ENABLED}"
+    )
+    log0("Muon roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items()) if v))
+    if MUON_TRUST_CLIP_ENABLED:
+        log0("Muon trust ratios: " + ", ".join(
+            f"{g['role']}={g['trust_ratio']}" for g in muon_groups
+        ))
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Aggressive role-bit packed + LZMA compression path.
+        # -----------------------------------------------------------------------
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        if QUANT_FORMAT not in ("fullmuon_aggressive_lzma", "hybrid_aggressive_lzma"):
+            raise RuntimeError(
+                f"Unsupported QUANT_FORMAT={QUANT_FORMAT}; use fullmuon_aggressive_lzma"
+            )
+
+        def _is_embedding_like(n: str) -> bool:
+            return (
+                n == "tok_emb.weight" or n == "lm_head.weight" or
+                n.startswith("bigram.embed") or n.startswith("bigram.proj") or
+                "embed" in n
+            )
+
+        def _is_ffn_gate(n: str) -> bool:
+            return ".ffn.gate_up.weight" in n
+
+        def _is_ffn_down(n: str) -> bool:
+            return ".ffn.down.weight" in n
+
+        def _is_attn_weight(n: str) -> bool:
+            return (".qkv.weight" in n) or (".out_proj.weight" in n and ".mamba." not in n)
+
+        def _is_mamba_weight(n: str) -> bool:
+            return ".mamba." in n
+
+        def _qmax_for_bits(bits: int) -> int:
+            if bits < 2 or bits > 8:
+                raise ValueError(f"bits must be in [2,8], got {bits}")
+            return (1 << (bits - 1)) - 1
+
+        def _role_bits_k(name: str):
+            if _is_ffn_gate(name):
+                return QUANT_BITS_FFN_GATE, QUANT_K_FFN_GATE, "ffn_gate"
+            if _is_ffn_down(name):
+                return QUANT_BITS_FFN_DOWN, QUANT_K_FFN_DOWN, "ffn_down"
+            if _is_mamba_weight(name):
+                return QUANT_BITS_MAMBA, QUANT_K_MAMBA, "mamba"
+            if _is_attn_weight(name):
+                return QUANT_BITS_ATTN, QUANT_K_ATTN, "attention"
+            if _is_embedding_like(name):
+                return QUANT_BITS_EMBED, QUANT_K_EMBED, "embedding"
+            return QUANT_BITS_MATRIX, QUANT_K_MATRIX, "other_matrix"
+
+        def _pack_signed_q(q: torch.Tensor, bits: int):
+            """Pack signed symmetric q values [-qmax, qmax] into b bytes per 8 values."""
+            qmax = _qmax_for_bits(bits)
+            shape = tuple(q.shape)
+            flat = (q.to(torch.int16).reshape(-1).cpu() + qmax).clamp(0, (1 << bits) - 1).to(torch.uint8)
+            n = int(flat.numel())
+            if bits == 8:
+                return flat.contiguous(), shape, n, bits, qmax
+            pad = (-n) % 8
+            if pad:
+                flat = torch.cat([flat, torch.zeros(pad, dtype=torch.uint8)])
+            x = flat.view(-1, 8).to(torch.int64)
+            word = torch.zeros(x.shape[0], dtype=torch.int64)
+            for i in range(8):
+                word |= (x[:, i] << (bits * i))
+            out = torch.empty((x.shape[0], bits), dtype=torch.uint8)
+            for j in range(bits):
+                out[:, j] = ((word >> (8 * j)) & 0xFF).to(torch.uint8)
+            return out.contiguous().view(-1), shape, n, bits, qmax
+
+        def _unpack_signed_q(packed: torch.Tensor, shape, n: int, bits: int, qmax: int):
+            if bits == 8:
+                flat = packed.cpu().contiguous().view(-1)[:n].to(torch.int16)
+                return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+            b = packed.cpu().contiguous().view(-1, bits).to(torch.int64)
+            word = torch.zeros(b.shape[0], dtype=torch.int64)
+            for j in range(bits):
+                word |= (b[:, j] << (8 * j))
+            vals = []
+            mask = (1 << bits) - 1
+            for i in range(8):
+                vals.append(((word >> (bits * i)) & mask).to(torch.int16))
+            flat = torch.stack(vals, dim=1).reshape(-1)[:n]
+            return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+
+        def _mamba_dt_rows(name: str, rows: int):
+            if not (QUANT_PROTECT_DYNAMICS and name.endswith("mamba.in_proj.weight")):
+                return None
+            n_dt = max(1, (2 * D_MODEL) // max(1, HEADDIM))
+            n_dt = min(n_dt, rows)
+            return torch.arange(rows - n_dt, rows, dtype=torch.long)
+
+        def _quantize_rows(t32: torch.Tensor, bits: int, k: float, optclip: bool = False):
+            qmax = float(_qmax_for_bits(bits))
+            if t32.ndim == 2:
+                rows = t32.shape[0]
+                max_abs = t32.abs().amax(dim=1).clamp_min(1e-8)
+                std_abs = t32.float().std(dim=1).clamp_min(1e-8)
+                base_clip = torch.minimum(max_abs, std_abs * float(k)).clamp_min(1e-8)
+                if optclip and QUANT_OPTCLIP_STEPS > 1:
+                    best_err = torch.full((rows,), float("inf"), dtype=torch.float32)
+                    best_q = None
+                    best_scale = None
+                    fracs = torch.linspace(
+                        float(QUANT_OPTCLIP_MIN_FRAC),
+                        float(QUANT_OPTCLIP_MAX_FRAC),
+                        steps=int(QUANT_OPTCLIP_STEPS),
+                        dtype=torch.float32,
+                    )
+                    for frac in fracs:
+                        clip_abs = (base_clip * float(frac)).clamp_min(1e-8)
+                        scale_f = (clip_abs / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax)
+                        q_try = torch.round(torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None]) / scale_f[:, None]).clamp(-qmax, qmax)
+                        err = (q_try * scale_f[:, None] - t32).pow(2).mean(dim=1)
+                        mask = err < best_err
+                        if best_q is None:
+                            best_q = q_try.to(torch.int8)
+                            best_scale = scale_f
+                            best_err = err
+                        else:
+                            best_q[mask] = q_try[mask].to(torch.int8)
+                            best_scale[mask] = scale_f[mask]
+                            best_err[mask] = err[mask]
+                    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+                scale = (base_clip / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax).to(torch.float16).contiguous()
+                q = torch.round(torch.clamp(t32, -base_clip[:, None], base_clip[:, None]) / scale.float()[:, None]).clamp(-qmax, qmax).to(torch.int8).contiguous()
+                return q, scale
+            else:
+                max_abs = float(t32.abs().max().item()) if t32.numel() else 0.0
+                std_abs = float(t32.float().std().item()) if t32.numel() else 0.0
+                clip_abs = max(1e-8, min(max_abs, std_abs * float(k)) if std_abs > 0 else max_abs)
+                qmaxf = qmax
+                scale = max(clip_abs / qmaxf, float(QUANT_SCALE_FLOOR_MULT) / qmaxf)
+                q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale).clamp(-qmaxf, qmaxf).to(torch.int8).contiguous()
+                return q, torch.tensor(scale, dtype=torch.float16)
+
+        def _quantize_float_tensor(name: str, t: torch.Tensor):
+            t32 = t.float().cpu().contiguous()
+            bits, k, role = _role_bits_k(name)
+            q, scale = _quantize_rows(t32, bits, k, optclip=(_is_embedding_like(name) and QUANT_OPTCLIP_EMBED and t32.ndim == 2))
+            override = None
+            rows_to_override = _mamba_dt_rows(name, t32.shape[0] if t32.ndim == 2 else 0)
+            if rows_to_override is not None and rows_to_override.numel() > 0:
+                q8, s8 = _quantize_rows(t32[rows_to_override], 8, QUANT_K_MAMBA, optclip=False)
+                override = {
+                    "rows": rows_to_override.to(torch.int32),
+                    "q": q8.contiguous(),
+                    "scale": s8.contiguous(),
+                    "bits": 8,
+                    "qmax": 127,
+                }
+            return q, scale, bits, role, override
+
+        def _prune_low_error_ones(q_map, scale_map, prune_frac: float):
+            if prune_frac <= 0:
+                return 0, 0
+            errs = []
+            total_ones = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                counts = (q.abs() == 1).sum(dim=1).cpu()
+                if int(counts.sum().item()) == 0:
+                    continue
+                row_err = s.float().pow(2).cpu()
+                errs.append(torch.repeat_interleave(row_err, counts))
+                total_ones += int(counts.sum().item())
+            if total_ones == 0 or not errs:
+                return 0, 0
+            n_prune_target = int(max(0, min(total_ones, round(total_ones * float(prune_frac)))))
+            if n_prune_target <= 0:
+                return total_ones, 0
+            all_err = torch.cat(errs)
+            kth = max(1, min(n_prune_target, all_err.numel()))
+            threshold = float(torch.kthvalue(all_err, kth).values.item())
+            pruned = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                row_mask = (s.float().pow(2) <= threshold).view(-1, *([1] * (q.ndim - 1)))
+                mask = (q.abs() == 1) & row_mask
+                pruned += int(mask.sum().item())
+                q[mask] = 0
+            return total_ones, pruned
+
+        def _build_quant_blob(q_entries, scale_entries, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac: float):
+            q_map = {k: v.clone() for k, v in q_entries.items()}
+            total_ones, pruned = _prune_low_error_ones(q_map, scale_entries, prune_frac)
+            packed_quantized, byte_quantized = {}, {}
+            stats = {
+                "packed_tensors": 0, "byte_tensors": 0, "packed_bytes": 0, "byte_q_numel": 0,
+                "fp_numel": sum(v.numel() for v in passthrough.values()),
+                "role_numel": {}, "role_packed_bytes": {},
+                "total_ones": total_ones, "pruned": pruned,
+            }
+            for name, q in q_map.items():
+                bits = int(bits_entries[name])
+                role = role_entries[name]
+                stats["role_numel"][role] = stats["role_numel"].get(role, 0) + int(q.numel())
+                if QUANT_PACK_ALL and bits < 8:
+                    packed, shape, n, bits2, qmax = _pack_signed_q(q, bits)
+                    packed_quantized[name] = {"data": packed, "shape": shape, "numel": int(n), "bits": int(bits2), "qmax": int(qmax), "role": role}
+                    stats["packed_tensors"] += 1
+                    stats["packed_bytes"] += int(packed.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(packed.numel())
+                else:
+                    byte_quantized[name] = q.contiguous()
+                    stats["byte_tensors"] += 1
+                    stats["byte_q_numel"] += int(q.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(q.numel())
+            quant_obj = {
+                "format": QUANT_FORMAT,
+                "quantized": byte_quantized,
+                "packed_quantized": packed_quantized,
+                "scales": scale_entries,
+                "row_overrides": overrides,
+                "passthrough": passthrough,
+                "aliases": aliases,
+                "meta": {
+                    "bits": {
+                        "ffn_gate": QUANT_BITS_FFN_GATE,
+                        "ffn_down": QUANT_BITS_FFN_DOWN,
+                        "mamba": QUANT_BITS_MAMBA,
+                        "attention": QUANT_BITS_ATTN,
+                        "embed": QUANT_BITS_EMBED,
+                        "other": QUANT_BITS_MATRIX,
+                    },
+                    "pack_all": QUANT_PACK_ALL,
+                    "scale_floor_mult": QUANT_SCALE_FLOOR_MULT,
+                    "protect_dynamics": QUANT_PROTECT_DYNAMICS,
+                    "optclip_embed": QUANT_OPTCLIP_EMBED,
+                    "prune_ones_frac": prune_frac,
+                },
+            }
+            buf = io.BytesIO()
+            torch.save(quant_obj, buf)
+            raw = buf.getvalue()
+            lzma_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+            blob = lzma.compress(raw, preset=lzma_preset)
+            return quant_obj, raw, blob, stats
+
+        log0("Quantizing model with aggressive role-bit packing + LZMA...")
+        state_dict = base_model.state_dict()
+        q_entries, scales, bits_entries, role_entries, passthrough, aliases, overrides = {}, {}, {}, {}, {}, {}, {}
+        base_stats = {"alias": 0, "passthrough": 0, "quantized": 0, "role_numel": {}}
+
+        tied_lm_weight = (
+            "tok_emb.weight" in state_dict and "lm_head.weight" in state_dict and
+            state_dict["tok_emb.weight"].shape == state_dict["lm_head.weight"].shape
+        )
+
+        for name, t in state_dict.items():
+            if tied_lm_weight and name == "lm_head.weight":
+                aliases[name] = "tok_emb.weight"
+                base_stats["alias"] += 1
+                continue
+            tcpu = t.detach().cpu().contiguous()
+            if (not tcpu.is_floating_point()) or tcpu.numel() <= QUANT_PASSTHROUGH_NUMEL:
+                if tcpu.is_floating_point() and tcpu.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = tcpu.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = tcpu
+                base_stats["passthrough"] += 1
+                continue
+            q, scale, bits, role, override = _quantize_float_tensor(name, tcpu)
+            q_entries[name] = q
+            scales[name] = scale
+            bits_entries[name] = int(bits)
+            role_entries[name] = role
+            if override is not None:
+                overrides[name] = override
+            base_stats["quantized"] += 1
+            base_stats["role_numel"][role] = base_stats["role_numel"].get(role, 0) + int(q.numel())
+
+        candidate_fracs = [QUANT_PRUNE_ONES_FRAC]
+        if QUANT_AUTO_PRUNE_TO_BYTES:
+            candidate_fracs = sorted(set(candidate_fracs + QUANT_AUTO_PRUNE_FRACS))
+        best_tuple = None
+        for frac in candidate_fracs:
+            quant_obj_c, raw_c, blob_c, stats_c = _build_quant_blob(
+                q_entries, scales, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac=float(frac)
+            )
+            log0(
+                f"Quant candidate prune={float(frac):.3f}: compressed={len(blob_c):,} bytes, "
+                f"raw={len(raw_c):,}, packed_bytes={stats_c['packed_bytes']:,}, byte_q={stats_c['byte_q_numel']:,}, "
+                f"ones={stats_c['total_ones']:,}, pruned={stats_c['pruned']:,}"
+            )
+            if best_tuple is None:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+            if len(blob_c) <= QUANT_TARGET_BYTES:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+                break
+            if len(blob_c) < len(best_tuple[2]):
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+
+        quant_obj, quant_raw, quant_blob, q_stats, selected_prune = best_tuple
+        compressed_bytes = len(quant_blob)
+        raw_bytes = len(quant_raw)
+        q_raw_bytes = (
+            q_stats["byte_q_numel"] + q_stats["packed_bytes"] +
+            sum(v.numel() * v.element_size() for v in scales.values()) +
+            sum(v.numel() * v.element_size() for v in passthrough.values()) +
+            sum(ov["q"].numel() * ov["q"].element_size() + ov["scale"].numel() * ov["scale"].element_size() + ov["rows"].numel() * ov["rows"].element_size() for ov in overrides.values())
+        )
+        log0(
+            f"Selected quant prune={selected_prune:.3f}: byte_q_tensors={q_stats['byte_tensors']}, "
+            f"packed_q_tensors={q_stats['packed_tensors']}, passthrough={base_stats['passthrough']}, alias={base_stats['alias']}, "
+            f"packed_bytes={q_stats['packed_bytes']:,}, byte_q_numel={q_stats['byte_q_numel']:,}, "
+            f"approx_payload={q_raw_bytes/1024/1024:.2f} MiB"
+        )
+        log0(f"Role quantized numel: {base_stats['role_numel']}")
+        log0(f"Role packed/byte payload bytes: {q_stats['role_packed_bytes']}")
+        log0(f"Serialized raw torch.save: {raw_bytes:,} bytes ({raw_bytes/1024/1024:.2f} MiB)")
+        log0(f"Compressed model (lzma{QUANT_LZMA_PRESET}{'+extreme' if QUANT_LZMA_EXTREME else ''}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MiB)")
+        if compressed_bytes <= 16_000_000:
+            log0("Artifact size check: UNDER 16,000,000-byte cap before code bytes")
+        else:
+            log0("Artifact size check: OVER 16,000,000-byte cap before code bytes")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate.
+        quant_obj_rt = torch.load(io.BytesIO(lzma.decompress(quant_blob)), map_location="cpu")
+        dequant_state = {}
+        for name, q in quant_obj_rt.get("quantized", {}).items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, pack_obj in quant_obj_rt.get("packed_quantized", {}).items():
+            q = _unpack_signed_q(
+                pack_obj["data"], tuple(pack_obj["shape"]), int(pack_obj["numel"]),
+                int(pack_obj["bits"]), int(pack_obj["qmax"])
+            )
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, ov in quant_obj_rt.get("row_overrides", {}).items():
+            if name in dequant_state:
+                rows = ov["rows"].long()
+                q8 = ov["q"].float()
+                s8 = ov["scale"].float()
+                dequant_state[name][rows] = (q8 * s8.view(-1, *([1] * (q8.ndim - 1)))).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+        for name, src_name in quant_obj_rt.get("aliases", {}).items():
+            dequant_state[name] = dequant_state[src_name]
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        if MASTER_PROCESS:
+            artifact_path = f"final_model.{QUANT_FORMAT}.lzma"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_gc_muon.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_gc_muon.py
@@ -1,0 +1,2449 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Gradient-centered Muon ablation.
+# Centers matrix gradients before momentum + Newton-Schulz.
+# Modes:
+#   row    => subtract row mean
+#   col    => subtract column mean
+#   rowcol => subtract row mean then column mean
+GC_MUON = os.environ.get("GC_MUON", "1") == "1"
+GC_MUON_MODE = os.environ.get("GC_MUON_MODE", "rowcol").lower()
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}, "
+    f"gc_muon={GC_MUON}, gc_mode={GC_MUON_MODE}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+
+def center_muon_gradient(g: torch.Tensor) -> torch.Tensor:
+    """Gradient centering for matrix-shaped Muon params."""
+    if not GC_MUON or g.ndim < 2:
+        return g
+
+    orig_shape = g.shape
+    x = g.reshape(g.shape[0], -1) if g.ndim > 2 else g
+
+    if GC_MUON_MODE in ("row", "rowcol", "both"):
+        x = x - x.mean(dim=1, keepdim=True)
+    if GC_MUON_MODE in ("col", "rowcol", "both"):
+        x = x - x.mean(dim=0, keepdim=True)
+
+    return x.reshape(orig_shape) if g.ndim > 2 else x
+
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = center_muon_gradient(p.grad)
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_h3_compare.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_h3_compare.py
@@ -1,0 +1,2434 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# H3-style associative comparison SSM config.
+# Selected blocks become cheap H3-inspired SSM compare blocks:
+# q = current token query; write = shifted_key * value; memory = SSM(write);
+# output = silu(q) * memory.
+H3_COMPARE_ENABLED = os.environ.get("H3_COMPARE_ENABLED", "0") == "1"
+H3_COMPARE_IDXS = [int(x) for x in os.environ.get("H3_COMPARE_IDXS", "5").split(",") if x.strip()]
+H3_DIM = int(os.environ.get("H3_DIM", "384"))
+H3_SCALE_INIT = float(os.environ.get("H3_SCALE_INIT", "0.25"))
+H3_SHIFT_K = os.environ.get("H3_SHIFT_K", "1") == "1"
+H3_ZERO_OUT = os.environ.get("H3_ZERO_OUT", "0") == "1"
+H3_USE_VALUE_GATE = os.environ.get("H3_USE_VALUE_GATE", "1") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+    "h3_scale",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(
+    f"h3_compare: enabled={H3_COMPARE_ENABLED}, idxs={H3_COMPARE_IDXS}, "
+    f"h3_dim={H3_DIM}, scale_init={H3_SCALE_INIT}, shift_k={H3_SHIFT_K}, "
+    f"value_gate={H3_USE_VALUE_GATE}, zero_out={H3_ZERO_OUT}"
+)
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class H3CompareBlock(nn.Module):
+    """
+    H3-inspired associative comparison block.
+
+    This is not attention. It explicitly writes a key/value-like stream into an
+    SSM and lets the current query multiplicatively read/compare against the
+    resulting causal memory stream.
+
+        q_t = query(x_t)
+        k_t = key(x_t)
+        v_t = value(x_t)
+        write_t = k_{t-1} * v_t  # causal shifted key by default
+        mem_t = SSM(write_<=t)
+        y_t = silu(q_t) * mem_t
+    """
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.h3_dim = H3_DIM
+        self.shift_k = H3_SHIFT_K
+        self.use_value_gate = H3_USE_VALUE_GATE
+
+        self.in_norm = RMSNorm(d_model)
+        self.qkv_proj = nn.Linear(d_model, 3 * self.h3_dim, bias=False)
+
+        if self.use_value_gate:
+            self.value_gate = nn.Linear(d_model, self.h3_dim, bias=False)
+        else:
+            self.value_gate = None
+
+        self.kv_norm = RMSNorm(self.h3_dim)
+        self.kv_ssm = Mamba2(
+            d_model=self.h3_dim,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+
+        self.out_norm = RMSNorm(self.h3_dim)
+        self.out_proj = nn.Linear(self.h3_dim, d_model, bias=False)
+        if H3_ZERO_OUT:
+            nn.init.zeros_(self.out_proj.weight)
+
+        # Starts modestly. This lets the model use H3 without destroying the
+        # backbone early in training.
+        self.h3_scale = nn.Parameter(torch.full((d_model,), H3_SCALE_INIT))
+
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        h = self.in_norm(x)
+        q, k, v = self.qkv_proj(h).chunk(3, dim=-1)
+
+        # Previous-token key creates a causal association: "what key was active
+        # before this value?"
+        if self.shift_k:
+            k = F.pad(k[:, :-1, :], (0, 0, 1, 0), value=0.0)
+
+        if self.value_gate is not None:
+            v = v * torch.sigmoid(self.value_gate(h))
+
+        write = k * v
+        memory_stream = self.kv_ssm(self.kv_norm(write))
+        if isinstance(memory_stream, tuple):
+            memory_stream = memory_stream[0]
+
+        y = F.silu(q) * memory_stream
+        y = self.out_proj(self.out_norm(y))
+
+        x = x + self.h3_scale[None, None, :] * y
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem
+
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention + optional H3 comparison blocks.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        h3_set = set(H3_COMPARE_IDXS) if H3_COMPARE_ENABLED else set()
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in h3_set:
+                layers.append(H3CompareBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+            elif i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name or "kv_ssm" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_headsplit_warm22.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_headsplit_warm22.py
@@ -1,0 +1,2446 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.22"))  # test: earlier warmdown/head split
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+
+# Separate optimizer group for untied output head.
+HEAD_LR = float(os.environ.get("HEAD_LR", "0.045"))
+HEAD_WD = float(os.environ.get("HEAD_WD", "0.02"))
+EMBED_WD = float(os.environ.get("EMBED_WD", str(0.095)))
+HEAD_INCLUDE_REV_PROJ = os.environ.get("HEAD_INCLUDE_REV_PROJ", "1") == "1"
+
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(
+    f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, "
+    f"head_lr={HEAD_LR}, wd={WEIGHT_DECAY}, embed_wd={EMBED_WD}, head_wd={HEAD_WD}, "
+    f"head_include_rev_proj={HEAD_INCLUDE_REV_PROJ}, grad_clip={GRAD_CLIP}"
+)
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params, head_params = [], [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue
+        _seen_data_ptrs.add(dp)
+
+        if name == "tok_emb.weight":
+            embed_params.append(p)
+            continue
+
+        if name.startswith("lm_head.") or (HEAD_INCLUDE_REV_PROJ and name.startswith("embed_proj_rev.")):
+            head_params.append(p)
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+            mat_params.append(p)
+        else:
+            scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    adam_groups = [
+        {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+        {"params": embed_params, "lr": EMBED_LR, "weight_decay": EMBED_WD, "base_lr": EMBED_LR},
+    ]
+    if head_params:
+        adam_groups.append({"params": head_params, "lr": HEAD_LR, "weight_decay": HEAD_WD, "base_lr": HEAD_LR})
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), "
+        f"embed={len(embed_params)} lr={EMBED_LR} wd={EMBED_WD}, "
+        f"head={len(head_params)} lr={HEAD_LR} wd={HEAD_WD}"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_hybrid_heads_all.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_hybrid_heads_all.py
@@ -1,0 +1,2463 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Hybrid-head config: every selected block contains BOTH an SSM branch and
+# an attention branch over the same representation, then learns a gated merge.
+# This script defaults to all 10 blocks as hybrid heads. Set HYBRID_HEAD_IDXS
+# to a comma list to ablate subsets, or HYBRID_HEADS_ENABLED=0 to recover base.
+HYBRID_HEADS_ENABLED = os.environ.get("HYBRID_HEADS_ENABLED", "1") == "1"
+_DEFAULT_HYBRID_HEAD_IDXS = ",".join(str(i) for i in range(N_UNIQUE_BLOCKS))
+HYBRID_HEAD_IDXS = [int(x) for x in os.environ.get("HYBRID_HEAD_IDXS", _DEFAULT_HYBRID_HEAD_IDXS).split(",") if x.strip()]
+HYBRID_HEAD_SSM_DIM = int(os.environ.get("HYBRID_HEAD_SSM_DIM", "384"))
+HYBRID_HEAD_ATTN_DIM = int(os.environ.get("HYBRID_HEAD_ATTN_DIM", "128"))
+HYBRID_HEAD_ATTN_N_HEADS = int(os.environ.get("HYBRID_HEAD_ATTN_N_HEADS", "4"))
+HYBRID_HEAD_MERGE_BIAS = float(os.environ.get("HYBRID_HEAD_MERGE_BIAS", "-1.0"))
+HYBRID_HEAD_ZERO_ATTN_OUT = os.environ.get("HYBRID_HEAD_ZERO_ATTN_OUT", "1") == "1"
+HYBRID_HEAD_ZERO_SSM_OUT = os.environ.get("HYBRID_HEAD_ZERO_SSM_OUT", "0") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"hybrid_heads: enabled={HYBRID_HEADS_ENABLED}, idxs={HYBRID_HEAD_IDXS}, ssm_dim={HYBRID_HEAD_SSM_DIM}, attn_dim={HYBRID_HEAD_ATTN_DIM}, heads={HYBRID_HEAD_ATTN_N_HEADS}, merge_bias={HYBRID_HEAD_MERGE_BIAS}, zero_attn_out={HYBRID_HEAD_ZERO_ATTN_OUT}, zero_ssm_out={HYBRID_HEAD_ZERO_SSM_OUT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class HybridSSMAttentionBlock(nn.Module):
+    """
+    Hybrid-head mixer: SSM and attention operate in parallel inside the same block.
+
+    The branch split is lower-compute than full attention in every layer:
+      - SSM branch: d_model -> HYBRID_HEAD_SSM_DIM -> Mamba2 -> d_model
+      - Attention branch: d_model -> HYBRID_HEAD_ATTN_DIM -> causal attention -> d_model
+      - Learned merge gate chooses per-channel SSM vs attention contribution
+      - One shared FFN after the merge
+
+    This is meant to test the 'attention heads for exact recall, SSM heads for
+    compressed state' hypothesis without alternating whole SSM/attention layers.
+    """
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        if HYBRID_HEAD_SSM_DIM <= 0 or HYBRID_HEAD_ATTN_DIM <= 0:
+            raise ValueError("HYBRID_HEAD_SSM_DIM and HYBRID_HEAD_ATTN_DIM must be > 0")
+        if HYBRID_HEAD_ATTN_DIM % HYBRID_HEAD_ATTN_N_HEADS != 0:
+            raise ValueError(
+                f"HYBRID_HEAD_ATTN_DIM={HYBRID_HEAD_ATTN_DIM} must be divisible by "
+                f"HYBRID_HEAD_ATTN_N_HEADS={HYBRID_HEAD_ATTN_N_HEADS}"
+            )
+
+        self.n_heads = HYBRID_HEAD_ATTN_N_HEADS
+        self.head_dim = HYBRID_HEAD_ATTN_DIM // HYBRID_HEAD_ATTN_N_HEADS
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # SSM branch: compressed/fading state over most channels.
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_in = nn.Linear(d_model, HYBRID_HEAD_SSM_DIM, bias=False)
+        self.mamba = Mamba2(
+            d_model=HYBRID_HEAD_SSM_DIM,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_out = nn.Linear(HYBRID_HEAD_SSM_DIM, d_model, bias=False)
+        if HYBRID_HEAD_ZERO_SSM_OUT:
+            nn.init.zeros_(self.ssm_out.weight)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+
+        # Attention branch: exact recall/key-value lookup over a narrower subspace.
+        self.attn_norm = RMSNorm(d_model)
+        self.attn_in = nn.Linear(d_model, HYBRID_HEAD_ATTN_DIM, bias=False)
+        self.qkv = nn.Linear(HYBRID_HEAD_ATTN_DIM, 3 * HYBRID_HEAD_ATTN_DIM, bias=False)
+        self.attn_out = nn.Linear(HYBRID_HEAD_ATTN_DIM, d_model, bias=False)
+        if HYBRID_HEAD_ZERO_ATTN_OUT:
+            nn.init.zeros_(self.attn_out.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+
+        # Per-channel merge. Negative bias starts SSM-dominant; attention can earn its way in.
+        self.merge_gate = nn.Linear(d_model, d_model, bias=True)
+        nn.init.zeros_(self.merge_gate.weight)
+        nn.init.constant_(self.merge_gate.bias, HYBRID_HEAD_MERGE_BIAS)
+
+        # Shared FFN after merged mixer.
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            ssm_base = x + mem_mix * mem_ctx
+        else:
+            ssm_base = x
+
+        # SSM branch.
+        s = self.ssm_in(self.ssm_norm(ssm_base))
+        s = self.mamba(s)
+        if isinstance(s, tuple):
+            s = s[0]
+        s = self.ssm_out(s)
+
+        # Attention branch.
+        a = self.attn_in(self.attn_norm(x))
+        B, T, D = a.shape
+        qkv = self.qkv(a).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        a = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        a = a.transpose(1, 2).reshape(B, T, D)
+        a = self.attn_out(a)
+
+        # Gated merge: gate close to 0 favors SSM, close to 1 favors attention.
+        gate = torch.sigmoid(self.merge_gate(x)).to(x.dtype)
+        s = self.ssm_scale[None, None, :].to(s.dtype) * s
+        a = self.attn_scale[None, None, :].to(a.dtype) * a
+        x = x + (1.0 - gate) * s + gate * a
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers. Selected hybrid-head blocks contain BOTH an SSM branch
+        # and an attention branch in the same layer. This script defaults to all
+        # blocks hybridized via HYBRID_HEAD_IDXS=0..N-1.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        hybrid_head_set = set(HYBRID_HEAD_IDXS) if HYBRID_HEADS_ENABLED else set()
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in hybrid_head_set:
+                layers.append(HybridSSMAttentionBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+            elif i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_hybrid_sidecar.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_hybrid_sidecar.py
@@ -1,0 +1,2484 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+# Standard ATTN_LAYER_IDXS replaces an SSM block with a full attention block.
+# Hybrid sidecar keeps the SSM block and adds a narrow attention branch in parallel.
+HYBRID_SIDECAR_ENABLED = os.environ.get("HYBRID_SIDECAR_ENABLED", "1") == "1"
+ATTN_LAYER_DEFAULT = "" if HYBRID_SIDECAR_ENABLED else "5"
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", ATTN_LAYER_DEFAULT).split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Hybrid sidecar attention config. Use HYBRID_SIDECAR_IDXS=5 by default for the current best midpoint.
+HYBRID_SIDECAR_IDXS = [int(x) for x in os.environ.get("HYBRID_SIDECAR_IDXS", "5").split(",") if x.strip()] if HYBRID_SIDECAR_ENABLED else []
+HYBRID_ATTN_DIM = int(os.environ.get("HYBRID_ATTN_DIM", "128"))
+HYBRID_ATTN_N_HEADS = int(os.environ.get("HYBRID_ATTN_N_HEADS", "4"))
+HYBRID_ATTN_GATE_WIDTH = int(os.environ.get("HYBRID_ATTN_GATE_WIDTH", "128"))
+HYBRID_ATTN_GATE_INIT = float(os.environ.get("HYBRID_ATTN_GATE_INIT", "-2.0"))
+HYBRID_ATTN_RAMP_START_FRAC = float(os.environ.get("HYBRID_ATTN_RAMP_START_FRAC", "0.20"))
+HYBRID_ATTN_RAMP_END_FRAC = float(os.environ.get("HYBRID_ATTN_RAMP_END_FRAC", "0.60"))
+HYBRID_ATTN_ZERO_INIT = os.environ.get("HYBRID_ATTN_ZERO_INIT", "1") == "1"
+if HYBRID_ATTN_DIM % max(HYBRID_ATTN_N_HEADS, 1) != 0:
+    raise ValueError(f"HYBRID_ATTN_DIM={HYBRID_ATTN_DIM} must be divisible by HYBRID_ATTN_N_HEADS={HYBRID_ATTN_N_HEADS}")
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(
+    f"hybrid_sidecar: enabled={HYBRID_SIDECAR_ENABLED}, idxs={HYBRID_SIDECAR_IDXS}, "
+    f"attn_dim={HYBRID_ATTN_DIM}, heads={HYBRID_ATTN_N_HEADS}, gate_width={HYBRID_ATTN_GATE_WIDTH}, "
+    f"gate_init={HYBRID_ATTN_GATE_INIT}, ramp={HYBRID_ATTN_RAMP_START_FRAC}->{HYBRID_ATTN_RAMP_END_FRAC}, "
+    f"zero_init={HYBRID_ATTN_ZERO_INIT}"
+)
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+class HybridSSMAttnBlock(nn.Module):
+    """
+    Parallel SSM + narrow attention sidecar block.
+
+    The Mamba branch stays as the main sequence compressor, while a small
+    attention branch provides exact local recall. A learned gate and a
+    training-time ramp keep the attention sidecar from dominating early.
+    """
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 attn_dim=128, n_heads=4, gate_width=128, gate_init=-2.0,
+                 zero_init=True):
+        super().__init__()
+        if attn_dim % n_heads != 0:
+            raise ValueError(f"attn_dim={attn_dim} must be divisible by n_heads={n_heads}")
+
+        # Main SSM branch: same capacity as a normal SelectiveSSMBlock.
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+
+        # Narrow attention sidecar: cheap exact recall branch.
+        self.attn_dim = attn_dim
+        self.n_heads = n_heads
+        self.head_dim = attn_dim // n_heads
+        self.gate_width = min(gate_width, d_model)
+        self.attn_norm = RMSNorm(d_model)
+        self.side_in_proj = nn.Linear(d_model, attn_dim, bias=False)
+        self.side_qkv = nn.Linear(attn_dim, 3 * attn_dim, bias=False)
+        self.side_out_proj = nn.Linear(attn_dim, d_model, bias=False)
+        self.side_gate = nn.Linear(self.gate_width, d_model, bias=True)
+        self.side_q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+        self.side_attn_scale = nn.Parameter(torch.ones(d_model))
+        self.register_buffer("attn_ramp", torch.tensor(0.0), persistent=False)
+
+        # Start transparent: sidecar cannot perturb the known-good SSM path at step 0.
+        if zero_init:
+            nn.init.zeros_(self.side_out_proj.weight)
+        nn.init.zeros_(self.side_gate.weight)
+        nn.init.constant_(self.side_gate.bias, gate_init)
+
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+
+        # SSM compression branch.
+        y_ssm = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y_ssm
+
+        # Attention recall sidecar. It sees the pre-SSM mixed representation so it
+        # acts as a parallel helper, not a second sequential layer.
+        B, T, _ = x_in.shape
+        normed = self.attn_norm(x_in)
+        a = self.side_in_proj(normed)
+        qkv = self.side_qkv(a).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.side_q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.attn_dim)
+        attn_out = self.side_out_proj(attn_out)
+
+        gate = torch.sigmoid(self.side_gate(normed[..., :self.gate_width]))
+        ramp = self.attn_ramp.to(dtype=x.dtype, device=x.device)
+        x = x + ramp * self.side_attn_scale[None, None, :] * gate * attn_out
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + optional full attention replacement + hybrid sidecar blocks.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        hybrid_set = set(HYBRID_SIDECAR_IDXS)
+        overlap = attn_set & hybrid_set
+        if overlap:
+            raise ValueError(f"Layer(s) {sorted(overlap)} cannot be both full attention and hybrid sidecar")
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in hybrid_set:
+                layers.append(HybridSSMAttnBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT,
+                    attn_dim=HYBRID_ATTN_DIM,
+                    n_heads=HYBRID_ATTN_N_HEADS,
+                    gate_width=HYBRID_ATTN_GATE_WIDTH,
+                    gate_init=HYBRID_ATTN_GATE_INIT,
+                    zero_init=HYBRID_ATTN_ZERO_INIT,
+                ))
+            elif i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    @torch.no_grad()
+    def set_hybrid_attn_ramp(self, ramp: float):
+        """Update sidecar attention ramp buffers outside the compiled forward."""
+        r = float(max(0.0, min(1.0, ramp)))
+        for block in self.blocks:
+            if hasattr(block, "attn_ramp"):
+                block.attn_ramp.fill_(r)
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+
+        # Hybrid sidecar ramp: train SSM backbone first, then gradually let the
+        # attention sidecar contribute. This avoids attention dominating early.
+        if HYBRID_SIDECAR_ENABLED and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            denom = max(HYBRID_ATTN_RAMP_END_FRAC - HYBRID_ATTN_RAMP_START_FRAC, 1e-8)
+            side_ramp = max(0.0, min(1.0, (frac - HYBRID_ATTN_RAMP_START_FRAC) / denom))
+            base_model.set_hybrid_attn_ramp(side_ramp)
+
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Use full sidecar strength for evaluation.
+    if HYBRID_SIDECAR_ENABLED:
+        base_model.set_hybrid_attn_ramp(1.0)
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_mamba3_tieddense.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_mamba3_tieddense.py
@@ -1,0 +1,3057 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Mamba3 kernel setup. This variant intentionally avoids the Mamba2 direct
+# chunk-scan path and uses the Mamba3 SISO Triton kernel directly.
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+try:
+    from mamba_ssm.modules.mamba3 import Mamba3  # noqa: F401
+    from mamba_ssm.ops.triton.mamba3.mamba3_siso_combined import mamba3_siso_combined  # noqa: F401
+    _HAS_MAMBA3 = True
+except Exception as e:
+    _HAS_MAMBA3 = False
+    raise RuntimeError(
+        "Mamba3 kernels are unavailable. Install the matching stack from the "
+        "provided requirements file: torch>=2.9.1, triton>=3.5.0, "
+        "mamba-ssm>=2.3.1, sentencepiece, einops, numpy."
+    ) from e
+
+# Compatibility flag used by the existing carryover eval gate. For Mamba3 this
+# means the direct Mamba3 stateful kernel is available, not Mamba2 chunk_scan.
+_HAS_CHUNK_SCAN = _HAS_MAMBA3
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: J-Mamba3 SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Mamba3 knobs. Mamba3 has internal RoPE/angle dynamics; this file keeps
+# external transformer attention RoPE as well, matching our J baseline.
+MAMBA3_D_STATE = int(os.environ.get("MAMBA3_D_STATE", os.environ.get("D_STATE", "64")))
+MAMBA3_EXPAND = float(os.environ.get("MAMBA3_EXPAND", "2"))
+MAMBA3_HEADDIM = int(os.environ.get("MAMBA3_HEADDIM", os.environ.get("HEADDIM", "64")))
+MAMBA3_CHUNK_SIZE = int(os.environ.get("MAMBA3_CHUNK_SIZE", "64"))
+MAMBA3_NGROUPS = int(os.environ.get("MAMBA3_NGROUPS", "1"))
+MAMBA3_ROPE_FRACTION = float(os.environ.get("MAMBA3_ROPE_FRACTION", "0.5"))
+# Kept for legacy logs/env compatibility.
+HEADDIM = MAMBA3_HEADDIM
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary flag kept for compatibility. Mamba3 currently ignores seq_idx
+# in this wrapper; carryover eval is disabled by default for this experiment.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba3: d_state={MAMBA3_D_STATE}, expand={MAMBA3_EXPAND}, headdim={MAMBA3_HEADDIM}, chunk_size={MAMBA3_CHUNK_SIZE}, ngroups={MAMBA3_NGROUPS}, rope_fraction={MAMBA3_ROPE_FRACTION}")
+log0(f"seq_idx: compatibility flag={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN}; Mamba3 wrapper ignores seq_idx")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: J-Mamba3 tied-dense hybrid: 10L, ATTN_LAYER_IDXS=6, shared SSM FFN, shared attn correction at 2/5, bigram on, EMBED_DIM=512, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class CastedLinear(nn.Linear):
+    """Linear that casts fp32 master weights to activation dtype on forward."""
+    def forward(self, x):
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+@torch._dynamo.disable
+def _mamba3_ssd_kernel(Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, D, Z,
+                       chunk_size, Input_States=None, return_final_states=False):
+    from mamba_ssm.ops.triton.mamba3.mamba3_siso_combined import mamba3_siso_combined
+    return mamba3_siso_combined(
+        Q=Q, K=K, V=V, ADT=ADT, DT=DT, Trap=Trap,
+        Q_bias=Q_bias, K_bias=K_bias, Angles=Angles, D=D, Z=Z,
+        chunk_size=chunk_size, Input_States=Input_States,
+        return_final_states=return_final_states,
+    )
+
+
+class Mamba3Layer(nn.Module):
+    """Mamba3 SISO wrapper using the fused Triton kernel directly."""
+    def __init__(self, dim, d_state=64, expand=2.0, headdim=64,
+                 chunk_size=64, ngroups=1, rope_fraction=0.5):
+        super().__init__()
+        from mamba_ssm.modules.mamba3 import Mamba3
+        self.mamba3 = Mamba3(
+            d_model=dim, d_state=d_state, expand=expand, headdim=headdim,
+            is_mimo=False, chunk_size=chunk_size, ngroups=ngroups,
+            rope_fraction=rope_fraction, is_outproj_norm=False,
+        )
+        for attr in ("in_proj", "out_proj"):
+            src = getattr(self.mamba3, attr)
+            dst = CastedLinear(src.in_features, src.out_features, bias=src.bias is not None)
+            dst.weight = src.weight
+            if src.bias is not None:
+                dst.bias = src.bias
+            setattr(self.mamba3, attr, dst)
+
+    def _pre_ssd(self, x):
+        m = self.mamba3
+        zxBCdtAtrap = m.in_proj(x)
+        z, xv, B, C, dd_dt, dd_A, trap, angles = torch.split(
+            zxBCdtAtrap,
+            [m.d_inner, m.d_inner,
+             m.d_state * m.num_bc_heads * m.mimo_rank,
+             m.d_state * m.num_bc_heads * m.mimo_rank,
+             m.nheads, m.nheads, m.nheads, m.num_rope_angles],
+            dim=-1,
+        )
+        z = rearrange(z, "b l (h p) -> b l h p", p=m.headdim)
+        xv = rearrange(xv, "b l (h p) -> b l h p", p=m.headdim)
+        B = rearrange(B, "b l (r g n) -> b l r g n", r=m.mimo_rank, g=m.num_bc_heads)
+        C = rearrange(C, "b l (r g n) -> b l r g n", r=m.mimo_rank, g=m.num_bc_heads)
+        trap = rearrange(trap, "b l h -> b h l")
+        A = -F.softplus(dd_A.to(torch.float32))
+        A = torch.clamp(A, max=-m.A_floor)
+        DT = F.softplus(dd_dt + m.dt_bias)
+        ADT = A * DT
+        DT = rearrange(DT, "b l n -> b n l")
+        ADT = rearrange(ADT, "b l n -> b n l")
+        angles = angles.unsqueeze(-2).expand(-1, -1, m.nheads, -1)
+        B = m.B_norm(B).squeeze(2)
+        C = m.C_norm(C).squeeze(2)
+        return z, xv, B, C, ADT, DT, trap, angles
+
+    def _post_ssd(self, y):
+        m = self.mamba3
+        y = rearrange(y, "b l h p -> b l (h p)")
+        return m.out_proj(y)
+
+    def forward(self, x):
+        m = self.mamba3
+        z, xv, B, C, ADT, DT, trap, angles = self._pre_ssd(x)
+        y = _mamba3_ssd_kernel(
+            Q=C, K=B, V=xv, ADT=ADT, DT=DT, Trap=trap,
+            Q_bias=m.C_bias.squeeze(1), K_bias=m.B_bias.squeeze(1),
+            Angles=angles, D=m.D, Z=z, chunk_size=m.chunk_size,
+        )
+        return self._post_ssd(y)
+
+    def forward_stateful(self, x, input_states=None):
+        m = self.mamba3
+        z, xv, B, C, ADT, DT, trap, angles = self._pre_ssd(x)
+        result = _mamba3_ssd_kernel(
+            Q=C, K=B, V=xv, ADT=ADT, DT=DT, Trap=trap,
+            Q_bias=m.C_bias.squeeze(1), K_bias=m.B_bias.squeeze(1),
+            Angles=angles, D=m.D, Z=z, chunk_size=m.chunk_size,
+            Input_States=input_states, return_final_states=True,
+        )
+        y, last_angle, last_state, last_k, last_v, *_ = result
+        return self._post_ssd(y), (last_angle, last_state, last_k, last_v)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba3Layer(
+            d_model, d_state=MAMBA3_D_STATE, expand=MAMBA3_EXPAND,
+            headdim=MAMBA3_HEADDIM, chunk_size=MAMBA3_CHUNK_SIZE,
+            ngroups=MAMBA3_NGROUPS, rope_fraction=MAMBA3_ROPE_FRACTION,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        # inference_params / seq_idx accepted for compatibility; this Mamba3
+        # wrapper ignores seq_idx.
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input=None, seq_idx=None):
+        """Thread Mamba3 recurrent state across eval blocks. No conv state."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state = self.mamba.forward_stateful(self.ssm_norm(x_in), input_states=initial_ssm_state)
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, None
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba3 recurrent state across calls
+        via the direct Mamba3 SISO kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_MAMBA3 or rearrange is None:
+            raise RuntimeError("Mamba3 stateful carryover requested but Mamba3/einops is unavailable.")
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba3 recurrent state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_MAMBA3 and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but Mamba3/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense.py
@@ -1,0 +1,3053 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: J tied-dense SSM hybrid: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_attncorr384.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_attncorr384.py
@@ -1,0 +1,3054 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Default is 384d/8h as the first J ablation:
+# cheaper than the 512d J baseline while preserving a stronger recall sidecar
+# than the previous 256d variant.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", "384"))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: J-384 tied-dense SSM hybrid: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, SHARED_ATTN_CORR_DIM=384, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_bf16storage.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_bf16storage.py
@@ -1,0 +1,3166 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Selective BF16 parameter storage. Compute already uses AMP BF16; this
+# optionally stores projection-heavy non-recurrent weights in BF16 too.
+# Mamba recurrent parameters stay FP32 by default for scan/state stability.
+BF16_STORAGE_ENABLED = os.environ.get("BF16_STORAGE_ENABLED", "1") == "1"
+BF16_STORAGE_CAST_BIGRAM = os.environ.get("BF16_STORAGE_CAST_BIGRAM", "1") == "1"
+BF16_STORAGE_CAST_EMBED_PROJ = os.environ.get("BF16_STORAGE_CAST_EMBED_PROJ", "1") == "1"
+BF16_STORAGE_CAST_ATTN = os.environ.get("BF16_STORAGE_CAST_ATTN", "1") == "1"
+BF16_STORAGE_CAST_FFN = os.environ.get("BF16_STORAGE_CAST_FFN", "1") == "1"
+BF16_STORAGE_CAST_MAMBA_PROJ = os.environ.get("BF16_STORAGE_CAST_MAMBA_PROJ", "0") == "1"  # second-stage test only; default keeps all mamba.* FP32
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(
+    f"bf16_storage: enabled={BF16_STORAGE_ENABLED}, attn={BF16_STORAGE_CAST_ATTN}, "
+    f"ffn={BF16_STORAGE_CAST_FFN}, embed_proj={BF16_STORAGE_CAST_EMBED_PROJ}, "
+    f"bigram={BF16_STORAGE_CAST_BIGRAM}, mamba_proj={BF16_STORAGE_CAST_MAMBA_PROJ}"
+)
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: J tied-dense SSM hybrid + selective BF16 storage: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def _should_cast_bf16_storage(name: str) -> bool:
+    """
+    Select projection-heavy non-recurrent weights for BF16 parameter storage.
+    Keep all Mamba dynamics/recurrent internals FP32 by default. Also keep the
+    tied token embedding / lm_head FP32 for this first test.
+    """
+    if not BF16_STORAGE_ENABLED:
+        return False
+
+    # The first test keeps all mamba.* FP32. A second-stage experiment can
+    # selectively allow Mamba input/output projections while still protecting
+    # A_log/D/dt_bias by setting BF16_STORAGE_CAST_MAMBA_PROJ=1.
+    if ".mamba." in name or name.startswith("mamba."):
+        if not BF16_STORAGE_CAST_MAMBA_PROJ:
+            return False
+        return name.endswith("mamba.in_proj.weight") or name.endswith("mamba.out_proj.weight")
+
+    # Keep token embedding / tied LM head FP32 initially.
+    if name in ("tok_emb.weight", "lm_head.weight", "lm_head.bias"):
+        return False
+
+    if BF16_STORAGE_CAST_EMBED_PROJ and (
+        name.endswith("embed_proj.weight") or name.endswith("embed_proj_rev.weight")
+    ):
+        return True
+
+    if BF16_STORAGE_CAST_BIGRAM and (
+        name.startswith("bigram.embed.") or name.startswith("bigram.proj.")
+    ):
+        return True
+
+    if BF16_STORAGE_CAST_ATTN and (
+        name.endswith("qkv.weight") or name.endswith("out_proj.weight")
+    ):
+        # This catches normal attention and shared attention correction.
+        return True
+
+    if BF16_STORAGE_CAST_FFN and (
+        name.endswith("ffn.gate_up.weight")
+        or name.endswith("ffn.down.weight")
+        or name.startswith("shared_ssm_ffn.gate_up")
+        or name.startswith("shared_ssm_ffn.down")
+    ):
+        return True
+
+    return False
+
+
+def cast_projection_params_to_bf16_storage(model, dtype):
+    """
+    Store selected large non-recurrent projection weights in BF16 to reduce HBM
+    bandwidth and autocast weight-conversion overhead. This intentionally does
+    not cast Mamba recurrent/dynamics params, tok_emb/lm_head, or small control
+    tensors. Returns (n_tensors, n_params, details).
+    """
+    if dtype != torch.bfloat16 or not BF16_STORAGE_ENABLED:
+        return 0, 0, []
+
+    cast_count = 0
+    param_count = 0
+    details = []
+    for name, p in model.named_parameters():
+        if _should_cast_bf16_storage(name) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+            param_count += p.numel()
+            details.append((name, tuple(p.shape), p.numel()))
+    return cast_count, param_count, details
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies.
+    # Then optionally store selected large non-recurrent projection weights in BF16.
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} small/control parameters to {AMP_DTYPE}")
+    n_storage_cast, n_storage_params, storage_details = cast_projection_params_to_bf16_storage(base_model, AMP_DTYPE)
+    log0(f"BF16 storage cast: {n_storage_cast} tensors, {n_storage_params:,} params")
+    if MASTER_PROCESS and storage_details:
+        role_counts = {}
+        for name, shape, numel in storage_details:
+            if ".mamba." in name or name.startswith("mamba."):
+                role = "mamba_proj"
+            elif name.startswith("shared_attn_correction"):
+                role = "shared_attn_corr"
+            elif name.startswith("shared_ssm_ffn"):
+                role = "shared_ssm_ffn"
+            elif ".ffn." in name:
+                role = "local_ffn"
+            elif name.endswith("qkv.weight") or name.endswith("out_proj.weight"):
+                role = "attention"
+            elif name.startswith("bigram"):
+                role = "bigram"
+            elif name.startswith("embed_proj"):
+                role = "embed_proj"
+            else:
+                role = "other"
+            role_counts[role] = role_counts.get(role, 0) + numel
+        log0("BF16 storage cast roles: " + ", ".join(f"{k}={v:,}" for k, v in sorted(role_counts.items())))
+        for name, shape, numel in storage_details[:32]:
+            log0(f"  bf16_storage: {name} shape={shape} params={numel:,}")
+        if len(storage_details) > 32:
+            log0(f"  ... {len(storage_details) - 32} more bf16-storage tensors")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_len_curriculum.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_len_curriculum.py
@@ -1,0 +1,3135 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# Real train-length curriculum. Eval/validation remains at SEQ_LEN=8192,
+# but the training data loader can emit shorter rows early while preserving
+# the same TOK_PER_RANK token budget. This gives more examples/updates at
+# cheaper attention cost, then switches to full 8192 context for the finish.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+# PyTorch SDPA should choose FlashAttention-style kernels on H100 for bf16
+# causal attention when the shapes are eligible. Keep math fallback enabled for
+# safety; the attention block uses F.scaled_dot_product_attention.
+torch.backends.cuda.enable_flash_sdp(True)
+torch.backends.cuda.enable_mem_efficient_sdp(True)
+torch.backends.cuda.enable_math_sdp(True)
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, "
+    f"final_seq={SEQ_LEN}"
+)
+log0("variant_defaults: J tied-dense SSM hybrid + real length curriculum support: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+if LENGTH_CURRICULUM_ENABLED:
+    if CURRICULUM_SHORT_SEQ_LEN <= 0:
+        raise ValueError(f"CURRICULUM_SHORT_SEQ_LEN must be positive, got {CURRICULUM_SHORT_SEQ_LEN}")
+    if CURRICULUM_SHORT_SEQ_LEN > SEQ_LEN:
+        raise ValueError(f"CURRICULUM_SHORT_SEQ_LEN ({CURRICULUM_SHORT_SEQ_LEN}) must be <= SEQ_LEN ({SEQ_LEN})")
+    if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+        raise ValueError(
+            f"CURRICULUM_SHORT_SEQ_LEN ({CURRICULUM_SHORT_SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})"
+        )
+    if LOCAL_BATCH_TOK % CURRICULUM_SHORT_SEQ_LEN != 0:
+        log0(
+            f"Warning: local_batch_tok={LOCAL_BATCH_TOK} is not divisible by short_seq={CURRICULUM_SHORT_SEQ_LEN}; "
+            "the loader will round local tokens down for short-seq batches."
+        )
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def set_seq_len(self, seq_len: int):
+        """Switch training row length for curriculum batches.
+
+        The async worker prefetches batches with the old shape, so we stop it,
+        drain stale batches, update seq_len, and restart the worker. The token
+        stream position is preserved except for any one in-flight batch that the
+        old worker may already have consumed.
+        """
+        seq_len = int(seq_len)
+        if seq_len == self.seq_len:
+            return
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.seq_len = seq_len
+        self.stop_event = threading.Event()
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def set_seq_len(self, seq_len: int):
+        self.seq_len = int(seq_len)
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    initial_train_seq_len = CURRICULUM_SHORT_SEQ_LEN if LENGTH_CURRICULUM_ENABLED else SEQ_LEN
+    log0(f"Train loader initial seq_len={initial_train_seq_len} (eval/final seq_len={SEQ_LEN})")
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=initial_train_seq_len,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=initial_train_seq_len,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _current_train_seq_len = int(initial_train_seq_len)
+    _curriculum_switched = (not LENGTH_CURRICULUM_ENABLED) or (_current_train_seq_len == SEQ_LEN)
+    _curriculum_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Real length curriculum: all ranks switch training row length on the
+        # same step. Only rank 0 decides from wallclock; the flag is broadcast
+        # to prevent DDP shape desynchronization. Eval remains at SEQ_LEN.
+        if LENGTH_CURRICULUM_ENABLED and not _curriculum_switched and step % _STOP_CHECK_EVERY == 0:
+            if MASTER_PROCESS:
+                frac = elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9) if MAX_WALLCLOCK_SECONDS > 0 else 1.0
+                _curriculum_flag.fill_(1.0 if frac >= CURRICULUM_SWITCH_FRAC else 0.0)
+            dist.broadcast(_curriculum_flag, src=0)
+            if _curriculum_flag.item() > 0.5:
+                loader.set_seq_len(SEQ_LEN)
+                _current_train_seq_len = SEQ_LEN
+                _curriculum_switched = True
+                log0(f"LENGTH_CURRICULUM: switched train seq_len to {SEQ_LEN} at step {step} ({elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9) * 100:.0f}% wall)")
+
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+            cur_seq_len = int(x.shape[1])
+            if cur_seq_len % STREAM_CHUNKS != 0:
+                raise RuntimeError(f"current train seq_len {cur_seq_len} is not divisible by STREAM_CHUNKS={STREAM_CHUNKS}")
+            cur_chunk_len = cur_seq_len // STREAM_CHUNKS
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :cur_chunk_len]
+                        ys = y[:, :cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * cur_chunk_len : (c + 1) * cur_chunk_len]
+                        ys = y[:, c * cur_chunk_len : (c + 1) * cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"train_seq_len:{_current_train_seq_len} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_len_curriculum_flexgpu.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_len_curriculum_flexgpu.py
@@ -1,0 +1,3145 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# Real train-length curriculum. Eval/validation remains at SEQ_LEN=8192,
+# but the training data loader can emit shorter rows early while preserving
+# the same TOK_PER_RANK token budget. This gives more examples/updates at
+# cheaper attention cost, then switches to full 8192 context for the finish.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (flexible torchrun GPU count)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=6 ssm_recall_sota_sp8192_j_tieddense_len_curriculum_flexgpu.py"
+    )
+
+# By default allow any torchrun WORLD_SIZE. Set EXPECTED_WORLD_SIZE=N to
+# enforce a specific GPU count for debugging. This lets us run 6xH100 while
+# using MAX_WALLCLOCK_SECONDS=800 to match 8xH100 * 600s GPU-seconds.
+EXPECTED_WORLD_SIZE = int(os.environ.get("EXPECTED_WORLD_SIZE", "0"))
+if EXPECTED_WORLD_SIZE > 0 and WORLD_SIZE != EXPECTED_WORLD_SIZE:
+    raise RuntimeError(
+        f"Expected WORLD_SIZE={EXPECTED_WORLD_SIZE}, got WORLD_SIZE={WORLD_SIZE}. "
+        "Unset EXPECTED_WORLD_SIZE to allow flexible GPU counts."
+    )
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+# PyTorch SDPA should choose FlashAttention-style kernels on H100 for bf16
+# causal attention when the shapes are eligible. Keep math fallback enabled for
+# safety; the attention block uses F.scaled_dot_product_attention.
+torch.backends.cuda.enable_flash_sdp(True)
+torch.backends.cuda.enable_mem_efficient_sdp(True)
+torch.backends.cuda.enable_math_sdp(True)
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        require_h100 = os.environ.get("REQUIRE_H100", "1") == "1" and os.environ.get("ALLOW_NON_H100", "0") != "1"
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if require_h100 and bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}. Set ALLOW_NON_H100=1 to bypass this check.")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Distributed world_size={WORLD_SIZE}, local_rank={LOCAL_RANK}, expected_world_size={EXPECTED_WORLD_SIZE if EXPECTED_WORLD_SIZE > 0 else 'flex'}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, "
+    f"final_seq={SEQ_LEN}"
+)
+log0("variant_defaults: J tied-dense SSM hybrid + real length curriculum support: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+if LENGTH_CURRICULUM_ENABLED:
+    if CURRICULUM_SHORT_SEQ_LEN <= 0:
+        raise ValueError(f"CURRICULUM_SHORT_SEQ_LEN must be positive, got {CURRICULUM_SHORT_SEQ_LEN}")
+    if CURRICULUM_SHORT_SEQ_LEN > SEQ_LEN:
+        raise ValueError(f"CURRICULUM_SHORT_SEQ_LEN ({CURRICULUM_SHORT_SEQ_LEN}) must be <= SEQ_LEN ({SEQ_LEN})")
+    if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+        raise ValueError(
+            f"CURRICULUM_SHORT_SEQ_LEN ({CURRICULUM_SHORT_SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})"
+        )
+    if LOCAL_BATCH_TOK % CURRICULUM_SHORT_SEQ_LEN != 0:
+        log0(
+            f"Warning: local_batch_tok={LOCAL_BATCH_TOK} is not divisible by short_seq={CURRICULUM_SHORT_SEQ_LEN}; "
+            "the loader will round local tokens down for short-seq batches."
+        )
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def set_seq_len(self, seq_len: int):
+        """Switch training row length for curriculum batches.
+
+        The async worker prefetches batches with the old shape, so we stop it,
+        drain stale batches, update seq_len, and restart the worker. The token
+        stream position is preserved except for any one in-flight batch that the
+        old worker may already have consumed.
+        """
+        seq_len = int(seq_len)
+        if seq_len == self.seq_len:
+            return
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.seq_len = seq_len
+        self.stop_event = threading.Event()
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def set_seq_len(self, seq_len: int):
+        self.seq_len = int(seq_len)
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    initial_train_seq_len = CURRICULUM_SHORT_SEQ_LEN if LENGTH_CURRICULUM_ENABLED else SEQ_LEN
+    log0(f"Train loader initial seq_len={initial_train_seq_len} (eval/final seq_len={SEQ_LEN})")
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=initial_train_seq_len,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=initial_train_seq_len,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _current_train_seq_len = int(initial_train_seq_len)
+    _curriculum_switched = (not LENGTH_CURRICULUM_ENABLED) or (_current_train_seq_len == SEQ_LEN)
+    _curriculum_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Real length curriculum: all ranks switch training row length on the
+        # same step. Only rank 0 decides from wallclock; the flag is broadcast
+        # to prevent DDP shape desynchronization. Eval remains at SEQ_LEN.
+        if LENGTH_CURRICULUM_ENABLED and not _curriculum_switched and step % _STOP_CHECK_EVERY == 0:
+            if MASTER_PROCESS:
+                frac = elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9) if MAX_WALLCLOCK_SECONDS > 0 else 1.0
+                _curriculum_flag.fill_(1.0 if frac >= CURRICULUM_SWITCH_FRAC else 0.0)
+            dist.broadcast(_curriculum_flag, src=0)
+            if _curriculum_flag.item() > 0.5:
+                loader.set_seq_len(SEQ_LEN)
+                _current_train_seq_len = SEQ_LEN
+                _curriculum_switched = True
+                log0(f"LENGTH_CURRICULUM: switched train seq_len to {SEQ_LEN} at step {step} ({elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9) * 100:.0f}% wall)")
+
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+            cur_seq_len = int(x.shape[1])
+            if cur_seq_len % STREAM_CHUNKS != 0:
+                raise RuntimeError(f"current train seq_len {cur_seq_len} is not divisible by STREAM_CHUNKS={STREAM_CHUNKS}")
+            cur_chunk_len = cur_seq_len // STREAM_CHUNKS
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :cur_chunk_len]
+                        ys = y[:, :cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * cur_chunk_len : (c + 1) * cur_chunk_len]
+                        ys = y[:, c * cur_chunk_len : (c + 1) * cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"train_seq_len:{_current_train_seq_len} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_optclean.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_j_tieddense_optclean.py
@@ -1,0 +1,3106 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# J variant: tied-dense-capacity SSM hybrid.
+# Keep only local FFNs on attention layer(s) + optional final adapter, but run
+# one shared SSM FFN after every SSM block. This restores dense nonlinear
+# compute without paying for 9 independent SSM FFNs.
+SHARED_SSM_FFN_ENABLED = os.environ.get("SHARED_SSM_FFN_ENABLED", "1") == "1"
+SHARED_SSM_FFN_LAYERS_RAW = os.environ.get("SHARED_SSM_FFN_LAYERS", "all_ssm")
+SHARED_SSM_FFN_GATE_INIT = float(os.environ.get("SHARED_SSM_FFN_GATE_INIT", "0.0"))
+FINAL_FFN_ADAPTER_ENABLED = os.environ.get("FINAL_FFN_ADAPTER_ENABLED", "1") == "1"
+
+# Legacy final-FFN reuse is off by default for J. The shared SSM FFN below is
+# the main no-param capacity path; set this on only for diagnosis.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "0") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "")
+
+# Shared full-width attention correction: one attention sidecar reused after
+# SSM layers 2 and 5. Unlike the previous small 256d sidecar, this is full
+# 512d/8h attention so it can do real recall, but weights are shared.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", str(D_MODEL)))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", str(ATTN_N_HEADS)))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.0"))
+
+# Optional SSM state-carry training. Disabled by default because it is a bigger
+# training distribution change. When enabled, after STATE_CARRY_TRAIN_START_FRAC
+# of wallclock progress, the model processes each 8192 row as smaller chunks
+# with detached Mamba state between chunks.
+STATE_CARRY_TRAIN_ENABLED = os.environ.get("STATE_CARRY_TRAIN_ENABLED", "0") == "1"
+STATE_CARRY_TRAIN_START_FRAC = float(os.environ.get("STATE_CARRY_TRAIN_START_FRAC", "0.40"))
+STATE_CARRY_TRAIN_CHUNKS = int(os.environ.get("STATE_CARRY_TRAIN_CHUNKS", "4"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+# Optimizer hygiene: keep Muon for large dense matrices only. Small / table-like
+# matrices are often slower and less stable under Newton-Schulz than AdamW.
+MUON_MIN_DIM = int(os.environ.get("MUON_MIN_DIM", "0"))
+MUON_MIN_NUMEL = int(os.environ.get("MUON_MIN_NUMEL", "0"))
+BIGRAM_OPT = os.environ.get("BIGRAM_OPT", "muon").lower()  # "muon" or "adamw"
+SMALL_MATRIX_LR = float(os.environ.get("SMALL_MATRIX_LR", str(MATRIX_LR)))
+SMALL_MATRIX_WD = float(os.environ.get("SMALL_MATRIX_WD", str(WEIGHT_DECAY)))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: J tied-dense SSM hybrid: 10L, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, no TTT/quant")
+log0(f"shared_ssm_ffn: enabled={SHARED_SSM_FFN_ENABLED}, layers={SHARED_SSM_FFN_LAYERS_RAW}, gate_init={SHARED_SSM_FFN_GATE_INIT}, final_adapter={FINAL_FFN_ADAPTER_ENABLED}")
+log0(f"legacy_shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"state_carry_train: enabled={STATE_CARRY_TRAIN_ENABLED}, start_frac={STATE_CARRY_TRAIN_START_FRAC}, chunks={STATE_CARRY_TRAIN_CHUNKS}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"optimizer_hygiene: muon_min_dim={MUON_MIN_DIM}, muon_min_numel={MUON_MIN_NUMEL}, "
+    f"bigram_opt={BIGRAM_OPT}, small_matrix_lr={SMALL_MATRIX_LR}, small_matrix_wd={SMALL_MATRIX_WD}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Shared full-width causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        if not FINAL_FFN_ADAPTER_ENABLED:
+            ffn_active_set.discard(N_UNIQUE_BLOCKS - 1)
+        # Attention blocks keep their own FFN. SSM blocks generally do not
+        # have independent FFNs; they use the shared SSM FFN below. The final
+        # SSM block may keep its local FFN as a final-layer adapter.
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        self.ssm_layer_idxs = [i for i, blk in enumerate(self.blocks) if getattr(blk, "_is_ssm", False)]
+        log0(f"Local FFNs instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"SSM layers using shared SSM FFN candidate set: {self.ssm_layer_idxs}")
+
+        if SHARED_SSM_FFN_LAYERS_RAW.strip().lower() in ("all", "all_ssm", "ssm", "*"):
+            self.shared_ssm_ffn_layers = set(self.ssm_layer_idxs)
+        else:
+            self.shared_ssm_ffn_layers = set(_parse_int_list_env("SHARED_SSM_FFN_LAYERS", SHARED_SSM_FFN_LAYERS_RAW))
+            self.shared_ssm_ffn_layers = {i for i in self.shared_ssm_ffn_layers if i in self.ssm_layer_idxs}
+
+        if SHARED_SSM_FFN_ENABLED:
+            self.shared_ssm_ffn = SwiGLU_FFN(D_MODEL, FFN_MULT)
+            self.shared_ssm_ffn_norms = nn.ModuleDict({str(i): RMSNorm(D_MODEL) for i in sorted(self.shared_ssm_ffn_layers)})
+            self.shared_ssm_ffn_scales = nn.ParameterDict({
+                str(i): nn.Parameter(torch.full((D_MODEL,), float(torch.sigmoid(torch.tensor(SHARED_SSM_FFN_GATE_INIT)).item())))
+                for i in sorted(self.shared_ssm_ffn_layers)
+            })
+        else:
+            self.shared_ssm_ffn = None
+            self.shared_ssm_ffn_norms = nn.ModuleDict()
+            self.shared_ssm_ffn_scales = nn.ParameterDict()
+        log0(f"Shared SSM FFN active layers: {sorted(self.shared_ssm_ffn_layers) if SHARED_SSM_FFN_ENABLED else []}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared SSM FFN. For layers
+        # 2/5 this gives: SSM -> full-width attention correction -> shared FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if (
+            self.shared_ssm_ffn is not None
+            and block_idx in self.shared_ssm_ffn_layers
+            and getattr(self.blocks[block_idx], "_is_ssm", False)
+        ):
+            key = str(block_idx)
+            scale = self.shared_ssm_ffn_scales[key].to(dtype=x.dtype, device=x.device)
+            normed = self.shared_ssm_ffn_norms[key](x)
+            x = x + scale[None, None, :] * self.shared_ssm_ffn(normed)
+
+        # Legacy/debug path: reapply a selected existing FFN. Disabled by
+        # default in J because shared_ssm_ffn is the intended tied FFN path.
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def _detach_layer_states(self, layer_states):
+        if layer_states is None:
+            return None
+        out = {}
+        for k, pair in layer_states.items():
+            ssm_state, conv_state = pair
+            out[k] = (
+                ssm_state.detach() if torch.is_tensor(ssm_state) else ssm_state,
+                conv_state.detach() if torch.is_tensor(conv_state) else conv_state,
+            )
+        return out
+
+    def forward_state_carry_train(self, ids, chunks: int):
+        """
+        Optional training mode: split one long training row into chunks, carry
+        Mamba state across chunks, and detach carried state between chunks.
+        This teaches SSM blocks to see nonzero initial state without full BPTT
+        over the whole 8192 row. Attention remains local to each chunk.
+        """
+        chunks = int(chunks)
+        if chunks <= 1:
+            return self.forward(ids)
+        if ids.shape[1] % chunks != 0:
+            raise ValueError(f"state-carry train chunks={chunks} must divide sequence length {ids.shape[1]}")
+        chunk_len = ids.shape[1] // chunks
+        layer_states = None
+        seq_idx_base = 0
+        outs = []
+        for c in range(chunks):
+            xs = ids[:, c * chunk_len:(c + 1) * chunk_len]
+            h, layer_states, seq_idx_base = self.forward_with_state(xs, layer_states, seq_idx_base=seq_idx_base)
+            outs.append(h)
+            layer_states = self._detach_layer_states(layer_states)
+        return torch.cat(outs, dim=1)
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None, state_carry_chunks=1):
+        if state_carry_chunks is not None and int(state_carry_chunks) > 1:
+            if state is not None or return_state or inference_params is not None:
+                raise RuntimeError("state_carry_chunks training path is incompatible with state/return_state/inference_params")
+            return self.forward_state_carry_train(ids, int(state_carry_chunks))
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False, state_carry_chunks=1):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True, state_carry_chunks=state_carry_chunks)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False, state_carry_chunks=state_carry_chunks)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params, small_matrix_params = [], [], [], []
+    role_counts = {"muon": 0, "small_adamw": 0, "bigram_adamw": 0, "scalar": 0, "embed": 0}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def use_muon_for_matrix(name: str, p: torch.nn.Parameter, is_control: bool) -> bool:
+        if is_control:
+            return False
+        if MUON_ONLY_2D and p.ndim != 2:
+            return False
+        if (not MUON_ONLY_2D) and p.ndim < 2:
+            return False
+        if BIGRAM_OPT == "adamw" and name.startswith("bigram."):
+            return False
+        if p.ndim == 2:
+            if MUON_MIN_DIM > 0 and min(p.shape) < MUON_MIN_DIM:
+                return False
+            if MUON_MIN_NUMEL > 0 and p.numel() < MUON_MIN_NUMEL:
+                return False
+        return True
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            role_counts["embed"] += 1
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if use_muon_for_matrix(name, p, is_control):
+            mat_params.append(p)
+            role_counts["muon"] += 1
+        elif ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+            small_matrix_params.append(p)
+            if name.startswith("bigram."):
+                role_counts["bigram_adamw"] += 1
+            else:
+                role_counts["small_adamw"] += 1
+        else:
+            scalar_params.append(p)
+            role_counts["scalar"] += 1
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    adam_groups = [
+        {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+        {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+    ]
+    if len(small_matrix_params) > 0:
+        adam_groups.append({
+            "params": small_matrix_params,
+            "lr": SMALL_MATRIX_LR,
+            "weight_decay": SMALL_MATRIX_WD,
+            "base_lr": SMALL_MATRIX_LR,
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"small_matrix={len(small_matrix_params)} (AdamW), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd} "
+        f"muon_min_dim={MUON_MIN_DIM} muon_min_numel={MUON_MIN_NUMEL} bigram_opt={BIGRAM_OPT}"
+    )
+    log0(
+        "Optimizer role counts: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items()))
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            state_carry_chunks_this = 1
+            if (
+                STATE_CARRY_TRAIN_ENABLED
+                and active_stream_chunks == 1
+                and MAX_WALLCLOCK_SECONDS > 0
+                and (elapsed / max(MAX_WALLCLOCK_SECONDS, 1e-9)) >= STATE_CARRY_TRAIN_START_FRAC
+            ):
+                state_carry_chunks_this = max(1, STATE_CARRY_TRAIN_CHUNKS)
+
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys, state_carry_chunks=state_carry_chunks_this)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_adamw.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_adamw.py
@@ -1,0 +1,2916 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+# K35: keep independent FFN compute in every layer, but shrink only ordinary SSM-layer FFNs.
+# Attention layer(s) and final layer stay full-width; SSM layers default to hidden=896.
+K35_ENABLED = os.environ.get("K35_ENABLED", "1") == "1"
+K35_FULL_FFN_IDXS = [int(x) for x in os.environ.get("K35_FULL_FFN_IDXS", "6,9").split(",") if x.strip()]
+SSM_FFN_HIDDEN = int(os.environ.get("SSM_FFN_HIDDEN", "896"))
+FULL_FFN_HIDDEN = int(os.environ.get("FULL_FFN_HIDDEN", str(D_MODEL * FFN_MULT)))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "320"))  # K35 default: tighter tied factorization for ~35M params
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Full-model TaskMuon: role-aware Muon scaling for the K35/full-FFN family.
+# The goal is calmer SSM dynamics while keeping FFN/attention matrices learning fast.
+FULL_TASKMUON_ENABLED = os.environ.get("FULL_TASKMUON_ENABLED", "1") == "1"
+FULL_TASKMUON_TRUST_CLIP = os.environ.get("FULL_TASKMUON_TRUST_CLIP", "1") == "1"
+TASKMUON_FFN_LR = float(os.environ.get("TASKMUON_FFN_LR", "0.90"))
+TASKMUON_ATTN_QKV_LR = float(os.environ.get("TASKMUON_ATTN_QKV_LR", "0.90"))
+TASKMUON_ATTN_OUT_LR = float(os.environ.get("TASKMUON_ATTN_OUT_LR", "0.75"))
+TASKMUON_MAMBA_IN_LR = float(os.environ.get("TASKMUON_MAMBA_IN_LR", "0.65"))
+TASKMUON_MAMBA_OUT_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_LR", "0.55"))
+TASKMUON_EMBED_PROJ_LR = float(os.environ.get("TASKMUON_EMBED_PROJ_LR", "0.85"))
+TASKMUON_MAMBA_BC_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_BC_ROW_LR", "0.30"))
+TASKMUON_MAMBA_DT_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_DT_ROW_LR", "0.10"))
+TASKMUON_FFN_TRUST = float(os.environ.get("TASKMUON_FFN_TRUST", "0.020"))
+TASKMUON_ATTN_TRUST = float(os.environ.get("TASKMUON_ATTN_TRUST", "0.015"))
+TASKMUON_MAMBA_IN_TRUST = float(os.environ.get("TASKMUON_MAMBA_IN_TRUST", "0.006"))
+TASKMUON_MAMBA_OUT_TRUST = float(os.environ.get("TASKMUON_MAMBA_OUT_TRUST", "0.008"))
+TASKMUON_MAMBA_WD_MULT = float(os.environ.get("TASKMUON_MAMBA_WD_MULT", "0.50"))
+TASKMUON_SMALL_MATRIX_ADAMW = os.environ.get("TASKMUON_SMALL_MATRIX_ADAMW", "1") == "1"
+TASKMUON_MUON_MIN_DIM = int(os.environ.get("TASKMUON_MUON_MIN_DIM", "129"))
+TASKMUON_MUON_MIN_NUMEL = int(os.environ.get("TASKMUON_MUON_MIN_NUMEL", "262144"))
+TASKMUON_SMALL_MATRIX_LR = float(os.environ.get("TASKMUON_SMALL_MATRIX_LR", "0.02"))
+TASKMUON_SMALL_MATRIX_WD = float(os.environ.get("TASKMUON_SMALL_MATRIX_WD", "0.05"))
+
+# Selective optimizer routing: keep Muon only where its matrix geometry helps.
+# Default: Muon for FFN + attention + optional mamba.out_proj; AdamW for
+# mamba.in_proj, Mamba dynamics scalars, bigram matrices, small matrices,
+# norms/scales/gates. This is a cleaner diagnostic for K35 instability.
+SELECTIVE_MUON_ENABLED = os.environ.get("SELECTIVE_MUON_ENABLED", "1") == "1"
+TASKMUON_MAMBA_IN_OPT = os.environ.get("TASKMUON_MAMBA_IN_OPT", "adamw").lower()   # "adamw" or "muon"
+TASKMUON_MAMBA_OUT_OPT = os.environ.get("TASKMUON_MAMBA_OUT_OPT", "muon").lower()  # "muon" or "adamw"
+TASKMUON_MAMBA_IN_ADAM_LR = float(os.environ.get("TASKMUON_MAMBA_IN_ADAM_LR", "0.006"))
+TASKMUON_MAMBA_IN_ADAM_WD = float(os.environ.get("TASKMUON_MAMBA_IN_ADAM_WD", "0.02"))
+TASKMUON_MAMBA_OUT_ADAM_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_ADAM_LR", "0.006"))
+TASKMUON_MAMBA_OUT_ADAM_WD = float(os.environ.get("TASKMUON_MAMBA_OUT_ADAM_WD", "0.02"))
+TASKMUON_MAMBA_DYN_LR = float(os.environ.get("TASKMUON_MAMBA_DYN_LR", "0.002"))
+TASKMUON_MAMBA_DYN_WD = float(os.environ.get("TASKMUON_MAMBA_DYN_WD", "0.0"))
+TASKMUON_BIGRAM_LR = float(os.environ.get("TASKMUON_BIGRAM_LR", "0.015"))
+TASKMUON_BIGRAM_WD = float(os.environ.get("TASKMUON_BIGRAM_WD", "0.02"))
+TASKMUON_CONTROL_LR = float(os.environ.get("TASKMUON_CONTROL_LR", str(SCALAR_LR)))
+TASKMUON_CONTROL_WD = float(os.environ.get("TASKMUON_CONTROL_WD", "0.0"))
+
+
+# Pure AdamW diagnostic: no Muon anywhere. This follows the standard hybrid
+# SSM/Transformer recipe: AdamW for dense transformer/FFN matrices, and
+# separate no-WD / lower-LR groups for SSM recurrent/dynamics parameters.
+ADAMW_ONLY_ENABLED = os.environ.get("ADAMW_ONLY_ENABLED", "1") == "1"
+ADAMW_BASE_LR = float(os.environ.get("ADAMW_BASE_LR", "0.001"))
+ADAMW_FFN_LR = float(os.environ.get("ADAMW_FFN_LR", str(ADAMW_BASE_LR)))
+ADAMW_ATTN_LR = float(os.environ.get("ADAMW_ATTN_LR", str(ADAMW_BASE_LR)))
+ADAMW_EMBED_LR = float(os.environ.get("ADAMW_EMBED_LR", str(ADAMW_BASE_LR)))
+ADAMW_BIGRAM_LR = float(os.environ.get("ADAMW_BIGRAM_LR", str(ADAMW_BASE_LR)))
+ADAMW_MAMBA_IN_LR = float(os.environ.get("ADAMW_MAMBA_IN_LR", "0.0006"))
+ADAMW_MAMBA_OUT_LR = float(os.environ.get("ADAMW_MAMBA_OUT_LR", "0.0008"))
+ADAMW_MAMBA_OTHER_LR = float(os.environ.get("ADAMW_MAMBA_OTHER_LR", "0.0006"))
+ADAMW_MAMBA_DYN_LR = float(os.environ.get("ADAMW_MAMBA_DYN_LR", "0.00015"))
+ADAMW_CONTROL_LR = float(os.environ.get("ADAMW_CONTROL_LR", str(ADAMW_BASE_LR)))
+ADAMW_SMALL_LR = float(os.environ.get("ADAMW_SMALL_LR", str(ADAMW_BASE_LR)))
+ADAMW_WEIGHT_DECAY = float(os.environ.get("ADAMW_WEIGHT_DECAY", str(WEIGHT_DECAY)))
+ADAMW_FFN_WD = float(os.environ.get("ADAMW_FFN_WD", str(ADAMW_WEIGHT_DECAY)))
+ADAMW_ATTN_WD = float(os.environ.get("ADAMW_ATTN_WD", str(ADAMW_WEIGHT_DECAY)))
+ADAMW_EMBED_WD = float(os.environ.get("ADAMW_EMBED_WD", str(ADAMW_WEIGHT_DECAY)))
+ADAMW_BIGRAM_WD = float(os.environ.get("ADAMW_BIGRAM_WD", "0.02"))
+ADAMW_MAMBA_IN_WD = float(os.environ.get("ADAMW_MAMBA_IN_WD", "0.0"))
+ADAMW_MAMBA_OUT_WD = float(os.environ.get("ADAMW_MAMBA_OUT_WD", "0.02"))
+ADAMW_MAMBA_OTHER_WD = float(os.environ.get("ADAMW_MAMBA_OTHER_WD", "0.0"))
+ADAMW_MAMBA_DYN_WD = float(os.environ.get("ADAMW_MAMBA_DYN_WD", "0.0"))
+ADAMW_CONTROL_WD = float(os.environ.get("ADAMW_CONTROL_WD", "0.0"))
+ADAMW_SMALL_WD = float(os.environ.get("ADAMW_SMALL_WD", "0.02"))
+ADAMW_MIN_BIG_MATRIX_NUMEL = int(os.environ.get("ADAMW_MIN_BIG_MATRIX_NUMEL", "262144"))
+ADAMW_BETA1 = float(os.environ.get("ADAMW_BETA1", str(BETA1)))
+ADAMW_BETA2 = float(os.environ.get("ADAMW_BETA2", str(BETA2)))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"k35: enabled={K35_ENABLED}, full_ffn_idxs={K35_FULL_FFN_IDXS}, full_hidden={FULL_FFN_HIDDEN}, ssm_hidden={SSM_FFN_HIDDEN}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("k35_adamw_defaults: tied head, K35 width controls, RoPE on, pure AdamW optimizer by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(
+    f"adamw_only: enabled={ADAMW_ONLY_ENABLED}, base_lr={ADAMW_BASE_LR}, ffn_lr={ADAMW_FFN_LR}, "
+    f"attn_lr={ADAMW_ATTN_LR}, mamba_in/out={ADAMW_MAMBA_IN_LR}/{ADAMW_MAMBA_OUT_LR}, "
+    f"mamba_dyn_lr={ADAMW_MAMBA_DYN_LR}, wd={ADAMW_WEIGHT_DECAY}, betas=({ADAMW_BETA1},{ADAMW_BETA2})"
+)
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"full_taskmuon: enabled={FULL_TASKMUON_ENABLED}, trust_clip={FULL_TASKMUON_TRUST_CLIP}, "
+    f"mamba_in/out={TASKMUON_MAMBA_IN_LR}/{TASKMUON_MAMBA_OUT_LR}, "
+    f"mamba_bc/dt_rows={TASKMUON_MAMBA_BC_ROW_LR}/{TASKMUON_MAMBA_DT_ROW_LR}, "
+    f"attn_qkv/out={TASKMUON_ATTN_QKV_LR}/{TASKMUON_ATTN_OUT_LR}, ffn={TASKMUON_FFN_LR}, "
+    f"small_matrix_adamw={TASKMUON_SMALL_MATRIX_ADAMW}"
+)
+log0(
+    f"selective_muon: enabled={SELECTIVE_MUON_ENABLED}, "
+    f"mamba_in_opt={TASKMUON_MAMBA_IN_OPT}, mamba_out_opt={TASKMUON_MAMBA_OUT_OPT}, "
+    f"mamba_in_adam_lr/wd={TASKMUON_MAMBA_IN_ADAM_LR}/{TASKMUON_MAMBA_IN_ADAM_WD}, "
+    f"mamba_dyn_lr/wd={TASKMUON_MAMBA_DYN_LR}/{TASKMUON_MAMBA_DYN_WD}, "
+    f"bigram_lr/wd={TASKMUON_BIGRAM_LR}/{TASKMUON_BIGRAM_WD}, "
+    f"small_lr/wd={TASKMUON_SMALL_MATRIX_LR}/{TASKMUON_SMALL_MATRIX_WD}, "
+    f"control_lr/wd={TASKMUON_CONTROL_LR}/{TASKMUON_CONTROL_WD}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3, hidden_dim=None):
+        super().__init__()
+        hidden = int(hidden_dim) if hidden_dim is not None and int(hidden_dim) > 0 else d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        self.layer_ffn_hidden = []
+        full_ffn_set = set(K35_FULL_FFN_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            if not K35_ENABLED:
+                ffn_hidden_i = D_MODEL * FFN_MULT
+            elif i in attn_set or i in full_ffn_set:
+                ffn_hidden_i = FULL_FFN_HIDDEN
+            else:
+                ffn_hidden_i = SSM_FFN_HIDDEN
+            self.layer_ffn_hidden.append(int(ffn_hidden_i))
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, ffn_hidden=ffn_hidden_i))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, ffn_hidden=ffn_hidden_i))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+def _set_mamba_inproj_row_multipliers(model):
+    """Attach row multipliers to Mamba in_proj weights for role-aware Muon."""
+    for mod in model.modules():
+        if not isinstance(mod, SelectiveSSMBlock):
+            continue
+        m = mod.mamba
+        p = m.in_proj.weight
+        try:
+            d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+            ngroups = getattr(m, "ngroups", 1)
+            d_state = m.d_state
+            nheads = m.nheads
+            total = p.shape[0]
+            expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+            d_mlp = max(0, (total - expected) // 2)
+            rm = torch.ones(total, dtype=torch.float32) * float(TASKMUON_MAMBA_IN_LR)
+            offset = 2 * d_mlp + d_inner if d_mlp > 0 else d_inner
+            x_rows = d_inner
+            bc_rows = 2 * ngroups * d_state
+            if offset + x_rows + bc_rows <= total:
+                rm[offset + x_rows: offset + x_rows + bc_rows] = float(TASKMUON_MAMBA_BC_ROW_LR)
+            if nheads <= total:
+                rm[-nheads:] = float(TASKMUON_MAMBA_DT_ROW_LR)
+            p._muon_row_mult = rm
+            p._muon_shape_scale_cap = 1.0
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+        except Exception:
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+
+
+def _set_attn_qkv_row_multipliers(p):
+    rm = torch.ones(p.shape[0], dtype=torch.float32) * float(TASKMUON_ATTN_QKV_LR)
+    p._muon_row_mult = rm
+    if FULL_TASKMUON_TRUST_CLIP:
+        p._muon_trust_ratio = TASKMUON_ATTN_TRUST
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    shape_scale = (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    cap = getattr(p, "_muon_shape_scale_cap", None)
+                    if cap is not None:
+                        shape_scale = min(float(shape_scale), float(cap))
+                    upd_orth = upd_orth * shape_scale
+                    upd = upd_orth.reshape(upd.shape)
+                row_mult = getattr(p, "_muon_row_mult", None)
+                if row_mult is not None and upd.ndim >= 2:
+                    rm = row_mult.to(device=upd.device, dtype=upd.dtype)
+                    upd = upd * rm.view(-1, *([1] * (upd.ndim - 1)))
+                trust = getattr(p, "_muon_trust_ratio", None)
+                if trust is not None and trust > 0:
+                    u_rms = upd.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    w_rms = p.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    scale = torch.clamp((float(trust) * w_rms) / u_rms, max=1.0)
+                    upd = upd * scale.to(dtype=upd.dtype)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    """
+    Selective FullTaskMuon optimizer:
+      - Muon: FFN gate_up/down, attention qkv/out, optionally mamba.out_proj.
+      - AdamW: mamba.in_proj by default, Mamba dynamics scalars, bigram matrices,
+        small 2D matrices, norms/scales/gates/control params.
+    This avoids applying Newton-Schulz geometry to heterogeneous Mamba in_proj rows.
+    """
+    if ADAMW_ONLY_ENABLED:
+        adam_groups = []
+        role_counts = {}
+        seen = set()
+
+        def count(role):
+            role_counts[role] = role_counts.get(role, 0) + 1
+
+        def add_group(role, p, lr, wd):
+            if not hasattr(add_group, "by_role"):
+                add_group.by_role = {}
+            key = (role, float(lr), float(wd))
+            if key not in add_group.by_role:
+                add_group.by_role[key] = {"params": [], "lr": lr, "base_lr": lr, "weight_decay": wd, "role": role}
+            add_group.by_role[key]["params"].append(p)
+            count(role)
+
+        def is_mamba_dyn_name(name: str) -> bool:
+            return (
+                ".mamba.A_log" in name
+                or ".mamba.D" in name
+                or ".mamba.dt_bias" in name
+            )
+
+        def is_bigram_name(name: str) -> bool:
+            return name.startswith("bigram.") or ".bigram." in name
+
+        for name, p in model.named_parameters():
+            try:
+                p._pg_name = name
+            except Exception:
+                pass
+            dp = p.data_ptr()
+            if dp in seen:
+                continue
+            seen.add(dp)
+
+            is_control = (
+                any(c in name for c in CTRL_PATTERNS)
+                or getattr(p, "_no_weight_decay", False)
+                or name.endswith(".bias")
+                or p.ndim < 2
+            )
+
+            if name in ("tok_emb.weight", "lm_head.weight"):
+                add_group("embed", p, ADAMW_EMBED_LR, ADAMW_EMBED_WD)
+            elif is_mamba_dyn_name(name):
+                add_group("mamba_dyn", p, ADAMW_MAMBA_DYN_LR, ADAMW_MAMBA_DYN_WD)
+            elif ".mamba.in_proj.weight" in name:
+                # Mamba in_proj contains heterogeneous z/x/B/C/dt-style rows; no WD.
+                add_group("mamba_in_proj", p, ADAMW_MAMBA_IN_LR, ADAMW_MAMBA_IN_WD)
+            elif ".mamba.out_proj.weight" in name:
+                add_group("mamba_out_proj", p, ADAMW_MAMBA_OUT_LR, ADAMW_MAMBA_OUT_WD)
+            elif ".mamba." in name:
+                # conv1d and other Mamba internals: conservative no-WD group.
+                add_group("mamba_other", p, ADAMW_MAMBA_OTHER_LR, ADAMW_MAMBA_OTHER_WD)
+            elif is_bigram_name(name):
+                add_group("bigram", p, ADAMW_BIGRAM_LR, ADAMW_BIGRAM_WD)
+            elif is_control:
+                add_group("control_no_wd", p, ADAMW_CONTROL_LR, ADAMW_CONTROL_WD)
+            elif ".qkv.weight" in name or ".out_proj.weight" in name:
+                # Attention qkv/out only; Mamba out_proj was handled above.
+                add_group("attention", p, ADAMW_ATTN_LR, ADAMW_ATTN_WD)
+            elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+                add_group("ffn", p, ADAMW_FFN_LR, ADAMW_FFN_WD)
+            elif "embed_proj" in name or "embed_proj_rev" in name:
+                add_group("embed_proj", p, ADAMW_EMBED_LR, ADAMW_EMBED_WD)
+            elif p.ndim == 2 and p.numel() < ADAMW_MIN_BIG_MATRIX_NUMEL:
+                add_group("small_matrix", p, ADAMW_SMALL_LR, ADAMW_SMALL_WD)
+            else:
+                add_group("generic", p, ADAMW_BASE_LR, ADAMW_WEIGHT_DECAY)
+
+        adam_groups = list(getattr(add_group, "by_role", {}).values())
+        optimizer_adamw = torch.optim.AdamW(
+            adam_groups,
+            betas=(ADAMW_BETA1, ADAMW_BETA2),
+            eps=ADAM_EPS,
+            fused=True,
+        )
+        n_by_role = {g["role"]: len(g["params"]) for g in adam_groups}
+        log0(f"Optimizer split: PURE_ADAMW groups={n_by_role}")
+        log0("Optimizer roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items())))
+        return optimizer_adamw, None, []
+
+    if FULL_TASKMUON_ENABLED and TASKMUON_MAMBA_IN_OPT == "muon":
+        _set_mamba_inproj_row_multipliers(model)
+
+    muon_groups_by_role = {}
+    no_wd_params, embed_params = [], []
+    small_matrix_params, bigram_params = [], []
+    mamba_in_params, mamba_out_adamw_params, mamba_dyn_params = [], [], []
+    scalar_wd_params = []
+    role_counts = {}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def count(role):
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    def add_muon(role, p, lr_mult=1.0, wd_mult=1.0, trust=None, shape_cap=None):
+        if trust is not None and FULL_TASKMUON_TRUST_CLIP:
+            p._muon_trust_ratio = float(trust)
+        if shape_cap is not None:
+            p._muon_shape_scale_cap = float(shape_cap)
+        if role not in muon_groups_by_role:
+            muon_groups_by_role[role] = {
+                "params": [],
+                "lr": MATRIX_LR * lr_mult,
+                "base_lr": MATRIX_LR * lr_mult,
+                "weight_decay": WEIGHT_DECAY * wd_mult,
+                "role": role,
+            }
+        muon_groups_by_role[role]["params"].append(p)
+        count(role)
+
+    def is_mamba_dyn_name(name: str) -> bool:
+        return (
+            ".mamba.A_log" in name
+            or ".mamba.D" in name
+            or ".mamba.dt_bias" in name
+        )
+
+    def is_bigram_name(name: str) -> bool:
+        return name.startswith("bigram.") or ".bigram." in name
+
+    for name, p in model.named_parameters():
+        try:
+            p._pg_name = name
+        except Exception:
+            pass
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            count("embed_adamw")
+            continue
+
+        # Mamba dynamics scalars get their own gentle AdamW group.
+        if is_mamba_dyn_name(name):
+            mamba_dyn_params.append(p)
+            count("mamba_dyn_adamw")
+            continue
+
+        # Norms/scales/gates/bias/control params: AdamW, default no WD.
+        is_control = (
+            any(c in name for c in CTRL_PATTERNS)
+            or getattr(p, "_no_weight_decay", False)
+            or name.endswith(".bias")
+            or p.ndim < 2
+        )
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if is_control:
+            no_wd_params.append(p)
+            count("control_no_wd_adamw")
+            continue
+
+        # Bigram tables/proj are embedding-like; Muon is not useful here.
+        if is_bigram_name(name):
+            bigram_params.append(p)
+            count("bigram_adamw")
+            continue
+
+        # Mamba in_proj is heterogeneous: z/x/B/C/dt rows. Default AdamW.
+        if ".mamba.in_proj.weight" in name:
+            if SELECTIVE_MUON_ENABLED and TASKMUON_MAMBA_IN_OPT == "adamw":
+                mamba_in_params.append(p)
+                count("mamba_in_adamw")
+            else:
+                _set_mamba_inproj_row_multipliers(model)
+                add_muon("mamba_in_proj", p, lr_mult=TASKMUON_MAMBA_IN_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_IN_TRUST, shape_cap=1.0)
+            continue
+
+        # Mamba out_proj is a normal residual write-back projection; Muon often helps.
+        if ".mamba.out_proj.weight" in name:
+            if SELECTIVE_MUON_ENABLED and TASKMUON_MAMBA_OUT_OPT == "adamw":
+                mamba_out_adamw_params.append(p)
+                count("mamba_out_adamw")
+            else:
+                add_muon("mamba_out_proj", p, lr_mult=TASKMUON_MAMBA_OUT_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_OUT_TRUST, shape_cap=1.0)
+            continue
+
+        # Small 2D matrices are poor Muon targets; keep them AdamW.
+        if (
+            SELECTIVE_MUON_ENABLED
+            and TASKMUON_SMALL_MATRIX_ADAMW
+            and p.ndim == 2
+            and (min(p.shape) <= TASKMUON_MUON_MIN_DIM or p.numel() <= TASKMUON_MUON_MIN_NUMEL)
+        ):
+            small_matrix_params.append(p)
+            count("small_matrix_adamw")
+            continue
+
+        if FULL_TASKMUON_ENABLED:
+            if ".qkv.weight" in name:
+                _set_attn_qkv_row_multipliers(p)
+                add_muon("attn_qkv", p, lr_mult=TASKMUON_ATTN_QKV_LR,
+                         wd_mult=1.0, trust=TASKMUON_ATTN_TRUST)
+            elif ".out_proj.weight" in name:
+                add_muon("attn_out_proj", p, lr_mult=TASKMUON_ATTN_OUT_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+                add_muon("ffn", p, lr_mult=TASKMUON_FFN_LR,
+                         wd_mult=1.0, trust=TASKMUON_FFN_TRUST)
+            elif "embed_proj" in name or "embed_proj_rev" in name:
+                # If large enough, Muon can still be useful for embed projections.
+                add_muon("embed_proj", p, lr_mult=TASKMUON_EMBED_PROJ_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif p.ndim == 2:
+                add_muon("generic", p, lr_mult=1.0, wd_mult=1.0)
+            elif (not MUON_ONLY_2D) and p.ndim >= 2:
+                add_muon("generic_nd", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_wd_params.append(p)
+                count("scalar_wd_adamw")
+        else:
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)):
+                add_muon("matrix", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_wd_params.append(p)
+                count("scalar_wd_adamw")
+
+    muon_groups = list(muon_groups_by_role.values())
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adam_groups = []
+    def add_adam_group(params, lr, wd, role):
+        if params:
+            adam_groups.append({
+                "params": params,
+                "lr": lr,
+                "weight_decay": wd,
+                "base_lr": lr,
+                "role": role,
+            })
+
+    add_adam_group(no_wd_params, TASKMUON_CONTROL_LR, TASKMUON_CONTROL_WD, "control_no_wd")
+    add_adam_group(scalar_wd_params, SCALAR_LR, WEIGHT_DECAY, "scalar_wd")
+    add_adam_group(embed_params, EMBED_LR, WEIGHT_DECAY, "embed")
+    add_adam_group(small_matrix_params, TASKMUON_SMALL_MATRIX_LR, TASKMUON_SMALL_MATRIX_WD, "small_matrix")
+    add_adam_group(bigram_params, TASKMUON_BIGRAM_LR, TASKMUON_BIGRAM_WD, "bigram")
+    add_adam_group(mamba_in_params, TASKMUON_MAMBA_IN_ADAM_LR, TASKMUON_MAMBA_IN_ADAM_WD, "mamba_in")
+    add_adam_group(mamba_out_adamw_params, TASKMUON_MAMBA_OUT_ADAM_LR, TASKMUON_MAMBA_OUT_ADAM_WD, "mamba_out")
+    add_adam_group(mamba_dyn_params, TASKMUON_MAMBA_DYN_LR, TASKMUON_MAMBA_DYN_WD, "mamba_dyn")
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    n_muon_params = sum(len(g["params"]) for g in muon_groups)
+    n_adam_by_role = {g["role"]: len(g["params"]) for g in adam_groups}
+    log0(
+        f"Optimizer split: matrix={n_muon_params} (Muon/{len(muon_groups)} groups), "
+        f"adamw_groups={n_adam_by_role}"
+    )
+    log0(
+        f"Muon config: selective={int(SELECTIVE_MUON_ENABLED)} full_taskmuon={int(FULL_TASKMUON_ENABLED)} "
+        f"muon_only_2d={int(MUON_ONLY_2D)} eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd} "
+        f"mamba_in_opt={TASKMUON_MAMBA_IN_OPT} mamba_out_opt={TASKMUON_MAMBA_OUT_OPT}"
+    )
+    log0("Optimizer roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items())))
+    mat_params = [p for g in muon_groups for p in g["params"]]
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+        for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+            try:
+                if _ldr is not None:
+                    _ldr.shutdown()
+            except Exception:
+                pass
+        return
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_selective_muon.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_selective_muon.py
@@ -1,0 +1,2796 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+# K35: keep independent FFN compute in every layer, but shrink only ordinary SSM-layer FFNs.
+# Attention layer(s) and final layer stay full-width; SSM layers default to hidden=896.
+K35_ENABLED = os.environ.get("K35_ENABLED", "1") == "1"
+K35_FULL_FFN_IDXS = [int(x) for x in os.environ.get("K35_FULL_FFN_IDXS", "6,9").split(",") if x.strip()]
+SSM_FFN_HIDDEN = int(os.environ.get("SSM_FFN_HIDDEN", "896"))
+FULL_FFN_HIDDEN = int(os.environ.get("FULL_FFN_HIDDEN", str(D_MODEL * FFN_MULT)))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "320"))  # K35 default: tighter tied factorization for ~35M params
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Full-model TaskMuon: role-aware Muon scaling for the K35/full-FFN family.
+# The goal is calmer SSM dynamics while keeping FFN/attention matrices learning fast.
+FULL_TASKMUON_ENABLED = os.environ.get("FULL_TASKMUON_ENABLED", "1") == "1"
+FULL_TASKMUON_TRUST_CLIP = os.environ.get("FULL_TASKMUON_TRUST_CLIP", "1") == "1"
+TASKMUON_FFN_LR = float(os.environ.get("TASKMUON_FFN_LR", "0.90"))
+TASKMUON_ATTN_QKV_LR = float(os.environ.get("TASKMUON_ATTN_QKV_LR", "0.90"))
+TASKMUON_ATTN_OUT_LR = float(os.environ.get("TASKMUON_ATTN_OUT_LR", "0.75"))
+TASKMUON_MAMBA_IN_LR = float(os.environ.get("TASKMUON_MAMBA_IN_LR", "0.65"))
+TASKMUON_MAMBA_OUT_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_LR", "0.55"))
+TASKMUON_EMBED_PROJ_LR = float(os.environ.get("TASKMUON_EMBED_PROJ_LR", "0.85"))
+TASKMUON_MAMBA_BC_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_BC_ROW_LR", "0.30"))
+TASKMUON_MAMBA_DT_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_DT_ROW_LR", "0.10"))
+TASKMUON_FFN_TRUST = float(os.environ.get("TASKMUON_FFN_TRUST", "0.020"))
+TASKMUON_ATTN_TRUST = float(os.environ.get("TASKMUON_ATTN_TRUST", "0.015"))
+TASKMUON_MAMBA_IN_TRUST = float(os.environ.get("TASKMUON_MAMBA_IN_TRUST", "0.006"))
+TASKMUON_MAMBA_OUT_TRUST = float(os.environ.get("TASKMUON_MAMBA_OUT_TRUST", "0.008"))
+TASKMUON_MAMBA_WD_MULT = float(os.environ.get("TASKMUON_MAMBA_WD_MULT", "0.50"))
+TASKMUON_SMALL_MATRIX_ADAMW = os.environ.get("TASKMUON_SMALL_MATRIX_ADAMW", "1") == "1"
+TASKMUON_MUON_MIN_DIM = int(os.environ.get("TASKMUON_MUON_MIN_DIM", "129"))
+TASKMUON_MUON_MIN_NUMEL = int(os.environ.get("TASKMUON_MUON_MIN_NUMEL", "262144"))
+TASKMUON_SMALL_MATRIX_LR = float(os.environ.get("TASKMUON_SMALL_MATRIX_LR", "0.02"))
+TASKMUON_SMALL_MATRIX_WD = float(os.environ.get("TASKMUON_SMALL_MATRIX_WD", "0.05"))
+
+# Selective optimizer routing: keep Muon only where its matrix geometry helps.
+# Default: Muon for FFN + attention + optional mamba.out_proj; AdamW for
+# mamba.in_proj, Mamba dynamics scalars, bigram matrices, small matrices,
+# norms/scales/gates. This is a cleaner diagnostic for K35 instability.
+SELECTIVE_MUON_ENABLED = os.environ.get("SELECTIVE_MUON_ENABLED", "1") == "1"
+TASKMUON_MAMBA_IN_OPT = os.environ.get("TASKMUON_MAMBA_IN_OPT", "adamw").lower()   # "adamw" or "muon"
+TASKMUON_MAMBA_OUT_OPT = os.environ.get("TASKMUON_MAMBA_OUT_OPT", "muon").lower()  # "muon" or "adamw"
+TASKMUON_MAMBA_IN_ADAM_LR = float(os.environ.get("TASKMUON_MAMBA_IN_ADAM_LR", "0.006"))
+TASKMUON_MAMBA_IN_ADAM_WD = float(os.environ.get("TASKMUON_MAMBA_IN_ADAM_WD", "0.02"))
+TASKMUON_MAMBA_OUT_ADAM_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_ADAM_LR", "0.006"))
+TASKMUON_MAMBA_OUT_ADAM_WD = float(os.environ.get("TASKMUON_MAMBA_OUT_ADAM_WD", "0.02"))
+TASKMUON_MAMBA_DYN_LR = float(os.environ.get("TASKMUON_MAMBA_DYN_LR", "0.002"))
+TASKMUON_MAMBA_DYN_WD = float(os.environ.get("TASKMUON_MAMBA_DYN_WD", "0.0"))
+TASKMUON_BIGRAM_LR = float(os.environ.get("TASKMUON_BIGRAM_LR", "0.015"))
+TASKMUON_BIGRAM_WD = float(os.environ.get("TASKMUON_BIGRAM_WD", "0.02"))
+TASKMUON_CONTROL_LR = float(os.environ.get("TASKMUON_CONTROL_LR", str(SCALAR_LR)))
+TASKMUON_CONTROL_WD = float(os.environ.get("TASKMUON_CONTROL_WD", "0.0"))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"k35: enabled={K35_ENABLED}, full_ffn_idxs={K35_FULL_FFN_IDXS}, full_hidden={FULL_FFN_HIDDEN}, ssm_hidden={SSM_FFN_HIDDEN}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("k35_defaults: tied head, EMBED_DIM=320, BIGRAM off, SSM FFN hidden=896, full FFNs on layers 6/9, RoPE on, FullTaskMuon on")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"full_taskmuon: enabled={FULL_TASKMUON_ENABLED}, trust_clip={FULL_TASKMUON_TRUST_CLIP}, "
+    f"mamba_in/out={TASKMUON_MAMBA_IN_LR}/{TASKMUON_MAMBA_OUT_LR}, "
+    f"mamba_bc/dt_rows={TASKMUON_MAMBA_BC_ROW_LR}/{TASKMUON_MAMBA_DT_ROW_LR}, "
+    f"attn_qkv/out={TASKMUON_ATTN_QKV_LR}/{TASKMUON_ATTN_OUT_LR}, ffn={TASKMUON_FFN_LR}, "
+    f"small_matrix_adamw={TASKMUON_SMALL_MATRIX_ADAMW}"
+)
+log0(
+    f"selective_muon: enabled={SELECTIVE_MUON_ENABLED}, "
+    f"mamba_in_opt={TASKMUON_MAMBA_IN_OPT}, mamba_out_opt={TASKMUON_MAMBA_OUT_OPT}, "
+    f"mamba_in_adam_lr/wd={TASKMUON_MAMBA_IN_ADAM_LR}/{TASKMUON_MAMBA_IN_ADAM_WD}, "
+    f"mamba_dyn_lr/wd={TASKMUON_MAMBA_DYN_LR}/{TASKMUON_MAMBA_DYN_WD}, "
+    f"bigram_lr/wd={TASKMUON_BIGRAM_LR}/{TASKMUON_BIGRAM_WD}, "
+    f"small_lr/wd={TASKMUON_SMALL_MATRIX_LR}/{TASKMUON_SMALL_MATRIX_WD}, "
+    f"control_lr/wd={TASKMUON_CONTROL_LR}/{TASKMUON_CONTROL_WD}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3, hidden_dim=None):
+        super().__init__()
+        hidden = int(hidden_dim) if hidden_dim is not None and int(hidden_dim) > 0 else d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        self.layer_ffn_hidden = []
+        full_ffn_set = set(K35_FULL_FFN_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            if not K35_ENABLED:
+                ffn_hidden_i = D_MODEL * FFN_MULT
+            elif i in attn_set or i in full_ffn_set:
+                ffn_hidden_i = FULL_FFN_HIDDEN
+            else:
+                ffn_hidden_i = SSM_FFN_HIDDEN
+            self.layer_ffn_hidden.append(int(ffn_hidden_i))
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, ffn_hidden=ffn_hidden_i))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, ffn_hidden=ffn_hidden_i))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+def _set_mamba_inproj_row_multipliers(model):
+    """Attach row multipliers to Mamba in_proj weights for role-aware Muon."""
+    for mod in model.modules():
+        if not isinstance(mod, SelectiveSSMBlock):
+            continue
+        m = mod.mamba
+        p = m.in_proj.weight
+        try:
+            d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+            ngroups = getattr(m, "ngroups", 1)
+            d_state = m.d_state
+            nheads = m.nheads
+            total = p.shape[0]
+            expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+            d_mlp = max(0, (total - expected) // 2)
+            rm = torch.ones(total, dtype=torch.float32) * float(TASKMUON_MAMBA_IN_LR)
+            offset = 2 * d_mlp + d_inner if d_mlp > 0 else d_inner
+            x_rows = d_inner
+            bc_rows = 2 * ngroups * d_state
+            if offset + x_rows + bc_rows <= total:
+                rm[offset + x_rows: offset + x_rows + bc_rows] = float(TASKMUON_MAMBA_BC_ROW_LR)
+            if nheads <= total:
+                rm[-nheads:] = float(TASKMUON_MAMBA_DT_ROW_LR)
+            p._muon_row_mult = rm
+            p._muon_shape_scale_cap = 1.0
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+        except Exception:
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+
+
+def _set_attn_qkv_row_multipliers(p):
+    rm = torch.ones(p.shape[0], dtype=torch.float32) * float(TASKMUON_ATTN_QKV_LR)
+    p._muon_row_mult = rm
+    if FULL_TASKMUON_TRUST_CLIP:
+        p._muon_trust_ratio = TASKMUON_ATTN_TRUST
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    shape_scale = (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    cap = getattr(p, "_muon_shape_scale_cap", None)
+                    if cap is not None:
+                        shape_scale = min(float(shape_scale), float(cap))
+                    upd_orth = upd_orth * shape_scale
+                    upd = upd_orth.reshape(upd.shape)
+                row_mult = getattr(p, "_muon_row_mult", None)
+                if row_mult is not None and upd.ndim >= 2:
+                    rm = row_mult.to(device=upd.device, dtype=upd.dtype)
+                    upd = upd * rm.view(-1, *([1] * (upd.ndim - 1)))
+                trust = getattr(p, "_muon_trust_ratio", None)
+                if trust is not None and trust > 0:
+                    u_rms = upd.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    w_rms = p.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    scale = torch.clamp((float(trust) * w_rms) / u_rms, max=1.0)
+                    upd = upd * scale.to(dtype=upd.dtype)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    """
+    Selective FullTaskMuon optimizer:
+      - Muon: FFN gate_up/down, attention qkv/out, optionally mamba.out_proj.
+      - AdamW: mamba.in_proj by default, Mamba dynamics scalars, bigram matrices,
+        small 2D matrices, norms/scales/gates/control params.
+    This avoids applying Newton-Schulz geometry to heterogeneous Mamba in_proj rows.
+    """
+    if FULL_TASKMUON_ENABLED and TASKMUON_MAMBA_IN_OPT == "muon":
+        _set_mamba_inproj_row_multipliers(model)
+
+    muon_groups_by_role = {}
+    no_wd_params, embed_params = [], []
+    small_matrix_params, bigram_params = [], []
+    mamba_in_params, mamba_out_adamw_params, mamba_dyn_params = [], [], []
+    scalar_wd_params = []
+    role_counts = {}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def count(role):
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    def add_muon(role, p, lr_mult=1.0, wd_mult=1.0, trust=None, shape_cap=None):
+        if trust is not None and FULL_TASKMUON_TRUST_CLIP:
+            p._muon_trust_ratio = float(trust)
+        if shape_cap is not None:
+            p._muon_shape_scale_cap = float(shape_cap)
+        if role not in muon_groups_by_role:
+            muon_groups_by_role[role] = {
+                "params": [],
+                "lr": MATRIX_LR * lr_mult,
+                "base_lr": MATRIX_LR * lr_mult,
+                "weight_decay": WEIGHT_DECAY * wd_mult,
+                "role": role,
+            }
+        muon_groups_by_role[role]["params"].append(p)
+        count(role)
+
+    def is_mamba_dyn_name(name: str) -> bool:
+        return (
+            ".mamba.A_log" in name
+            or ".mamba.D" in name
+            or ".mamba.dt_bias" in name
+        )
+
+    def is_bigram_name(name: str) -> bool:
+        return name.startswith("bigram.") or ".bigram." in name
+
+    for name, p in model.named_parameters():
+        try:
+            p._pg_name = name
+        except Exception:
+            pass
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            count("embed_adamw")
+            continue
+
+        # Mamba dynamics scalars get their own gentle AdamW group.
+        if is_mamba_dyn_name(name):
+            mamba_dyn_params.append(p)
+            count("mamba_dyn_adamw")
+            continue
+
+        # Norms/scales/gates/bias/control params: AdamW, default no WD.
+        is_control = (
+            any(c in name for c in CTRL_PATTERNS)
+            or getattr(p, "_no_weight_decay", False)
+            or name.endswith(".bias")
+            or p.ndim < 2
+        )
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if is_control:
+            no_wd_params.append(p)
+            count("control_no_wd_adamw")
+            continue
+
+        # Bigram tables/proj are embedding-like; Muon is not useful here.
+        if is_bigram_name(name):
+            bigram_params.append(p)
+            count("bigram_adamw")
+            continue
+
+        # Mamba in_proj is heterogeneous: z/x/B/C/dt rows. Default AdamW.
+        if ".mamba.in_proj.weight" in name:
+            if SELECTIVE_MUON_ENABLED and TASKMUON_MAMBA_IN_OPT == "adamw":
+                mamba_in_params.append(p)
+                count("mamba_in_adamw")
+            else:
+                _set_mamba_inproj_row_multipliers(model)
+                add_muon("mamba_in_proj", p, lr_mult=TASKMUON_MAMBA_IN_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_IN_TRUST, shape_cap=1.0)
+            continue
+
+        # Mamba out_proj is a normal residual write-back projection; Muon often helps.
+        if ".mamba.out_proj.weight" in name:
+            if SELECTIVE_MUON_ENABLED and TASKMUON_MAMBA_OUT_OPT == "adamw":
+                mamba_out_adamw_params.append(p)
+                count("mamba_out_adamw")
+            else:
+                add_muon("mamba_out_proj", p, lr_mult=TASKMUON_MAMBA_OUT_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_OUT_TRUST, shape_cap=1.0)
+            continue
+
+        # Small 2D matrices are poor Muon targets; keep them AdamW.
+        if (
+            SELECTIVE_MUON_ENABLED
+            and TASKMUON_SMALL_MATRIX_ADAMW
+            and p.ndim == 2
+            and (min(p.shape) <= TASKMUON_MUON_MIN_DIM or p.numel() <= TASKMUON_MUON_MIN_NUMEL)
+        ):
+            small_matrix_params.append(p)
+            count("small_matrix_adamw")
+            continue
+
+        if FULL_TASKMUON_ENABLED:
+            if ".qkv.weight" in name:
+                _set_attn_qkv_row_multipliers(p)
+                add_muon("attn_qkv", p, lr_mult=TASKMUON_ATTN_QKV_LR,
+                         wd_mult=1.0, trust=TASKMUON_ATTN_TRUST)
+            elif ".out_proj.weight" in name:
+                add_muon("attn_out_proj", p, lr_mult=TASKMUON_ATTN_OUT_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+                add_muon("ffn", p, lr_mult=TASKMUON_FFN_LR,
+                         wd_mult=1.0, trust=TASKMUON_FFN_TRUST)
+            elif "embed_proj" in name or "embed_proj_rev" in name:
+                # If large enough, Muon can still be useful for embed projections.
+                add_muon("embed_proj", p, lr_mult=TASKMUON_EMBED_PROJ_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif p.ndim == 2:
+                add_muon("generic", p, lr_mult=1.0, wd_mult=1.0)
+            elif (not MUON_ONLY_2D) and p.ndim >= 2:
+                add_muon("generic_nd", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_wd_params.append(p)
+                count("scalar_wd_adamw")
+        else:
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)):
+                add_muon("matrix", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_wd_params.append(p)
+                count("scalar_wd_adamw")
+
+    muon_groups = list(muon_groups_by_role.values())
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adam_groups = []
+    def add_adam_group(params, lr, wd, role):
+        if params:
+            adam_groups.append({
+                "params": params,
+                "lr": lr,
+                "weight_decay": wd,
+                "base_lr": lr,
+                "role": role,
+            })
+
+    add_adam_group(no_wd_params, TASKMUON_CONTROL_LR, TASKMUON_CONTROL_WD, "control_no_wd")
+    add_adam_group(scalar_wd_params, SCALAR_LR, WEIGHT_DECAY, "scalar_wd")
+    add_adam_group(embed_params, EMBED_LR, WEIGHT_DECAY, "embed")
+    add_adam_group(small_matrix_params, TASKMUON_SMALL_MATRIX_LR, TASKMUON_SMALL_MATRIX_WD, "small_matrix")
+    add_adam_group(bigram_params, TASKMUON_BIGRAM_LR, TASKMUON_BIGRAM_WD, "bigram")
+    add_adam_group(mamba_in_params, TASKMUON_MAMBA_IN_ADAM_LR, TASKMUON_MAMBA_IN_ADAM_WD, "mamba_in")
+    add_adam_group(mamba_out_adamw_params, TASKMUON_MAMBA_OUT_ADAM_LR, TASKMUON_MAMBA_OUT_ADAM_WD, "mamba_out")
+    add_adam_group(mamba_dyn_params, TASKMUON_MAMBA_DYN_LR, TASKMUON_MAMBA_DYN_WD, "mamba_dyn")
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    n_muon_params = sum(len(g["params"]) for g in muon_groups)
+    n_adam_by_role = {g["role"]: len(g["params"]) for g in adam_groups}
+    log0(
+        f"Optimizer split: matrix={n_muon_params} (Muon/{len(muon_groups)} groups), "
+        f"adamw_groups={n_adam_by_role}"
+    )
+    log0(
+        f"Muon config: selective={int(SELECTIVE_MUON_ENABLED)} full_taskmuon={int(FULL_TASKMUON_ENABLED)} "
+        f"muon_only_2d={int(MUON_ONLY_2D)} eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd} "
+        f"mamba_in_opt={TASKMUON_MAMBA_IN_OPT} mamba_out_opt={TASKMUON_MAMBA_OUT_OPT}"
+    )
+    log0("Optimizer roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items())))
+    mat_params = [p for g in muon_groups for p in g["params"]]
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+        for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+            try:
+                if _ldr is not None:
+                    _ldr.shutdown()
+            except Exception:
+                pass
+        return
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_targetaware.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_targetaware.py
@@ -1,0 +1,2987 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+# K35: keep independent FFN compute in every layer, but shrink only ordinary SSM-layer FFNs.
+# Attention layer(s) and final layer stay full-width; SSM layers default to hidden=896.
+K35_ENABLED = os.environ.get("K35_ENABLED", "1") == "1"
+K35_FULL_FFN_IDXS = [int(x) for x in os.environ.get("K35_FULL_FFN_IDXS", "6,9").split(",") if x.strip()]
+SSM_FFN_HIDDEN = int(os.environ.get("SSM_FFN_HIDDEN", "896"))
+FULL_FFN_HIDDEN = int(os.environ.get("FULL_FFN_HIDDEN", str(D_MODEL * FFN_MULT)))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "320"))  # K35 default: tighter tied factorization for ~35M params
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Full-model TaskMuon: role-aware Muon scaling for the K35/full-FFN family.
+# The goal is calmer SSM dynamics while keeping FFN/attention matrices learning fast.
+FULL_TASKMUON_ENABLED = os.environ.get("FULL_TASKMUON_ENABLED", "1") == "1"
+FULL_TASKMUON_TRUST_CLIP = os.environ.get("FULL_TASKMUON_TRUST_CLIP", "1") == "1"
+TASKMUON_FFN_LR = float(os.environ.get("TASKMUON_FFN_LR", "0.90"))
+TASKMUON_ATTN_QKV_LR = float(os.environ.get("TASKMUON_ATTN_QKV_LR", "0.90"))
+TASKMUON_ATTN_OUT_LR = float(os.environ.get("TASKMUON_ATTN_OUT_LR", "0.75"))
+TASKMUON_MAMBA_IN_LR = float(os.environ.get("TASKMUON_MAMBA_IN_LR", "0.65"))
+TASKMUON_MAMBA_OUT_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_LR", "0.55"))
+TASKMUON_EMBED_PROJ_LR = float(os.environ.get("TASKMUON_EMBED_PROJ_LR", "0.85"))
+TASKMUON_MAMBA_BC_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_BC_ROW_LR", "0.30"))
+TASKMUON_MAMBA_DT_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_DT_ROW_LR", "0.10"))
+TASKMUON_FFN_TRUST = float(os.environ.get("TASKMUON_FFN_TRUST", "0.020"))
+TASKMUON_ATTN_TRUST = float(os.environ.get("TASKMUON_ATTN_TRUST", "0.015"))
+TASKMUON_MAMBA_IN_TRUST = float(os.environ.get("TASKMUON_MAMBA_IN_TRUST", "0.006"))
+TASKMUON_MAMBA_OUT_TRUST = float(os.environ.get("TASKMUON_MAMBA_OUT_TRUST", "0.008"))
+TASKMUON_MAMBA_WD_MULT = float(os.environ.get("TASKMUON_MAMBA_WD_MULT", "0.50"))
+TASKMUON_SMALL_MATRIX_ADAMW = os.environ.get("TASKMUON_SMALL_MATRIX_ADAMW", "1") == "1"
+TASKMUON_MUON_MIN_DIM = int(os.environ.get("TASKMUON_MUON_MIN_DIM", "129"))
+TASKMUON_MUON_MIN_NUMEL = int(os.environ.get("TASKMUON_MUON_MIN_NUMEL", "262144"))
+TASKMUON_SMALL_MATRIX_LR = float(os.environ.get("TASKMUON_SMALL_MATRIX_LR", "0.02"))
+TASKMUON_SMALL_MATRIX_WD = float(os.environ.get("TASKMUON_SMALL_MATRIX_WD", "0.05"))
+
+# TargetAware Muon+AdamW optimizer experiment.
+# Big dense FFN/attention matrices use Muon by default; Mamba/SSM, bigram,
+# embeddings, small/control params use AdamW by default. A loss-gap schedule
+# replaces the wallclock cosine schedule when this optimizer is enabled.
+TARGET_AWARE_OPT_ENABLED = os.environ.get("TARGET_AWARE_OPT_ENABLED", "1") == "1"
+TA_TARGET_LOSS = float(os.environ.get("TA_TARGET_LOSS", "2.80"))
+TA_INITIAL_GAP = float(os.environ.get("TA_INITIAL_GAP", "0.0"))  # 0 = infer from first training loss
+TA_GAP_EXPONENT = float(os.environ.get("TA_GAP_EXPONENT", "0.50"))
+TA_MIN_LR_SCALE = float(os.environ.get("TA_MIN_LR_SCALE", "0.08"))
+TA_MAX_LR_SCALE = float(os.environ.get("TA_MAX_LR_SCALE", "1.00"))
+TA_WARMUP_STEPS = int(os.environ.get("TA_WARMUP_STEPS", "80"))
+TA_SNR_ENABLED = os.environ.get("TA_SNR_ENABLED", "1") == "1"
+TA_SNR_BETA = float(os.environ.get("TA_SNR_BETA", "0.98"))
+TA_SNR_MIN_GATE = float(os.environ.get("TA_SNR_MIN_GATE", "0.35"))
+TA_SNR_MAX_GATE = float(os.environ.get("TA_SNR_MAX_GATE", "1.00"))
+TA_ADAM_BETA1 = float(os.environ.get("TA_ADAM_BETA1", "0.90"))
+TA_ADAM_BETA2 = float(os.environ.get("TA_ADAM_BETA2", "0.95"))
+TA_ADAM_EPS = float(os.environ.get("TA_ADAM_EPS", "1e-8"))
+TA_MUON_MOMENTUM = float(os.environ.get("TA_MUON_MOMENTUM", "0.95"))
+TA_MUON_BACKEND_STEPS = int(os.environ.get("TA_MUON_BACKEND_STEPS", str(MUON_BACKEND_STEPS)))
+TA_MUON_NESTEROV = os.environ.get("TA_MUON_NESTEROV", "1") == "1"
+# Role LRs/WDs. Muon LRs are Muon-scale; AdamW LRs are smaller.
+TA_FFN_MUON_LR = float(os.environ.get("TA_FFN_MUON_LR", str(MATRIX_LR)))
+TA_ATTN_MUON_LR = float(os.environ.get("TA_ATTN_MUON_LR", str(MATRIX_LR)))
+TA_FFN_WD = float(os.environ.get("TA_FFN_WD", str(WEIGHT_DECAY)))
+TA_ATTN_WD = float(os.environ.get("TA_ATTN_WD", str(WEIGHT_DECAY)))
+TA_MAMBA_IN_OPT = os.environ.get("TA_MAMBA_IN_OPT", "adamw").lower()  # adamw or muon
+TA_MAMBA_OUT_OPT = os.environ.get("TA_MAMBA_OUT_OPT", "adamw").lower()  # adamw or muon
+TA_MAMBA_IN_LR = float(os.environ.get("TA_MAMBA_IN_LR", "0.006"))
+TA_MAMBA_IN_WD = float(os.environ.get("TA_MAMBA_IN_WD", "0.0"))
+TA_MAMBA_OUT_LR = float(os.environ.get("TA_MAMBA_OUT_LR", "0.006"))
+TA_MAMBA_OUT_WD = float(os.environ.get("TA_MAMBA_OUT_WD", "0.02"))
+TA_MAMBA_OTHER_LR = float(os.environ.get("TA_MAMBA_OTHER_LR", "0.003"))
+TA_MAMBA_OTHER_WD = float(os.environ.get("TA_MAMBA_OTHER_WD", "0.0"))
+TA_MAMBA_DYN_LR = float(os.environ.get("TA_MAMBA_DYN_LR", "0.002"))
+TA_MAMBA_DYN_WD = float(os.environ.get("TA_MAMBA_DYN_WD", "0.0"))
+TA_EMBED_LR = float(os.environ.get("TA_EMBED_LR", str(EMBED_LR)))
+TA_EMBED_WD = float(os.environ.get("TA_EMBED_WD", "0.01"))
+TA_EMBED_PROJ_LR = float(os.environ.get("TA_EMBED_PROJ_LR", "0.015"))
+TA_EMBED_PROJ_WD = float(os.environ.get("TA_EMBED_PROJ_WD", "0.02"))
+TA_BIGRAM_LR = float(os.environ.get("TA_BIGRAM_LR", "0.015"))
+TA_BIGRAM_WD = float(os.environ.get("TA_BIGRAM_WD", "0.02"))
+TA_SMALL_MATRIX_LR = float(os.environ.get("TA_SMALL_MATRIX_LR", "0.015"))
+TA_SMALL_MATRIX_WD = float(os.environ.get("TA_SMALL_MATRIX_WD", "0.02"))
+TA_CONTROL_LR = float(os.environ.get("TA_CONTROL_LR", str(SCALAR_LR)))
+TA_CONTROL_WD = float(os.environ.get("TA_CONTROL_WD", "0.0"))
+TA_MUON_MIN_DIM = int(os.environ.get("TA_MUON_MIN_DIM", "129"))
+TA_MUON_MIN_NUMEL = int(os.environ.get("TA_MUON_MIN_NUMEL", "262144"))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"k35: enabled={K35_ENABLED}, full_ffn_idxs={K35_FULL_FFN_IDXS}, full_hidden={FULL_FFN_HIDDEN}, ssm_hidden={SSM_FFN_HIDDEN}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("k35_targetaware_defaults: K35 architecture + TargetAwareMuonAdam optimizer; FFN/attention Muon, Mamba AdamW by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"full_taskmuon: enabled={FULL_TASKMUON_ENABLED}, trust_clip={FULL_TASKMUON_TRUST_CLIP}, "
+    f"mamba_in/out={TASKMUON_MAMBA_IN_LR}/{TASKMUON_MAMBA_OUT_LR}, "
+    f"mamba_bc/dt_rows={TASKMUON_MAMBA_BC_ROW_LR}/{TASKMUON_MAMBA_DT_ROW_LR}, "
+    f"attn_qkv/out={TASKMUON_ATTN_QKV_LR}/{TASKMUON_ATTN_OUT_LR}, ffn={TASKMUON_FFN_LR}, "
+    f"small_matrix_adamw={TASKMUON_SMALL_MATRIX_ADAMW}"
+)
+log0(
+    f"target_aware_optimizer: enabled={TARGET_AWARE_OPT_ENABLED}, target_loss={TA_TARGET_LOSS}, "
+    f"gap_exp={TA_GAP_EXPONENT}, lr_floor={TA_MIN_LR_SCALE}, "
+    f"snr={TA_SNR_ENABLED}, snr_beta={TA_SNR_BETA}, "
+    f"snr_gate=[{TA_SNR_MIN_GATE},{TA_SNR_MAX_GATE}], "
+    f"mamba_in/out_opt={TA_MAMBA_IN_OPT}/{TA_MAMBA_OUT_OPT}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3, hidden_dim=None):
+        super().__init__()
+        hidden = int(hidden_dim) if hidden_dim is not None and int(hidden_dim) > 0 else d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        self.layer_ffn_hidden = []
+        full_ffn_set = set(K35_FULL_FFN_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            if not K35_ENABLED:
+                ffn_hidden_i = D_MODEL * FFN_MULT
+            elif i in attn_set or i in full_ffn_set:
+                ffn_hidden_i = FULL_FFN_HIDDEN
+            else:
+                ffn_hidden_i = SSM_FFN_HIDDEN
+            self.layer_ffn_hidden.append(int(ffn_hidden_i))
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, ffn_hidden=ffn_hidden_i))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, ffn_hidden=ffn_hidden_i))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+def _set_mamba_inproj_row_multipliers(model):
+    """Attach row multipliers to Mamba in_proj weights for role-aware Muon."""
+    for mod in model.modules():
+        if not isinstance(mod, SelectiveSSMBlock):
+            continue
+        m = mod.mamba
+        p = m.in_proj.weight
+        try:
+            d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+            ngroups = getattr(m, "ngroups", 1)
+            d_state = m.d_state
+            nheads = m.nheads
+            total = p.shape[0]
+            expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+            d_mlp = max(0, (total - expected) // 2)
+            rm = torch.ones(total, dtype=torch.float32) * float(TASKMUON_MAMBA_IN_LR)
+            offset = 2 * d_mlp + d_inner if d_mlp > 0 else d_inner
+            x_rows = d_inner
+            bc_rows = 2 * ngroups * d_state
+            if offset + x_rows + bc_rows <= total:
+                rm[offset + x_rows: offset + x_rows + bc_rows] = float(TASKMUON_MAMBA_BC_ROW_LR)
+            if nheads <= total:
+                rm[-nheads:] = float(TASKMUON_MAMBA_DT_ROW_LR)
+            p._muon_row_mult = rm
+            p._muon_shape_scale_cap = 1.0
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+        except Exception:
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+
+
+def _set_attn_qkv_row_multipliers(p):
+    rm = torch.ones(p.shape[0], dtype=torch.float32) * float(TASKMUON_ATTN_QKV_LR)
+    p._muon_row_mult = rm
+    if FULL_TASKMUON_TRUST_CLIP:
+        p._muon_trust_ratio = TASKMUON_ATTN_TRUST
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    shape_scale = (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    cap = getattr(p, "_muon_shape_scale_cap", None)
+                    if cap is not None:
+                        shape_scale = min(float(shape_scale), float(cap))
+                    upd_orth = upd_orth * shape_scale
+                    upd = upd_orth.reshape(upd.shape)
+                row_mult = getattr(p, "_muon_row_mult", None)
+                if row_mult is not None and upd.ndim >= 2:
+                    rm = row_mult.to(device=upd.device, dtype=upd.dtype)
+                    upd = upd * rm.view(-1, *([1] * (upd.ndim - 1)))
+                trust = getattr(p, "_muon_trust_ratio", None)
+                if trust is not None and trust > 0:
+                    u_rms = upd.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    w_rms = p.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    scale = torch.clamp((float(trust) * w_rms) / u_rms, max=1.0)
+                    upd = upd * scale.to(dtype=upd.dtype)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+
+class TargetAwareMuonAdam(torch.optim.Optimizer):
+    """
+    Unified Target-Aware Muon+AdamW optimizer.
+
+    - use_muon=True groups use Muon-style momentum + Newton-Schulz.
+    - use_muon=False groups use AdamW.
+    - A loss-gap multiplier and optional scalar gradient-SNR gate modulate all groups.
+
+    SNR state is scalar-per-tensor, not full gradient EMA tensors, to avoid huge
+    overhead in this 600s race setting.
+    """
+    def __init__(self, param_groups):
+        defaults = dict(lr=1e-3, base_lr=1e-3, weight_decay=0.0, use_muon=False, role="generic", snr_enabled=True)
+        super().__init__(param_groups, defaults)
+        self.target_loss = TA_TARGET_LOSS
+        self.initial_gap = TA_INITIAL_GAP if TA_INITIAL_GAP > 0 else None
+        self.gap_exponent = TA_GAP_EXPONENT
+        self.min_lr_scale = TA_MIN_LR_SCALE
+        self.max_lr_scale = TA_MAX_LR_SCALE
+        self.warmup_steps = TA_WARMUP_STEPS
+        self.snr_enabled = TA_SNR_ENABLED
+        self.snr_beta = TA_SNR_BETA
+        self.snr_min = TA_SNR_MIN_GATE
+        self.snr_max = TA_SNR_MAX_GATE
+        self.beta1 = TA_ADAM_BETA1
+        self.beta2 = TA_ADAM_BETA2
+        self.eps = TA_ADAM_EPS
+        self.muon_momentum = TA_MUON_MOMENTUM
+        self.backend_steps = TA_MUON_BACKEND_STEPS
+        self.nesterov = TA_MUON_NESTEROV
+        self._step = 0
+        self.last_loss = None
+        self.last_gap_mult = 1.0
+        self.last_warmup_mult = 1.0
+        self.last_snr_gate = 1.0
+
+    def _gap_mult(self, current_loss):
+        if current_loss is None:
+            return 1.0
+        try:
+            loss_val = float(current_loss.detach().float().item()) if torch.is_tensor(current_loss) else float(current_loss)
+        except Exception:
+            return 1.0
+        self.last_loss = loss_val
+        gap = max(loss_val - self.target_loss, 0.0)
+        if self.initial_gap is None:
+            self.initial_gap = max(gap, 1e-6)
+        ratio = gap / max(self.initial_gap, 1e-6)
+        mult = ratio ** self.gap_exponent
+        mult = min(max(mult, self.min_lr_scale), self.max_lr_scale)
+        self.last_gap_mult = float(mult)
+        return float(mult)
+
+    def _snr_gate(self, g, state, group):
+        if (not self.snr_enabled) or (not group.get("snr_enabled", True)):
+            return None
+        # First few steps: do not gate before the EMA is meaningful.
+        if self._step <= 1:
+            return None
+        rms = g.detach().float().pow(2).mean().sqrt()
+        if "grad_rms_ema" not in state:
+            state["grad_rms_ema"] = rms.clone()
+            state["grad_rms2_ema"] = (rms * rms).clone()
+            return None
+        beta = self.snr_beta
+        state["grad_rms_ema"].mul_(beta).add_(rms, alpha=1.0 - beta)
+        state["grad_rms2_ema"].mul_(beta).add_(rms * rms, alpha=1.0 - beta)
+        mean = state["grad_rms_ema"]
+        var = (state["grad_rms2_ema"] - mean * mean).clamp_min(1e-12)
+        snr = (mean * mean) / var
+        gate = snr / (snr + 1.0)
+        return gate.clamp(float(self.snr_min), float(self.snr_max))
+
+    @torch.no_grad()
+    def step(self, closure=None, current_loss=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        self._step += 1
+        gap_mult = self._gap_mult(current_loss)
+        warmup_mult = min(self._step / max(1, self.warmup_steps), 1.0)
+        self.last_warmup_mult = float(warmup_mult)
+        gate_sum, gate_count = 0.0, 0
+
+        for group in self.param_groups:
+            base_lr = float(group.get("base_lr", group.get("lr", 1e-3)))
+            wd = float(group.get("weight_decay", 0.0))
+            use_muon = bool(group.get("use_muon", False))
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad
+                state = self.state[p]
+                snr_gate = self._snr_gate(g, state, group)
+                if snr_gate is not None:
+                    gate_sum += snr_gate.detach()
+                    gate_count += 1
+                lr = base_lr * warmup_mult * gap_mult
+                if lr <= 0:
+                    continue
+
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+
+                if use_muon and p.ndim >= 2:
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(self.muon_momentum).add_(g)
+                    upd = g.add(buf, alpha=self.muon_momentum) if self.nesterov else buf
+                    upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=self.backend_steps)
+                    shape_scale = (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = (upd_orth * shape_scale).reshape(upd.shape)
+                    if snr_gate is not None:
+                        upd = upd * snr_gate.to(device=upd.device, dtype=upd.dtype)
+                    p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+                else:
+                    if "exp_avg" not in state:
+                        state["exp_avg"] = torch.zeros_like(p)
+                        state["exp_avg_sq"] = torch.zeros_like(p)
+                        state["adam_step"] = 0
+                    state["adam_step"] += 1
+                    exp_avg = state["exp_avg"]
+                    exp_avg_sq = state["exp_avg_sq"]
+                    beta1, beta2 = self.beta1, self.beta2
+                    exp_avg.mul_(beta1).add_(g, alpha=1.0 - beta1)
+                    exp_avg_sq.mul_(beta2).addcmul_(g, g, value=1.0 - beta2)
+                    t = state["adam_step"]
+                    bc1 = 1.0 - beta1 ** t
+                    bc2 = 1.0 - beta2 ** t
+                    denom = (exp_avg_sq.sqrt() / math.sqrt(bc2)).add_(self.eps)
+                    upd = exp_avg / denom
+                    if snr_gate is not None:
+                        upd = upd * snr_gate.to(device=upd.device, dtype=upd.dtype)
+                    p.add_(upd.to(dtype=p.dtype), alpha=-(lr / bc1))
+
+        if gate_count:
+            try:
+                self.last_snr_gate = float((gate_sum / gate_count).item())
+            except Exception:
+                pass
+        return loss
+
+
+def build_target_aware_optimizer(model):
+    groups_by_key = {}
+    counts = {}
+    seen = set()
+
+    def count(role):
+        counts[role] = counts.get(role, 0) + 1
+
+    def add(role, p, lr, wd, use_muon=False, snr_enabled=True):
+        key = (role, float(lr), float(wd), bool(use_muon), bool(snr_enabled))
+        if key not in groups_by_key:
+            groups_by_key[key] = {
+                "params": [], "lr": float(lr), "base_lr": float(lr),
+                "weight_decay": float(wd), "use_muon": bool(use_muon),
+                "role": role, "snr_enabled": bool(snr_enabled),
+            }
+        groups_by_key[key]["params"].append(p)
+        count(role + ("_muon" if use_muon else "_adamw"))
+
+    def is_mamba_dyn(name):
+        return any(x in name for x in ("A_log", "D", "dt_bias"))
+
+    for name, p in model.named_parameters():
+        try:
+            p._pg_name = name
+        except Exception:
+            pass
+        dp = p.data_ptr()
+        if dp in seen:
+            continue
+        seen.add(dp)
+        is_control = any(c in name for c in CTRL_PATTERNS) or getattr(p, "_no_weight_decay", False) or p.ndim < 2
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            add("embed", p, TA_EMBED_LR, TA_EMBED_WD, use_muon=False, snr_enabled=False)
+        elif ".mamba." in name:
+            if is_mamba_dyn(name):
+                add("mamba_dyn", p, TA_MAMBA_DYN_LR, TA_MAMBA_DYN_WD, use_muon=False)
+            elif ".mamba.in_proj.weight" in name:
+                add("mamba_in", p, TA_MAMBA_IN_LR, TA_MAMBA_IN_WD, use_muon=(TA_MAMBA_IN_OPT == "muon"))
+            elif ".mamba.out_proj.weight" in name:
+                add("mamba_out", p, TA_MAMBA_OUT_LR, TA_MAMBA_OUT_WD, use_muon=(TA_MAMBA_OUT_OPT == "muon"))
+            else:
+                add("mamba_other", p, TA_MAMBA_OTHER_LR, TA_MAMBA_OTHER_WD, use_muon=False)
+        elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+            add("ffn", p, TA_FFN_MUON_LR, TA_FFN_WD, use_muon=True)
+        elif ".qkv.weight" in name or ".out_proj.weight" in name:
+            add("attention", p, TA_ATTN_MUON_LR, TA_ATTN_WD, use_muon=True)
+        elif name.startswith("bigram."):
+            add("bigram", p, TA_BIGRAM_LR, TA_BIGRAM_WD, use_muon=False)
+        elif "embed_proj" in name or "embed_proj_rev" in name:
+            add("embed_proj", p, TA_EMBED_PROJ_LR, TA_EMBED_PROJ_WD, use_muon=False)
+        elif is_control:
+            add("control", p, TA_CONTROL_LR, TA_CONTROL_WD, use_muon=False, snr_enabled=False)
+        elif p.ndim == 2 and (min(p.shape) < TA_MUON_MIN_DIM or p.numel() < TA_MUON_MIN_NUMEL):
+            add("small", p, TA_SMALL_MATRIX_LR, TA_SMALL_MATRIX_WD, use_muon=False)
+        elif p.ndim >= 2:
+            add("generic", p, MATRIX_LR, WEIGHT_DECAY, use_muon=True)
+        else:
+            add("control", p, TA_CONTROL_LR, TA_CONTROL_WD, use_muon=False, snr_enabled=False)
+
+    groups = list(groups_by_key.values())
+    opt = TargetAwareMuonAdam(groups)
+    n_muon = sum(len(g["params"]) for g in groups if g.get("use_muon", False))
+    n_adam = sum(len(g["params"]) for g in groups if not g.get("use_muon", False))
+    log0(f"Optimizer split: TARGET_AWARE_MUON_ADAM groups={len(groups)}, muon_params={n_muon}, adamw_params={n_adam}")
+    log0("TargetAware roles: " + ", ".join(f"{k}={v}" for k, v in sorted(counts.items())))
+    return opt, None, []
+
+def build_optimizers(model):
+    if TARGET_AWARE_OPT_ENABLED:
+        return build_target_aware_optimizer(model)
+    if FULL_TASKMUON_ENABLED:
+        _set_mamba_inproj_row_multipliers(model)
+
+    muon_groups_by_role = {}
+    scalar_params, embed_params, small_matrix_params = [], [], []
+    role_counts = {}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def count(role):
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    def add_muon(role, p, lr_mult=1.0, wd_mult=1.0, trust=None, shape_cap=None):
+        if trust is not None and FULL_TASKMUON_TRUST_CLIP:
+            p._muon_trust_ratio = float(trust)
+        if shape_cap is not None:
+            p._muon_shape_scale_cap = float(shape_cap)
+        if role not in muon_groups_by_role:
+            muon_groups_by_role[role] = {
+                "params": [],
+                "lr": MATRIX_LR * lr_mult,
+                "base_lr": MATRIX_LR * lr_mult,
+                "weight_decay": WEIGHT_DECAY * wd_mult,
+                "role": role,
+            }
+        muon_groups_by_role[role]["params"].append(p)
+        count(role)
+
+    for name, p in model.named_parameters():
+        try:
+            p._pg_name = name
+        except Exception:
+            pass
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            count("embed_adamw")
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS) or getattr(p, "_no_weight_decay", False) or p.ndim < 2
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if is_control:
+            scalar_params.append(p)
+            count("scalar_adamw")
+            continue
+
+        if TASKMUON_SMALL_MATRIX_ADAMW and p.ndim == 2 and (min(p.shape) < TASKMUON_MUON_MIN_DIM or p.numel() < TASKMUON_MUON_MIN_NUMEL):
+            small_matrix_params.append(p)
+            count("small_matrix_adamw")
+            continue
+
+        if FULL_TASKMUON_ENABLED:
+            if ".mamba.in_proj.weight" in name:
+                add_muon("mamba_in_proj", p, lr_mult=TASKMUON_MAMBA_IN_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_IN_TRUST, shape_cap=1.0)
+            elif ".mamba.out_proj.weight" in name:
+                add_muon("mamba_out_proj", p, lr_mult=TASKMUON_MAMBA_OUT_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_OUT_TRUST, shape_cap=1.0)
+            elif ".qkv.weight" in name:
+                _set_attn_qkv_row_multipliers(p)
+                add_muon("attn_qkv", p, lr_mult=TASKMUON_ATTN_QKV_LR,
+                         wd_mult=1.0, trust=TASKMUON_ATTN_TRUST)
+            elif ".out_proj.weight" in name:
+                add_muon("attn_out_proj", p, lr_mult=TASKMUON_ATTN_OUT_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+                add_muon("ffn", p, lr_mult=TASKMUON_FFN_LR,
+                         wd_mult=1.0, trust=TASKMUON_FFN_TRUST)
+            elif "embed_proj" in name or "embed_proj_rev" in name:
+                add_muon("embed_proj", p, lr_mult=TASKMUON_EMBED_PROJ_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif p.ndim == 2:
+                add_muon("generic", p, lr_mult=1.0, wd_mult=1.0)
+            elif (not MUON_ONLY_2D) and p.ndim >= 2:
+                add_muon("generic_nd", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_params.append(p)
+                count("scalar_adamw")
+        else:
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)):
+                add_muon("matrix", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_params.append(p)
+                count("scalar_adamw")
+
+    muon_groups = list(muon_groups_by_role.values())
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adam_groups = [
+        {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR, "role": "scalar"},
+        {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR, "role": "embed"},
+    ]
+    if small_matrix_params:
+        adam_groups.append({
+            "params": small_matrix_params,
+            "lr": TASKMUON_SMALL_MATRIX_LR,
+            "weight_decay": TASKMUON_SMALL_MATRIX_WD,
+            "base_lr": TASKMUON_SMALL_MATRIX_LR,
+            "role": "small_matrix",
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    n_muon_params = sum(len(g["params"]) for g in muon_groups)
+    log0(
+        f"Optimizer split: matrix={n_muon_params} (Muon/{len(muon_groups)} groups), "
+        f"scalar/control={len(scalar_params)} (AdamW), small_matrix={len(small_matrix_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: full_taskmuon={int(FULL_TASKMUON_ENABLED)} muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    log0("FullTaskMuon roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items())))
+    mat_params = [p for g in muon_groups for p in g["params"]]
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        if not TARGET_AWARE_OPT_ENABLED:
+            for group in optimizer_adamw.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            if optimizer_muon is not None:
+                for group in optimizer_muon.param_groups:
+                    group["lr"] = group["base_lr"] * mul
+                # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+                if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                    frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                    cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                    for group in optimizer_muon.param_groups:
+                        group["momentum"] = cur_momentum
+        else:
+            # TargetAwareMuonAdam owns warmup / loss-gap / SNR modulation.
+            mul = getattr(optimizer_adamw, "last_gap_mult", 1.0)
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        current_loss_for_opt = (_loss_accum / float(max(GRAD_ACCUM, 1))).detach()
+
+        if TARGET_AWARE_OPT_ENABLED:
+            # H100 uses bf16 AMP, so GradScaler is disabled. If a scaler is active,
+            # grads have already been unscaled above; call optimizer directly so
+            # current_loss can drive loss-gap scheduling.
+            optimizer_adamw.step(current_loss=current_loss_for_opt)
+            if scaler.is_enabled():
+                scaler.update()
+        elif scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+        for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+            try:
+                if _ldr is not None:
+                    _ldr.shutdown()
+            except Exception:
+                pass
+        return
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_taskmuon.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_k35_taskmuon.py
@@ -1,0 +1,2700 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+# K35: keep independent FFN compute in every layer, but shrink only ordinary SSM-layer FFNs.
+# Attention layer(s) and final layer stay full-width; SSM layers default to hidden=896.
+K35_ENABLED = os.environ.get("K35_ENABLED", "1") == "1"
+K35_FULL_FFN_IDXS = [int(x) for x in os.environ.get("K35_FULL_FFN_IDXS", "6,9").split(",") if x.strip()]
+SSM_FFN_HIDDEN = int(os.environ.get("SSM_FFN_HIDDEN", "896"))
+FULL_FFN_HIDDEN = int(os.environ.get("FULL_FFN_HIDDEN", str(D_MODEL * FFN_MULT)))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "320"))  # K35 default: tighter tied factorization for ~35M params
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# Full-model TaskMuon: role-aware Muon scaling for the K35/full-FFN family.
+# The goal is calmer SSM dynamics while keeping FFN/attention matrices learning fast.
+FULL_TASKMUON_ENABLED = os.environ.get("FULL_TASKMUON_ENABLED", "1") == "1"
+FULL_TASKMUON_TRUST_CLIP = os.environ.get("FULL_TASKMUON_TRUST_CLIP", "1") == "1"
+TASKMUON_FFN_LR = float(os.environ.get("TASKMUON_FFN_LR", "0.90"))
+TASKMUON_ATTN_QKV_LR = float(os.environ.get("TASKMUON_ATTN_QKV_LR", "0.90"))
+TASKMUON_ATTN_OUT_LR = float(os.environ.get("TASKMUON_ATTN_OUT_LR", "0.75"))
+TASKMUON_MAMBA_IN_LR = float(os.environ.get("TASKMUON_MAMBA_IN_LR", "0.65"))
+TASKMUON_MAMBA_OUT_LR = float(os.environ.get("TASKMUON_MAMBA_OUT_LR", "0.55"))
+TASKMUON_EMBED_PROJ_LR = float(os.environ.get("TASKMUON_EMBED_PROJ_LR", "0.85"))
+TASKMUON_MAMBA_BC_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_BC_ROW_LR", "0.30"))
+TASKMUON_MAMBA_DT_ROW_LR = float(os.environ.get("TASKMUON_MAMBA_DT_ROW_LR", "0.10"))
+TASKMUON_FFN_TRUST = float(os.environ.get("TASKMUON_FFN_TRUST", "0.020"))
+TASKMUON_ATTN_TRUST = float(os.environ.get("TASKMUON_ATTN_TRUST", "0.015"))
+TASKMUON_MAMBA_IN_TRUST = float(os.environ.get("TASKMUON_MAMBA_IN_TRUST", "0.006"))
+TASKMUON_MAMBA_OUT_TRUST = float(os.environ.get("TASKMUON_MAMBA_OUT_TRUST", "0.008"))
+TASKMUON_MAMBA_WD_MULT = float(os.environ.get("TASKMUON_MAMBA_WD_MULT", "0.50"))
+TASKMUON_SMALL_MATRIX_ADAMW = os.environ.get("TASKMUON_SMALL_MATRIX_ADAMW", "1") == "1"
+TASKMUON_MUON_MIN_DIM = int(os.environ.get("TASKMUON_MUON_MIN_DIM", "129"))
+TASKMUON_MUON_MIN_NUMEL = int(os.environ.get("TASKMUON_MUON_MIN_NUMEL", "262144"))
+TASKMUON_SMALL_MATRIX_LR = float(os.environ.get("TASKMUON_SMALL_MATRIX_LR", "0.02"))
+TASKMUON_SMALL_MATRIX_WD = float(os.environ.get("TASKMUON_SMALL_MATRIX_WD", "0.05"))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"k35: enabled={K35_ENABLED}, full_ffn_idxs={K35_FULL_FFN_IDXS}, full_hidden={FULL_FFN_HIDDEN}, ssm_hidden={SSM_FFN_HIDDEN}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("k35_defaults: tied head, EMBED_DIM=320, BIGRAM off, SSM FFN hidden=896, full FFNs on layers 6/9, RoPE on, FullTaskMuon on")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+log0(
+    f"full_taskmuon: enabled={FULL_TASKMUON_ENABLED}, trust_clip={FULL_TASKMUON_TRUST_CLIP}, "
+    f"mamba_in/out={TASKMUON_MAMBA_IN_LR}/{TASKMUON_MAMBA_OUT_LR}, "
+    f"mamba_bc/dt_rows={TASKMUON_MAMBA_BC_ROW_LR}/{TASKMUON_MAMBA_DT_ROW_LR}, "
+    f"attn_qkv/out={TASKMUON_ATTN_QKV_LR}/{TASKMUON_ATTN_OUT_LR}, ffn={TASKMUON_FFN_LR}, "
+    f"small_matrix_adamw={TASKMUON_SMALL_MATRIX_ADAMW}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3, hidden_dim=None):
+        super().__init__()
+        hidden = int(hidden_dim) if hidden_dim is not None and int(hidden_dim) > 0 else d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, ffn_hidden=None):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult, hidden_dim=ffn_hidden)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        self.layer_ffn_hidden = []
+        full_ffn_set = set(K35_FULL_FFN_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            if not K35_ENABLED:
+                ffn_hidden_i = D_MODEL * FFN_MULT
+            elif i in attn_set or i in full_ffn_set:
+                ffn_hidden_i = FULL_FFN_HIDDEN
+            else:
+                ffn_hidden_i = SSM_FFN_HIDDEN
+            self.layer_ffn_hidden.append(int(ffn_hidden_i))
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, ffn_hidden=ffn_hidden_i))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, ffn_hidden=ffn_hidden_i))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+def _set_mamba_inproj_row_multipliers(model):
+    """Attach row multipliers to Mamba in_proj weights for role-aware Muon."""
+    for mod in model.modules():
+        if not isinstance(mod, SelectiveSSMBlock):
+            continue
+        m = mod.mamba
+        p = m.in_proj.weight
+        try:
+            d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+            ngroups = getattr(m, "ngroups", 1)
+            d_state = m.d_state
+            nheads = m.nheads
+            total = p.shape[0]
+            expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+            d_mlp = max(0, (total - expected) // 2)
+            rm = torch.ones(total, dtype=torch.float32) * float(TASKMUON_MAMBA_IN_LR)
+            offset = 2 * d_mlp + d_inner if d_mlp > 0 else d_inner
+            x_rows = d_inner
+            bc_rows = 2 * ngroups * d_state
+            if offset + x_rows + bc_rows <= total:
+                rm[offset + x_rows: offset + x_rows + bc_rows] = float(TASKMUON_MAMBA_BC_ROW_LR)
+            if nheads <= total:
+                rm[-nheads:] = float(TASKMUON_MAMBA_DT_ROW_LR)
+            p._muon_row_mult = rm
+            p._muon_shape_scale_cap = 1.0
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+        except Exception:
+            if FULL_TASKMUON_TRUST_CLIP:
+                p._muon_trust_ratio = TASKMUON_MAMBA_IN_TRUST
+
+
+def _set_attn_qkv_row_multipliers(p):
+    rm = torch.ones(p.shape[0], dtype=torch.float32) * float(TASKMUON_ATTN_QKV_LR)
+    p._muon_row_mult = rm
+    if FULL_TASKMUON_TRUST_CLIP:
+        p._muon_trust_ratio = TASKMUON_ATTN_TRUST
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    shape_scale = (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    cap = getattr(p, "_muon_shape_scale_cap", None)
+                    if cap is not None:
+                        shape_scale = min(float(shape_scale), float(cap))
+                    upd_orth = upd_orth * shape_scale
+                    upd = upd_orth.reshape(upd.shape)
+                row_mult = getattr(p, "_muon_row_mult", None)
+                if row_mult is not None and upd.ndim >= 2:
+                    rm = row_mult.to(device=upd.device, dtype=upd.dtype)
+                    upd = upd * rm.view(-1, *([1] * (upd.ndim - 1)))
+                trust = getattr(p, "_muon_trust_ratio", None)
+                if trust is not None and trust > 0:
+                    u_rms = upd.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    w_rms = p.float().pow(2).mean().sqrt().clamp_min(1e-12)
+                    scale = torch.clamp((float(trust) * w_rms) / u_rms, max=1.0)
+                    upd = upd * scale.to(dtype=upd.dtype)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    if FULL_TASKMUON_ENABLED:
+        _set_mamba_inproj_row_multipliers(model)
+
+    muon_groups_by_role = {}
+    scalar_params, embed_params, small_matrix_params = [], [], []
+    role_counts = {}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def count(role):
+        role_counts[role] = role_counts.get(role, 0) + 1
+
+    def add_muon(role, p, lr_mult=1.0, wd_mult=1.0, trust=None, shape_cap=None):
+        if trust is not None and FULL_TASKMUON_TRUST_CLIP:
+            p._muon_trust_ratio = float(trust)
+        if shape_cap is not None:
+            p._muon_shape_scale_cap = float(shape_cap)
+        if role not in muon_groups_by_role:
+            muon_groups_by_role[role] = {
+                "params": [],
+                "lr": MATRIX_LR * lr_mult,
+                "base_lr": MATRIX_LR * lr_mult,
+                "weight_decay": WEIGHT_DECAY * wd_mult,
+                "role": role,
+            }
+        muon_groups_by_role[role]["params"].append(p)
+        count(role)
+
+    for name, p in model.named_parameters():
+        try:
+            p._pg_name = name
+        except Exception:
+            pass
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            count("embed_adamw")
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS) or getattr(p, "_no_weight_decay", False) or p.ndim < 2
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if is_control:
+            scalar_params.append(p)
+            count("scalar_adamw")
+            continue
+
+        if TASKMUON_SMALL_MATRIX_ADAMW and p.ndim == 2 and (min(p.shape) < TASKMUON_MUON_MIN_DIM or p.numel() < TASKMUON_MUON_MIN_NUMEL):
+            small_matrix_params.append(p)
+            count("small_matrix_adamw")
+            continue
+
+        if FULL_TASKMUON_ENABLED:
+            if ".mamba.in_proj.weight" in name:
+                add_muon("mamba_in_proj", p, lr_mult=TASKMUON_MAMBA_IN_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_IN_TRUST, shape_cap=1.0)
+            elif ".mamba.out_proj.weight" in name:
+                add_muon("mamba_out_proj", p, lr_mult=TASKMUON_MAMBA_OUT_LR,
+                         wd_mult=TASKMUON_MAMBA_WD_MULT, trust=TASKMUON_MAMBA_OUT_TRUST, shape_cap=1.0)
+            elif ".qkv.weight" in name:
+                _set_attn_qkv_row_multipliers(p)
+                add_muon("attn_qkv", p, lr_mult=TASKMUON_ATTN_QKV_LR,
+                         wd_mult=1.0, trust=TASKMUON_ATTN_TRUST)
+            elif ".out_proj.weight" in name:
+                add_muon("attn_out_proj", p, lr_mult=TASKMUON_ATTN_OUT_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+                add_muon("ffn", p, lr_mult=TASKMUON_FFN_LR,
+                         wd_mult=1.0, trust=TASKMUON_FFN_TRUST)
+            elif "embed_proj" in name or "embed_proj_rev" in name:
+                add_muon("embed_proj", p, lr_mult=TASKMUON_EMBED_PROJ_LR,
+                         wd_mult=0.8, trust=TASKMUON_ATTN_TRUST)
+            elif p.ndim == 2:
+                add_muon("generic", p, lr_mult=1.0, wd_mult=1.0)
+            elif (not MUON_ONLY_2D) and p.ndim >= 2:
+                add_muon("generic_nd", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_params.append(p)
+                count("scalar_adamw")
+        else:
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)):
+                add_muon("matrix", p, lr_mult=1.0, wd_mult=1.0)
+            else:
+                scalar_params.append(p)
+                count("scalar_adamw")
+
+    muon_groups = list(muon_groups_by_role.values())
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adam_groups = [
+        {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR, "role": "scalar"},
+        {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR, "role": "embed"},
+    ]
+    if small_matrix_params:
+        adam_groups.append({
+            "params": small_matrix_params,
+            "lr": TASKMUON_SMALL_MATRIX_LR,
+            "weight_decay": TASKMUON_SMALL_MATRIX_WD,
+            "base_lr": TASKMUON_SMALL_MATRIX_LR,
+            "role": "small_matrix",
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adam_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    n_muon_params = sum(len(g["params"]) for g in muon_groups)
+    log0(
+        f"Optimizer split: matrix={n_muon_params} (Muon/{len(muon_groups)} groups), "
+        f"scalar/control={len(scalar_params)} (AdamW), small_matrix={len(small_matrix_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: full_taskmuon={int(FULL_TASKMUON_ENABLED)} muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    log0("FullTaskMuon roles: " + ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items())))
+    mat_params = [p for g in muon_groups for p in g["params"]]
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+        for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+            try:
+                if _ldr is not None:
+                    _ldr.shutdown()
+            except Exception:
+                pass
+        return
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_long_s4d.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_long_s4d.py
@@ -1,0 +1,2594 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# SSM/Mamba long-timescale initialization.
+# standard: original S4D-real A = 0.5, 1.5, ...
+# long:     all state channels log-spaced over long token-scale horizons
+# longmix:  mix fast + slow channels for both local syntax and 8192+ memory
+S4D_INIT_MODE = os.environ.get("S4D_INIT_MODE", "longmix").lower()
+LONG_S4D_TAU_MIN = float(os.environ.get("LONG_S4D_TAU_MIN", "8"))
+LONG_S4D_TAU_MAX = float(os.environ.get("LONG_S4D_TAU_MAX", "32768"))
+LONG_S4D_FAST_FRAC = float(os.environ.get("LONG_S4D_FAST_FRAC", "0.25"))
+LONG_S4D_FAST_TAU_MIN = float(os.environ.get("LONG_S4D_FAST_TAU_MIN", "4"))
+LONG_S4D_FAST_TAU_MAX = float(os.environ.get("LONG_S4D_FAST_TAU_MAX", "256"))
+LONG_S4D_SLOW_TAU_MIN = float(os.environ.get("LONG_S4D_SLOW_TAU_MIN", "256"))
+LONG_S4D_SLOW_TAU_MAX = float(os.environ.get("LONG_S4D_SLOW_TAU_MAX", "32768"))
+LONG_S4D_REVERSE = os.environ.get("LONG_S4D_REVERSE", "0") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}, s4d_mode={S4D_INIT_MODE}"
+)
+log0(
+    f"long_s4d: tau_min={LONG_S4D_TAU_MIN:g}, tau_max={LONG_S4D_TAU_MAX:g}, "
+    f"fast_frac={LONG_S4D_FAST_FRAC:g}, fast={LONG_S4D_FAST_TAU_MIN:g}-{LONG_S4D_FAST_TAU_MAX:g}, "
+    f"slow={LONG_S4D_SLOW_TAU_MIN:g}-{LONG_S4D_SLOW_TAU_MAX:g}, reverse={LONG_S4D_REVERSE}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def _long_s4d_a_vector(d_state: int, device, dtype):
+    """
+    Returns positive A magnitudes for Mamba A_log, where actual continuous A is -exp(A_log).
+
+    In standard S4D init, magnitudes are O(1..d_state), which can be too fast for
+    8192-token training. Long modes initialize some/all channels with much smaller
+    A magnitudes, giving slower decay / longer memory timescales.
+    """
+    if S4D_INIT_MODE == "standard":
+        return torch.arange(1, 2 * d_state, 2, device=device, dtype=torch.float32) / 2.0
+
+    if S4D_INIT_MODE == "long":
+        tau = torch.logspace(
+            math.log10(max(LONG_S4D_TAU_MIN, 1e-3)),
+            math.log10(max(LONG_S4D_TAU_MAX, LONG_S4D_TAU_MIN + 1e-3)),
+            steps=d_state,
+            device=device,
+            dtype=torch.float32,
+        )
+        a = 1.0 / tau
+    elif S4D_INIT_MODE == "longmix":
+        fast_n = int(round(d_state * max(0.0, min(1.0, LONG_S4D_FAST_FRAC))))
+        fast_n = max(1, min(d_state - 1, fast_n)) if d_state > 1 else d_state
+        slow_n = d_state - fast_n
+
+        fast_tau = torch.logspace(
+            math.log10(max(LONG_S4D_FAST_TAU_MIN, 1e-3)),
+            math.log10(max(LONG_S4D_FAST_TAU_MAX, LONG_S4D_FAST_TAU_MIN + 1e-3)),
+            steps=fast_n,
+            device=device,
+            dtype=torch.float32,
+        )
+        if slow_n > 0:
+            slow_tau = torch.logspace(
+                math.log10(max(LONG_S4D_SLOW_TAU_MIN, 1e-3)),
+                math.log10(max(LONG_S4D_SLOW_TAU_MAX, LONG_S4D_SLOW_TAU_MIN + 1e-3)),
+                steps=slow_n,
+                device=device,
+                dtype=torch.float32,
+            )
+            tau = torch.cat([fast_tau, slow_tau], dim=0)
+        else:
+            tau = fast_tau
+        a = 1.0 / tau
+    else:
+        raise ValueError(f"Unknown S4D_INIT_MODE={S4D_INIT_MODE!r}; use standard|long|longmix")
+
+    if LONG_S4D_REVERSE:
+        a = torch.flip(a, dims=[0])
+
+    # Keep A magnitudes strictly positive and numerically sane.
+    a = torch.clamp(a, min=1e-6, max=1e3)
+    return a.to(dtype=dtype)
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+
+    For 8192-context SSM training, S4D_INIT_MODE=longmix initializes a mix of
+    fast and slow decay channels instead of all-fast S4D-real channels.
+    """
+    initialized = 0
+    skipped = 0
+    first_stats_logged = False
+
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        a_init = _long_s4d_a_vector(d_state, A_log.device, A_log.dtype)
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+
+            if MASTER_PROCESS and not first_stats_logged:
+                a_float = a_init.float().reshape(-1, d_state)[0]
+                tau_float = (1.0 / torch.clamp(a_float, min=1e-12)).detach().cpu()
+                log0(
+                    f"[s4d_init] mode={S4D_INIT_MODE} example module={mod_name} "
+                    f"A[min,max]=({float(a_float.min()):.3e},{float(a_float.max()):.3e}) "
+                    f"tau[min,max]=({float(tau_float.min()):.1f},{float(tau_float.max()):.1f})"
+                )
+                first_stats_logged = True
+
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lora_ttt_eval.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lora_ttt_eval.py
@@ -1,0 +1,2183 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Eval-only score-first LoRA TTT config.
+# This script loads a checkpoint/artifact and adapts only LoRA adapters on
+# already-scored validation chunks.
+TTT_LORA_ENABLED = os.environ.get("TTT_LORA_ENABLED", "1") == "1"
+TTT_LORA_RANK = int(os.environ.get("TTT_LORA_RANK", "4"))
+TTT_LORA_ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "8.0"))
+TTT_LORA_STD = float(os.environ.get("TTT_LORA_STD", "0.01"))
+TTT_LORA_QKV = os.environ.get("TTT_LORA_QKV", "1") == "1"
+TTT_LORA_OUT = os.environ.get("TTT_LORA_OUT", "1") == "1"
+
+# Score-first adapter TTT runtime settings.
+ARTIFACT_PATH = os.environ.get("ARTIFACT_PATH", "/workspace/parameter-golf/final_model.int8.ptz")
+RUN_BASELINE = os.environ.get("RUN_BASELINE", "1") == "1"
+TTT_CHUNK_TOKENS = int(os.environ.get("TTT_CHUNK_TOKENS", "262144"))
+TTT_TRAIN_WINDOWS = int(os.environ.get("TTT_TRAIN_WINDOWS", "4"))
+TTT_EPOCHS = int(os.environ.get("TTT_EPOCHS", "1"))
+TTT_ADAPTER_LR = float(os.environ.get("TTT_ADAPTER_LR", "5e-4"))
+TTT_ADAPTER_WD = float(os.environ.get("TTT_ADAPTER_WD", "0.0"))
+TTT_LORA_DECAY = float(os.environ.get("TTT_LORA_DECAY", "0.995"))
+TTT_GRAD_CLIP = float(os.environ.get("TTT_GRAD_CLIP", "1.0"))
+TTT_OPT = os.environ.get("TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+TTT_MAX_CHUNKS = int(os.environ.get("TTT_MAX_CHUNKS", "0"))  # 0 = all
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Eval-time LoRA adapters. Zero-B init means loaded checkpoint behavior
+        # is exactly preserved before TTT adaptation.
+        self.ttt_lora_rank = TTT_LORA_RANK if TTT_LORA_ENABLED else 0
+        self.ttt_lora_scale = TTT_LORA_ALPHA / max(TTT_LORA_RANK, 1)
+        if self.ttt_lora_rank > 0 and TTT_LORA_QKV:
+            self.qkv_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.qkv_lora_B = nn.Parameter(torch.zeros(3 * d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.qkv_lora_A, std=TTT_LORA_STD)
+        else:
+            self.qkv_lora_A = None
+            self.qkv_lora_B = None
+
+        if self.ttt_lora_rank > 0 and TTT_LORA_OUT:
+            self.out_lora_A = nn.Parameter(torch.empty(self.ttt_lora_rank, d_model))
+            self.out_lora_B = nn.Parameter(torch.zeros(d_model, self.ttt_lora_rank))
+            nn.init.normal_(self.out_lora_A, std=TTT_LORA_STD)
+        else:
+            self.out_lora_A = None
+            self.out_lora_B = None
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv_raw = self.qkv(normed)
+        if self.qkv_lora_A is not None:
+            qkv_delta = F.linear(F.linear(normed, self.qkv_lora_A), self.qkv_lora_B)
+            qkv_raw = qkv_raw + self.ttt_lora_scale * qkv_delta
+        qkv = qkv_raw.reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        out = self.out_proj(attn_out)
+        if self.out_lora_A is not None:
+            out_delta = F.linear(F.linear(attn_out, self.out_lora_A), self.out_lora_B)
+            out = out + self.ttt_lora_scale * out_delta
+        x = x + self.attn_scale[None, None, :] * out
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Eval-only checkpoint loading + score-first LoRA TTT
+# -----------------------------------------------------------------------------
+def _try_torch_load_bytes(raw: bytes):
+    import io
+    try:
+        return torch.load(io.BytesIO(raw), map_location="cpu")
+    except Exception:
+        return None
+
+
+def load_checkpoint_state(path: str):
+    """
+    Loads either:
+      - raw torch state_dict / {"state_dict": ...}
+      - compressed int8 artifact from this script:
+          {"quantized": ..., "scales": ..., "passthrough": ...}
+    """
+    import io
+    p = Path(path)
+    if not p.exists():
+        raise FileNotFoundError(f"ARTIFACT_PATH not found: {path}")
+
+    raw = p.read_bytes()
+    obj = _try_torch_load_bytes(raw)
+
+    if obj is None:
+        # Try zstd, then zlib.
+        if _COMPRESSOR == "zstd":
+            try:
+                dctx = zstandard.ZstdDecompressor()
+                obj = torch.load(io.BytesIO(dctx.decompress(raw)), map_location="cpu")
+            except Exception:
+                obj = None
+        if obj is None:
+            try:
+                obj = torch.load(io.BytesIO(zlib.decompress(raw)), map_location="cpu")
+            except Exception as e:
+                raise RuntimeError(f"Could not load checkpoint/artifact {path}: {e}") from e
+
+    if isinstance(obj, dict) and "state_dict" in obj:
+        obj = obj["state_dict"]
+
+    if isinstance(obj, dict) and "quantized" in obj and "scales" in obj and "passthrough" in obj:
+        state = {}
+        for name, q in obj["quantized"].items():
+            s = obj["scales"][name]
+            if s.ndim > 0:
+                state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in obj["passthrough"].items():
+            state[name] = t
+        return state
+
+    if not isinstance(obj, dict):
+        raise RuntimeError(f"Unsupported checkpoint object type: {type(obj)}")
+    return obj
+
+
+def get_lora_params(model: nn.Module):
+    params = []
+    names = []
+    for name, p in model.named_parameters():
+        is_lora = (
+            "qkv_lora_A" in name or "qkv_lora_B" in name or
+            "out_lora_A" in name or "out_lora_B" in name
+        )
+        p.requires_grad_(is_lora)
+        if is_lora:
+            params.append(p)
+            names.append(name)
+    return names, params
+
+
+@torch.no_grad()
+def reset_lora_adapters(model: nn.Module):
+    for name, p in model.named_parameters():
+        if "lora_B" in name:
+            p.zero_()
+
+
+@torch.no_grad()
+def decay_lora_adapters(model: nn.Module, decay: float):
+    if decay >= 1.0:
+        return
+    for name, p in model.named_parameters():
+        if "lora_" in name:
+            p.mul_(decay)
+
+
+def logits_from_hidden(core, hidden):
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    return core.softcap * torch.tanh(logits / core.softcap)
+
+
+def score_window_batch(core, xn, yn, bb, hs, ib, stride):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    with torch.no_grad():
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, -stride:, :]
+            flat_y = y[:, -stride:].reshape(-1)
+            logits = logits_from_hidden(core, hidden_tail)
+            loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+    cnt = float(flat_y.numel())
+    p_tail = xn[:, -stride:].reshape(-1)
+    t_tail = yn[:, -stride:].reshape(-1)
+    b = bb[t_tail].astype(np.int16, copy=True)
+    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+    byt = float(b.astype(np.float64).sum())
+    return float(loss.detach().float().item()), cnt, byt
+
+
+def adapt_window_batch(core, xn, yn, stride):
+    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+        hidden = core(x, state=None, return_state=False)
+        hidden_tail = hidden[:, -stride:, :]
+        flat_y = y[:, -stride:].reshape(-1)
+        logits = logits_from_hidden(core, hidden_tail)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="mean")
+    return loss
+
+
+def make_windows(val_tokens, window_ids, seq_len, stride):
+    x_list, y_list = [], []
+    max_tok = val_tokens.size
+    for w in window_ids:
+        pos = int(w) * stride
+        if pos + seq_len + 1 <= max_tok:
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+    if not x_list:
+        return None, None
+    return np.stack(x_list), np.stack(y_list)
+
+
+def eval_score_first_lora_ttt(core, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first adapter TTT:
+      1. Score a contiguous range of sliding windows with current LoRA state.
+      2. Update only LoRA params using tail-token CE on already-scored windows.
+      3. Carry LoRA params to the next chunk.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core.train()  # adapters update; dropout absent
+    reset_lora_adapters(core)
+    lora_names, lora_params = get_lora_params(core)
+    n_lora = sum(p.numel() for p in lora_params)
+    log0(
+        f"LoRA TTT: params={len(lora_params)} ({n_lora:,}), rank={TTT_LORA_RANK}, "
+        f"alpha={TTT_LORA_ALPHA}, chunk_tokens={TTT_CHUNK_TOKENS}, "
+        f"train_windows/rank={TTT_TRAIN_WINDOWS}, epochs={TTT_EPOCHS}, "
+        f"lr={TTT_ADAPTER_LR}, decay={TTT_LORA_DECAY}, opt={TTT_OPT}"
+    )
+    if MASTER_PROCESS:
+        log0("  lora preview: " + ", ".join(lora_names[:8]) + ("..." if len(lora_names) > 8 else ""))
+
+    if len(lora_params) == 0:
+        raise RuntimeError("No LoRA params found. Check TTT_LORA_ENABLED and attention layer config.")
+
+    if TTT_OPT == "sgd":
+        opt = torch.optim.SGD(lora_params, lr=TTT_ADAPTER_LR, momentum=0.0, weight_decay=TTT_ADAPTER_WD)
+    else:
+        opt = torch.optim.AdamW(lora_params, lr=TTT_ADAPTER_LR, betas=(0.9, 0.95), weight_decay=TTT_ADAPTER_WD)
+
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+    total_windows = max(0, (total_tokens - seq_len) // stride + 1)
+    windows_per_chunk = max(1, TTT_CHUNK_TOKENS // stride)
+    n_chunks = (total_windows + windows_per_chunk - 1) // windows_per_chunk
+    if TTT_MAX_CHUNKS > 0:
+        n_chunks = min(n_chunks, TTT_MAX_CHUNKS)
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every = max(1, n_chunks // 10)
+
+    for ci in range(n_chunks):
+        w0 = ci * windows_per_chunk
+        w1 = min((ci + 1) * windows_per_chunk, total_windows)
+        n_local = max(0, w1 - w0)
+
+        # Score first: split this same global chunk across ranks.
+        local_start = w0 + (n_local * RANK) // WORLD_SIZE
+        local_end = w0 + (n_local * (RANK + 1)) // WORLD_SIZE
+
+        core.eval()
+        for wb in range(local_start, local_end, batch_windows):
+            we = min(wb + batch_windows, local_end)
+            ids = list(range(wb, we))
+            xn, yn = make_windows(val_tokens, ids, seq_len, stride)
+            if xn is None:
+                continue
+            l, c, b = score_window_batch(core, xn, yn, bb, hs, ib, stride)
+            loss_sum += l
+            tok_sum += c
+            byt_sum += b
+
+        # Then adapt on already-scored windows from this chunk only.
+        if TTT_TRAIN_WINDOWS > 0:
+            core.train()
+            n_train_total = max(TTT_TRAIN_WINDOWS * WORLD_SIZE, WORLD_SIZE)
+            sample_ids = np.linspace(w0, max(w0, w1 - 1), num=n_train_total, dtype=np.int64)
+            sample_ids = sample_ids[RANK::WORLD_SIZE][:TTT_TRAIN_WINDOWS]
+            sample_ids = [int(s) for s in sample_ids if local_start <= int(s) < local_end or w0 <= int(s) < w1]
+            if sample_ids:
+                xn, yn = make_windows(val_tokens, sample_ids, seq_len, stride)
+                if xn is not None:
+                    for _ in range(TTT_EPOCHS):
+                        opt.zero_grad(set_to_none=True)
+                        loss = adapt_window_batch(core, xn, yn, stride)
+                        loss.backward()
+                        for p in lora_params:
+                            if p.grad is not None:
+                                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        if TTT_GRAD_CLIP > 0:
+                            nn.utils.clip_grad_norm_(lora_params, TTT_GRAD_CLIP)
+                        opt.step()
+                    decay_lora_adapters(core, TTT_LORA_DECAY)
+
+        if (ci + 1) % log_every == 0 or ci == 0 or ci == n_chunks - 1:
+            elapsed = time.perf_counter() - t0_eval
+            stats_now = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+            dist.all_reduce(stats_now, op=dist.ReduceOp.SUM)
+            rs_loss, rs_tok, rs_byt = float(stats_now[0]), float(stats_now[1]), float(stats_now[2])
+            run_loss = rs_loss / max(rs_tok, 1.0)
+            run_bpb = (run_loss / math.log(2.0)) * (rs_tok / max(rs_byt, 1.0))
+            eta = elapsed / max(ci + 1, 1) * (n_chunks - ci - 1)
+            log0(f"  lora_ttt: chunk {ci+1}/{n_chunks} running_bpb:{run_bpb:.4f} eta:{eta:.0f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"LoRA TTT done: chunks={n_chunks}, scored_tokens={tok_sum:.0f}, elapsed={elapsed:.1f}s")
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        # Safe even though weights will be overwritten for base params.
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    log0(f"Loading checkpoint/artifact: {ARTIFACT_PATH}")
+    state = load_checkpoint_state(ARTIFACT_PATH)
+    missing, unexpected = base_model.load_state_dict(state, strict=False)
+    missing_non_lora = [k for k in missing if "lora_" not in k]
+    unexpected_non_lora = [k for k in unexpected if "lora_" not in k]
+    if missing_non_lora:
+        log0(f"WARNING: non-LoRA missing keys: {missing_non_lora[:12]}{'...' if len(missing_non_lora) > 12 else ''}")
+    if unexpected_non_lora:
+        log0(f"WARNING: unexpected keys: {unexpected_non_lora[:12]}{'...' if len(unexpected_non_lora) > 12 else ''}")
+    log0(f"Missing LoRA keys initialized fresh: {len([k for k in missing if 'lora_' in k])}")
+
+    # Freeze base and enable LoRA params only.
+    lora_names, lora_params = get_lora_params(base_model)
+    log0(f"Trainable LoRA params: {len(lora_params)} tensors, {sum(p.numel() for p in lora_params):,} params")
+
+    model_for_eval = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            model_for_eval = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            model_for_eval = base_model
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+    else:
+        log0("torch_compile: disabled")
+
+    # Optional baseline before TTT.
+    if RUN_BASELINE:
+        vl, vb = eval_val(model_for_eval, val_tokens, bb, hs, ib)
+        log0(f"Loaded baseline standard val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            sw_vl, sw_vb = eval_val_sliding(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Loaded baseline sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+
+    dist.barrier()
+    log0("=" * 60)
+    log0("Running score-first attention-LoRA TTT...")
+    ttt_vl, ttt_vb = eval_score_first_lora_ttt(model_for_eval, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+    log0(f"Score-first LoRA TTT val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+    log0("=" * 60)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lrsep.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lrsep.py
@@ -1,0 +1,2440 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — separated LR groups for hybrid SSM/attention training
+# MATRIX_LR is kept as a backwards-compatible fallback/default, but build_optimizers
+# now splits 2D matrices into attention / FFN / SSM groups.
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # fallback/default matrix LR
+ATTN_LR = float(os.environ.get("ATTN_LR", "0.024"))      # sharper recall/checkpoint layers
+FFN_LR = float(os.environ.get("FFN_LR", "0.022"))        # feed-forward refinement
+SSM_LR = float(os.environ.get("SSM_LR", "0.014"))        # conservative Mamba projection LR
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # non-SSM scalar/control params
+SSM_CTRL_LR = float(os.environ.get("SSM_CTRL_LR", "0.004"))
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # muon/adamw WD for normal params
+SSM_CTRL_WD = float(os.environ.get("SSM_CTRL_WD", "0.0"))      # keep SSM dynamics un-decayed
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(
+    f"optimizer: attn_lr={ATTN_LR}, ffn_lr={FFN_LR}, ssm_lr={SSM_LR}, "
+    f"scalar_lr={SCALAR_LR}, ssm_ctrl_lr={SSM_CTRL_LR}, embed_lr={EMBED_LR}, "
+    f"wd={WEIGHT_DECAY}, ssm_ctrl_wd={SSM_CTRL_WD}, grad_clip={GRAD_CLIP}"
+)
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    """
+    Hybrid optimizer split:
+    - Attention QKV/out projection matrices use ATTN_LR, so the recall checkpoint
+      can learn sharp retrieval behavior quickly.
+    - FFN matrices use FFN_LR.
+    - Mamba/SSM projection matrices use lower SSM_LR to avoid destabilizing the
+      selective-state dynamics.
+    - Mamba dynamics/control tensors (A_log, D, dt, conv, SSM scales, memory
+      gates) use AdamW with SSM_CTRL_LR and SSM_CTRL_WD.
+
+    The training loop already multiplies every param group's `base_lr` by the
+    global LR schedule, so no loop changes are needed.
+    """
+    attn_params, ffn_params, ssm_params = [], [], []
+    scalar_params, ssm_ctrl_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def _block_kind(param_name: str):
+        # Names look like blocks.{idx}.<submodule>...
+        parts = param_name.split(".")
+        if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+            idx = int(parts[1])
+            if 0 <= idx < len(model.blocks):
+                block = model.blocks[idx]
+                if isinstance(block, CausalAttentionBlock):
+                    return "attn"
+                if isinstance(block, SelectiveSSMBlock):
+                    return "ssm"
+        return None
+
+    def _is_ssm_control(param_name: str) -> bool:
+        # Keep fragile recurrent dynamics out of Muon/high-WD updates.
+        return (
+            "mamba.A_log" in param_name
+            or param_name.endswith(".A_log")
+            or "mamba.D" in param_name
+            or param_name.endswith(".D")
+            or "dt_bias" in param_name
+            or "dt_proj.bias" in param_name
+            or "conv1d" in param_name
+            or "ssm_scale" in param_name
+            or "ssm_norm" in param_name
+            or "mem_" in param_name
+            or "memory" in param_name
+        )
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            continue
+
+        kind = _block_kind(name)
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        is_ssm_control = _is_ssm_control(name) or (kind == "ssm" and is_control)
+        muon_matrix = ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2))
+
+        if p.ndim == 2 and not is_control and not is_ssm_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control and not is_ssm_control:
+            muon_eligible_nd += 1
+
+        # SSM dynamics/control params go to conservative AdamW regardless of shape.
+        if is_ssm_control:
+            ssm_ctrl_params.append(p)
+            continue
+
+        if muon_matrix and not is_control:
+            if "mamba" in name or (kind == "ssm" and not ("ffn" in name or "gate_up" in name or "down" in name)):
+                # Mamba projection matrices get the conservative SSM LR.
+                ssm_params.append(p)
+            elif kind == "attn" and ("qkv" in name or "out_proj" in name):
+                attn_params.append(p)
+            elif "ffn" in name or "gate_up" in name or "down" in name:
+                ffn_params.append(p)
+            else:
+                # Projections outside blocks, e.g. embed_proj/embed_proj_rev, are closer
+                # to FFN/refinement than recurrent dynamics.
+                ffn_params.append(p)
+        else:
+            scalar_params.append(p)
+
+    muon_groups = []
+    if attn_params:
+        muon_groups.append({"params": attn_params, "lr": ATTN_LR, "base_lr": ATTN_LR})
+    if ffn_params:
+        muon_groups.append({"params": ffn_params, "lr": FFN_LR, "base_lr": FFN_LR})
+    if ssm_params:
+        muon_groups.append({"params": ssm_params, "lr": SSM_LR, "base_lr": SSM_LR})
+
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adamw_groups = []
+    if scalar_params:
+        adamw_groups.append({
+            "params": scalar_params,
+            "lr": SCALAR_LR,
+            "weight_decay": WEIGHT_DECAY,
+            "base_lr": SCALAR_LR,
+        })
+    if ssm_ctrl_params:
+        adamw_groups.append({
+            "params": ssm_ctrl_params,
+            "lr": SSM_CTRL_LR,
+            "weight_decay": SSM_CTRL_WD,
+            "base_lr": SSM_CTRL_LR,
+        })
+    if embed_params:
+        adamw_groups.append({
+            "params": embed_params,
+            "lr": EMBED_LR,
+            "weight_decay": WEIGHT_DECAY,
+            "base_lr": EMBED_LR,
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adamw_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+
+    matrix_params = attn_params + ffn_params + ssm_params
+    log0(
+        f"Optimizer split: attn={len(attn_params)} lr={ATTN_LR}, "
+        f"ffn={len(ffn_params)} lr={FFN_LR}, "
+        f"ssm={len(ssm_params)} lr={SSM_LR}, "
+        f"ssm_ctrl={len(ssm_ctrl_params)} lr={SSM_CTRL_LR} wd={SSM_CTRL_WD}, "
+        f"scalar/control={len(scalar_params)} lr={SCALAR_LR}, "
+        f"embed={len(embed_params)} lr={EMBED_LR}"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd} "
+        f"groups={len(muon_groups)}"
+    )
+    return optimizer_adamw, optimizer_muon, matrix_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lrsep_ttt_ablate.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_lrsep_ttt_ablate.py
@@ -1,0 +1,2815 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — separated LR groups for hybrid SSM/attention training
+# MATRIX_LR is kept as a backwards-compatible fallback/default, but build_optimizers
+# now splits 2D matrices into attention / FFN / SSM groups.
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # fallback/default matrix LR
+ATTN_LR = float(os.environ.get("ATTN_LR", "0.024"))      # sharper recall/checkpoint layers
+FFN_LR = float(os.environ.get("FFN_LR", "0.022"))        # feed-forward refinement
+SSM_LR = float(os.environ.get("SSM_LR", "0.014"))        # conservative Mamba projection LR
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # non-SSM scalar/control params
+SSM_CTRL_LR = float(os.environ.get("SSM_CTRL_LR", "0.004"))
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # muon/adamw WD for normal params
+SSM_CTRL_WD = float(os.environ.get("SSM_CTRL_WD", "0.0"))      # keep SSM dynamics un-decayed
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+
+# TTT ablation runner: score-first, chunk-ordered, adapter/state-only variants.
+# Training still stops at MAX_WALLCLOCK_SECONDS; these run AFTER training/eval.
+RUN_TTT_ABLATIONS = os.environ.get("RUN_TTT_ABLATIONS", "1") == "1"
+TTT_ABLATION_VARIANTS = [
+    x.strip() for x in os.environ.get(
+        "TTT_ABLATION_VARIANTS",
+        "hybrid_lite,attention_lora,attention_lora_ssm_memory,ssm_proj_lora",
+    ).split(",") if x.strip()
+]
+TTT_ABLATION_CHUNK_TOKENS = int(os.environ.get("TTT_ABLATION_CHUNK_TOKENS", str(SCORE_FIRST_TTT_CHUNK_TOKENS)))
+TTT_ABLATION_EPOCHS = int(os.environ.get("TTT_ABLATION_EPOCHS", "1"))
+TTT_ABLATION_MAX_CHUNKS = int(os.environ.get("TTT_ABLATION_MAX_CHUNKS", "0"))  # 0 = full val
+TTT_ABLATION_TRAIN_WINDOWS = int(os.environ.get("TTT_ABLATION_TRAIN_WINDOWS", "32"))
+TTT_ABLATION_OPT = os.environ.get("TTT_ABLATION_OPT", "adamw").lower()  # adamw or sgd
+TTT_HYBRID_LITE_LR = float(os.environ.get("TTT_HYBRID_LITE_LR", "5e-4"))
+TTT_LORA_LR = float(os.environ.get("TTT_LORA_LR", "1e-3"))
+TTT_SSM_LORA_LR = float(os.environ.get("TTT_SSM_LORA_LR", "7e-4"))
+TTT_MEMORY_LR = float(os.environ.get("TTT_MEMORY_LR", "1e-3"))
+TTT_LORA_RANK = int(os.environ.get("TTT_LORA_RANK", "4"))
+TTT_LORA_ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "8.0"))
+TTT_MEMORY_INIT_GATE = float(os.environ.get("TTT_MEMORY_INIT_GATE", "0.10"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(
+    f"ttt_ablations: enabled={RUN_TTT_ABLATIONS}, variants={TTT_ABLATION_VARIANTS}, "
+    f"chunk={TTT_ABLATION_CHUNK_TOKENS}, epochs={TTT_ABLATION_EPOCHS}, "
+    f"max_chunks={TTT_ABLATION_MAX_CHUNKS}, train_windows={TTT_ABLATION_TRAIN_WINDOWS}, "
+    f"lora_rank={TTT_LORA_RANK}"
+)
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(
+    f"optimizer: attn_lr={ATTN_LR}, ffn_lr={FFN_LR}, ssm_lr={SSM_LR}, "
+    f"scalar_lr={SCALAR_LR}, ssm_ctrl_lr={SSM_CTRL_LR}, embed_lr={EMBED_LR}, "
+    f"wd={WEIGHT_DECAY}, ssm_ctrl_wd={SSM_CTRL_WD}, grad_clip={GRAD_CLIP}"
+)
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+        # TTT-only SSM adapters. Inactive during normal training, zero-impact at init.
+        self.ttt_ssm_lora_active = False
+        self.ttt_ssm_memory_active = False
+        self.ttt_lora_scale = TTT_LORA_ALPHA / max(TTT_LORA_RANK, 1)
+        if TTT_LORA_RANK > 0:
+            self.ttt_ssm_A = nn.Linear(d_model, TTT_LORA_RANK, bias=False)
+            self.ttt_ssm_B = nn.Linear(TTT_LORA_RANK, d_model, bias=False)
+            nn.init.normal_(self.ttt_ssm_A.weight, std=0.02)
+            nn.init.zeros_(self.ttt_ssm_B.weight)
+            self.ttt_ssm_A.weight.requires_grad_(False)
+            self.ttt_ssm_B.weight.requires_grad_(False)
+        # A document-local additive state. It is inactive and frozen during training;
+        # TTT variants can enable and optimize/carry it across score-first chunks.
+        self.ttt_mem = nn.Parameter(torch.zeros(1, 1, d_model), requires_grad=False)
+        self.ttt_mem_gate = nn.Parameter(torch.tensor(TTT_MEMORY_INIT_GATE), requires_grad=False)
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        if self.ttt_ssm_memory_active:
+            x_in = x_in + self.ttt_mem_gate.to(x_in.dtype) * self.ttt_mem.to(device=x_in.device, dtype=x_in.dtype)
+        if self.ttt_ssm_lora_active and hasattr(self, "ttt_ssm_A"):
+            x_in = x_in + self.ttt_lora_scale * self.ttt_ssm_B(self.ttt_ssm_A(x_in))
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        # TTT-only attention LoRA. Inactive during normal training, zero-impact at init.
+        self.ttt_attn_lora_active = False
+        self.ttt_lora_scale = TTT_LORA_ALPHA / max(TTT_LORA_RANK, 1)
+        if TTT_LORA_RANK > 0:
+            self.ttt_attn_qkv_A = nn.Linear(d_model, TTT_LORA_RANK, bias=False)
+            self.ttt_attn_qkv_B = nn.Linear(TTT_LORA_RANK, 3 * d_model, bias=False)
+            self.ttt_attn_out_A = nn.Linear(d_model, TTT_LORA_RANK, bias=False)
+            self.ttt_attn_out_B = nn.Linear(TTT_LORA_RANK, d_model, bias=False)
+            nn.init.normal_(self.ttt_attn_qkv_A.weight, std=0.02)
+            nn.init.normal_(self.ttt_attn_out_A.weight, std=0.02)
+            nn.init.zeros_(self.ttt_attn_qkv_B.weight)
+            nn.init.zeros_(self.ttt_attn_out_B.weight)
+            for _p in (
+                self.ttt_attn_qkv_A.weight,
+                self.ttt_attn_qkv_B.weight,
+                self.ttt_attn_out_A.weight,
+                self.ttt_attn_out_B.weight,
+            ):
+                _p.requires_grad_(False)
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv_flat = self.qkv(normed)
+        if self.ttt_attn_lora_active and hasattr(self, "ttt_attn_qkv_A"):
+            qkv_flat = qkv_flat + self.ttt_lora_scale * self.ttt_attn_qkv_B(self.ttt_attn_qkv_A(normed))
+        qkv = qkv_flat.reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        attn_proj = self.out_proj(attn_out)
+        if self.ttt_attn_lora_active and hasattr(self, "ttt_attn_out_A"):
+            attn_proj = attn_proj + self.ttt_lora_scale * self.ttt_attn_out_B(self.ttt_attn_out_A(attn_out))
+        x = x + self.attn_scale[None, None, :] * attn_proj
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    """
+    Hybrid optimizer split:
+    - Attention QKV/out projection matrices use ATTN_LR, so the recall checkpoint
+      can learn sharp retrieval behavior quickly.
+    - FFN matrices use FFN_LR.
+    - Mamba/SSM projection matrices use lower SSM_LR to avoid destabilizing the
+      selective-state dynamics.
+    - Mamba dynamics/control tensors (A_log, D, dt, conv, SSM scales, memory
+      gates) use AdamW with SSM_CTRL_LR and SSM_CTRL_WD.
+
+    The training loop already multiplies every param group's `base_lr` by the
+    global LR schedule, so no loop changes are needed.
+    """
+    attn_params, ffn_params, ssm_params = [], [], []
+    scalar_params, ssm_ctrl_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+
+    def _block_kind(param_name: str):
+        # Names look like blocks.{idx}.<submodule>...
+        parts = param_name.split(".")
+        if len(parts) >= 2 and parts[0] == "blocks" and parts[1].isdigit():
+            idx = int(parts[1])
+            if 0 <= idx < len(model.blocks):
+                block = model.blocks[idx]
+                if isinstance(block, CausalAttentionBlock):
+                    return "attn"
+                if isinstance(block, SelectiveSSMBlock):
+                    return "ssm"
+        return None
+
+    def _is_ssm_control(param_name: str) -> bool:
+        # Keep fragile recurrent dynamics out of Muon/high-WD updates.
+        return (
+            "mamba.A_log" in param_name
+            or param_name.endswith(".A_log")
+            or "mamba.D" in param_name
+            or param_name.endswith(".D")
+            or "dt_bias" in param_name
+            or "dt_proj.bias" in param_name
+            or "conv1d" in param_name
+            or "ssm_scale" in param_name
+            or "ssm_norm" in param_name
+            or "mem_" in param_name
+            or "memory" in param_name
+        )
+
+    for name, p in model.named_parameters():
+        if not p.requires_grad:
+            continue  # TTT-only adapters/memory are frozen during base training
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            continue
+
+        kind = _block_kind(name)
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        is_ssm_control = _is_ssm_control(name) or (kind == "ssm" and is_control)
+        muon_matrix = ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2))
+
+        if p.ndim == 2 and not is_control and not is_ssm_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control and not is_ssm_control:
+            muon_eligible_nd += 1
+
+        # SSM dynamics/control params go to conservative AdamW regardless of shape.
+        if is_ssm_control:
+            ssm_ctrl_params.append(p)
+            continue
+
+        if muon_matrix and not is_control:
+            if "mamba" in name or (kind == "ssm" and not ("ffn" in name or "gate_up" in name or "down" in name)):
+                # Mamba projection matrices get the conservative SSM LR.
+                ssm_params.append(p)
+            elif kind == "attn" and ("qkv" in name or "out_proj" in name):
+                attn_params.append(p)
+            elif "ffn" in name or "gate_up" in name or "down" in name:
+                ffn_params.append(p)
+            else:
+                # Projections outside blocks, e.g. embed_proj/embed_proj_rev, are closer
+                # to FFN/refinement than recurrent dynamics.
+                ffn_params.append(p)
+        else:
+            scalar_params.append(p)
+
+    muon_groups = []
+    if attn_params:
+        muon_groups.append({"params": attn_params, "lr": ATTN_LR, "base_lr": ATTN_LR})
+    if ffn_params:
+        muon_groups.append({"params": ffn_params, "lr": FFN_LR, "base_lr": FFN_LR})
+    if ssm_params:
+        muon_groups.append({"params": ssm_params, "lr": SSM_LR, "base_lr": SSM_LR})
+
+    optimizer_muon = Muon(
+        muon_groups,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(muon_groups) > 0 else None
+
+    adamw_groups = []
+    if scalar_params:
+        adamw_groups.append({
+            "params": scalar_params,
+            "lr": SCALAR_LR,
+            "weight_decay": WEIGHT_DECAY,
+            "base_lr": SCALAR_LR,
+        })
+    if ssm_ctrl_params:
+        adamw_groups.append({
+            "params": ssm_ctrl_params,
+            "lr": SSM_CTRL_LR,
+            "weight_decay": SSM_CTRL_WD,
+            "base_lr": SSM_CTRL_LR,
+        })
+    if embed_params:
+        adamw_groups.append({
+            "params": embed_params,
+            "lr": EMBED_LR,
+            "weight_decay": WEIGHT_DECAY,
+            "base_lr": EMBED_LR,
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adamw_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+
+    matrix_params = attn_params + ffn_params + ssm_params
+    log0(
+        f"Optimizer split: attn={len(attn_params)} lr={ATTN_LR}, "
+        f"ffn={len(ffn_params)} lr={FFN_LR}, "
+        f"ssm={len(ssm_params)} lr={SSM_LR}, "
+        f"ssm_ctrl={len(ssm_ctrl_params)} lr={SSM_CTRL_LR} wd={SSM_CTRL_WD}, "
+        f"scalar/control={len(scalar_params)} lr={SCALAR_LR}, "
+        f"embed={len(embed_params)} lr={EMBED_LR}"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd} "
+        f"groups={len(muon_groups)}"
+    )
+    return optimizer_adamw, optimizer_muon, matrix_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+
+def _unwrap_raw_model(model_or_ddp):
+    """Return the original eager SSM_LM even if DDP(torch.compile(model)) is passed."""
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    return getattr(core, "_orig_mod", core)
+
+
+def _set_ttt_modes(model, *, attn_lora=False, ssm_lora=False, ssm_memory=False):
+    for mod in model.modules():
+        if hasattr(mod, "ttt_attn_lora_active"):
+            mod.ttt_attn_lora_active = bool(attn_lora)
+        if hasattr(mod, "ttt_ssm_lora_active"):
+            mod.ttt_ssm_lora_active = bool(ssm_lora)
+        if hasattr(mod, "ttt_ssm_memory_active"):
+            mod.ttt_ssm_memory_active = bool(ssm_memory)
+
+
+@torch.no_grad()
+def _reset_ttt_adapters(model):
+    """Zero the trainable TTT deltas so each ablation starts from the same base."""
+    for mod in model.modules():
+        if hasattr(mod, "ttt_attn_qkv_B"):
+            mod.ttt_attn_qkv_B.weight.zero_()
+            mod.ttt_attn_out_B.weight.zero_()
+        if hasattr(mod, "ttt_ssm_B"):
+            mod.ttt_ssm_B.weight.zero_()
+        if hasattr(mod, "ttt_mem"):
+            mod.ttt_mem.zero_()
+        if hasattr(mod, "ttt_mem_gate"):
+            mod.ttt_mem_gate.fill_(TTT_MEMORY_INIT_GATE)
+
+
+def _select_ttt_ablation_params(model, variant):
+    variant = variant.lower()
+    params = []
+    names = []
+    for name, p in model.named_parameters():
+        include = False
+        if variant == "hybrid_lite":
+            include = (
+                "q_gain" in name
+                or "attn_scale" in name
+                or "ssm_scale" in name
+                or "mlp_scale" in name
+                or "resid_mix" in name
+                or "norm" in name
+                or "final_norm" in name
+            ) and "ttt_" not in name
+        elif variant == "attention_lora":
+            include = "ttt_attn_" in name
+        elif variant == "attention_lora_ssm_memory":
+            include = ("ttt_attn_" in name) or ("ttt_mem" in name)
+        elif variant == "ssm_proj_lora":
+            include = "ttt_ssm_" in name and "ttt_mem" not in name
+        else:
+            raise ValueError(f"Unknown TTT ablation variant: {variant}")
+        if include:
+            params.append(p)
+            names.append(name)
+    return names, params
+
+
+def _ttt_variant_lr(variant):
+    variant = variant.lower()
+    if variant == "hybrid_lite":
+        return TTT_HYBRID_LITE_LR
+    if variant == "attention_lora":
+        return TTT_LORA_LR
+    if variant == "attention_lora_ssm_memory":
+        return TTT_MEMORY_LR
+    if variant == "ssm_proj_lora":
+        return TTT_SSM_LORA_LR
+    return TTT_LORA_LR
+
+
+def _configure_ttt_variant(model, variant):
+    _set_ttt_modes(model, attn_lora=False, ssm_lora=False, ssm_memory=False)
+    if variant == "attention_lora":
+        _set_ttt_modes(model, attn_lora=True)
+    elif variant == "attention_lora_ssm_memory":
+        _set_ttt_modes(model, attn_lora=True, ssm_memory=True)
+    elif variant == "ssm_proj_lora":
+        _set_ttt_modes(model, ssm_lora=True)
+    elif variant == "hybrid_lite":
+        pass
+    else:
+        raise ValueError(f"Unknown TTT ablation variant: {variant}")
+
+
+def _make_window_batch(val_tokens, positions, seq_len):
+    x_list, y_list = [], []
+    for pos in positions:
+        if pos + seq_len + 1 > val_tokens.size:
+            continue
+        x_list.append(val_tokens[pos : pos + seq_len])
+        y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+    if not x_list:
+        return None, None
+    return np.stack(x_list), np.stack(y_list)
+
+
+def _dummy_zero_backward(adapt_params):
+    dummy = None
+    for p in adapt_params:
+        term = p.float().sum() * 0.0
+        dummy = term if dummy is None else dummy + term
+    if dummy is not None:
+        dummy.backward()
+
+
+def eval_score_first_ttt_ablation(model_or_ddp, val_tokens, bb, hs, ib, variant, stride=None):
+    """
+    Chunk-ordered score-first TTT ablation.
+
+    For each global chunk, all ranks score their shard of the chunk first, then
+    update only the selected tiny parameters/adapters on already-scored windows.
+    The updated adapters/state carry into the next chunk. Base weights are
+    restored after each variant.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = _unwrap_raw_model(model_or_ddp)
+    seq_len = SEQ_LEN
+    variant = variant.lower()
+
+    _reset_ttt_adapters(core)
+    _configure_ttt_variant(core, variant)
+    adapt_names, adapt_params = _select_ttt_ablation_params(core, variant)
+    if not adapt_params:
+        raise RuntimeError(f"No adaptive params selected for TTT variant {variant}")
+
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+    old_requires_grad = {name: p.requires_grad for name, p in core.named_parameters()}
+    for p in core.parameters():
+        p.requires_grad_(False)
+    for p in adapt_params:
+        p.requires_grad_(True)
+
+    lr = _ttt_variant_lr(variant)
+    if TTT_ABLATION_OPT == "sgd":
+        opt = torch.optim.SGD(adapt_params, lr=lr, momentum=SCORE_FIRST_TTT_MOMENTUM)
+    else:
+        opt = torch.optim.AdamW(adapt_params, lr=lr, betas=(0.9, 0.95), weight_decay=0.0)
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(
+        f"TTT ablation [{variant}]: params={len(adapt_params)} ({n_adapt:,}), "
+        f"lr={lr}, opt={TTT_ABLATION_OPT}, chunk={TTT_ABLATION_CHUNK_TOKENS}, "
+        f"epochs={TTT_ABLATION_EPOCHS}, max_chunks={TTT_ABLATION_MAX_CHUNKS or 'all'}"
+    )
+    if MASTER_PROCESS:
+        preview = ", ".join(adapt_names[:8])
+        if len(adapt_names) > 8:
+            preview += ", ..."
+        log0(f"  adaptive params preview: {preview}")
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = TTT_ABLATION_CHUNK_TOKENS
+    n_chunks = max(1, (total_tokens - seq_len) // chunk_tokens + 1)
+    if TTT_ABLATION_MAX_CHUNKS > 0:
+        n_chunks = min(n_chunks, TTT_ABLATION_MAX_CHUNKS)
+
+    batch_windows = max(1, 131072 // seq_len)
+    train_global_windows = max(WORLD_SIZE, TTT_ABLATION_TRAIN_WINDOWS)
+    log_every = max(1, n_chunks // 10)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+
+    try:
+        for ci in range(n_chunks):
+            chunk_tok_start = ci * chunk_tokens
+            chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+            if chunk_tok_end <= chunk_tok_start:
+                continue
+
+            n_windows = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+            # 1) SCORE first. Ranks shard the same global chunk/window list.
+            core.eval()
+            with torch.no_grad():
+                for wb in range(0, n_windows, batch_windows):
+                    we = min(wb + batch_windows, n_windows)
+                    local_ws = list(range(wb + RANK, we, WORLD_SIZE))
+                    positions = [chunk_tok_start + w * stride for w in local_ws]
+                    xn, yn = _make_window_batch(val_tokens, positions, seq_len)
+                    if xn is None:
+                        continue
+                    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        hidden = core(x, state=None, return_state=False)
+
+                    hidden_tail = hidden[:, -stride:, :]
+                    y_tail = y[:, -stride:]
+                    flat_y = y_tail.reshape(-1)
+                    if core.use_factored:
+                        flat_h = hidden_tail.reshape(-1, D_MODEL)
+                        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                    else:
+                        flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                    logits = core.softcap * torch.tanh(logits / core.softcap)
+                    loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                    cnt = float(flat_y.numel())
+                    loss_sum += float(loss.detach().float().item())
+                    p_tail = xn[:, -stride:].reshape(-1)
+                    t_tail = yn[:, -stride:].reshape(-1)
+                    b = bb[t_tail].astype(np.int16, copy=True)
+                    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                    tok_sum += cnt
+                    byt_sum += float(b.astype(np.float64).sum())
+
+            # 2) UPDATE on the scored chunk only. All ranks stay in global chunk order.
+            core.train()
+            for epoch in range(TTT_ABLATION_EPOCHS):
+                for wb in range(0, n_windows, train_global_windows):
+                    we = min(wb + train_global_windows, n_windows)
+                    local_ws = list(range(wb + RANK, we, WORLD_SIZE))
+                    positions = [chunk_tok_start + w * stride for w in local_ws]
+                    xn, yn = _make_window_batch(val_tokens, positions, seq_len)
+
+                    opt.zero_grad(set_to_none=True)
+                    if xn is None:
+                        _dummy_zero_backward(adapt_params)
+                    else:
+                        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            adapt_loss = lm_loss(core, x, y)
+                        adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is None:
+                            p.grad = torch.zeros_like(p)
+                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    opt.step()
+
+            if (ci + 1) % log_every == 0 or (ci + 1) == n_chunks:
+                stats_local = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+                stats_global = stats_local.clone()
+                dist.all_reduce(stats_global, op=dist.ReduceOp.SUM)
+                gl_loss, gl_tok, gl_byt = float(stats_global[0]), float(stats_global[1]), float(stats_global[2])
+                running_loss = gl_loss / max(gl_tok, 1.0)
+                running_bpb = (running_loss / math.log(2.0)) * (gl_tok / max(gl_byt, 1.0))
+                elapsed_e = time.perf_counter() - t0_eval
+                eta = elapsed_e / (ci + 1) * (n_chunks - ci - 1)
+                log0(f"  [{variant}] chunk {ci+1}/{n_chunks} running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+        elapsed = time.perf_counter() - t0_eval
+        log0(f"  [{variant}] scored local tokens={tok_sum:.0f}, elapsed={elapsed:.1f}s")
+        stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+        loss_sum_g, tok_sum_g, byt_sum_g = float(stats[0]), float(stats[1]), float(stats[2])
+        val_loss = loss_sum_g / max(tok_sum_g, 1.0)
+        bpt = val_loss / math.log(2.0)
+        return float(val_loss), float(bpt * (tok_sum_g / max(byt_sum_g, 1.0)))
+    finally:
+        with torch.no_grad():
+            for name, p in core.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+        for name, p in core.named_parameters():
+            p.requires_grad_(old_requires_grad.get(name, True))
+        _set_ttt_modes(core, attn_lora=False, ssm_lora=False, ssm_memory=False)
+        core.train()
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT ablations: run adapter/state methods one by one. ---
+    if RUN_TTT_ABLATIONS and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Ensure best weights are loaded before each TTT ablation. The ablation
+        # function restores weights after each variant.
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0("Running score-first TTT ablations...")
+        for variant in TTT_ABLATION_VARIANTS:
+            dist.barrier()
+            log0("-" * 60)
+            log0(f"Running TTT ablation: {variant}")
+            ttt_vl, ttt_vb = eval_score_first_ttt_ablation(
+                base_model, val_tokens, bb, hs, ib, variant=variant, stride=EVAL_STRIDE
+            )
+            log0(f"TTT ablation {variant} val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT ablation {variant} vs sliding: bpb={pre_ttt_sw_vb - ttt_vb:+.4f}")
+        log0("=" * 60)
+
+    # Optional legacy all-parameter score-first TTT. Off by default when ablations run.
+    elif SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running legacy all-param Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Legacy Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Legacy Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_moe_ffn.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_moe_ffn.py
@@ -1,0 +1,2417 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+
+# Lightweight sequence-level MoE FFN.
+# Designed to test a Jamba-like "mostly SSM + sparse attention + routed FFNs"
+# idea without token-level routing overhead.
+MOE_ENABLED = os.environ.get("MOE_ENABLED", "0") == "1"
+MOE_LAYER_IDXS = [int(x) for x in os.environ.get("MOE_LAYER_IDXS", "5,7,8,9").split(",") if x.strip()]
+MOE_NUM_EXPERTS = int(os.environ.get("MOE_NUM_EXPERTS", "3"))
+MOE_EXPERT_FFN_MULT = int(os.environ.get("MOE_EXPERT_FFN_MULT", "1"))
+# "soft" = differentiable, computes all experts; "ste" = straight-through top1 but computes all experts;
+# "hard" = true top1 compute but router gets no useful gradient through argmax.
+MOE_ROUTING = os.environ.get("MOE_ROUTING", "soft").lower()
+MOE_ROUTER_TEMP = float(os.environ.get("MOE_ROUTER_TEMP", "1.0"))
+MOE_ROUTER_ZERO_INIT = os.environ.get("MOE_ROUTER_ZERO_INIT", "1") == "1"
+
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(
+    f"moe: enabled={MOE_ENABLED}, layers={MOE_LAYER_IDXS}, experts={MOE_NUM_EXPERTS}, "
+    f"expert_mult={MOE_EXPERT_FFN_MULT}, routing={MOE_ROUTING}, "
+    f"router_temp={MOE_ROUTER_TEMP}, zero_init={MOE_ROUTER_ZERO_INIT}"
+)
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+
+class SequenceMoE_FFN(nn.Module):
+    """
+    Sequence-level MoE FFN.
+
+    Routes each whole sequence/window to experts using a pooled hidden summary.
+    This avoids token-level scatter/gather overhead and tests whether FFN capacity
+    benefits from document/topic specialization.
+
+    Modes:
+      - soft: differentiable weighted mixture over all experts. Router learns.
+      - ste: straight-through top-1 weights, computes all experts. Router learns.
+      - hard: computes only selected experts. Faster, but router gets no useful
+              gradient through the argmax; use mainly as a speed ablation.
+    """
+    def __init__(self, d_model, num_experts=3, expert_mult=1):
+        super().__init__()
+        if num_experts < 1:
+            raise ValueError("MOE_NUM_EXPERTS must be >= 1")
+        self.num_experts = num_experts
+        self.routing = MOE_ROUTING
+        self.router_norm = RMSNorm(d_model)
+        self.router = nn.Linear(d_model, num_experts, bias=False)
+        if MOE_ROUTER_ZERO_INIT:
+            nn.init.zeros_(self.router.weight)
+        self.experts = nn.ModuleList([
+            SwiGLU_FFN(d_model, expert_mult) for _ in range(num_experts)
+        ])
+
+    def _router_logits(self, x):
+        # x: (B, T, D). Sequence-level route from mean pooled normalized hidden.
+        summary = self.router_norm(x).mean(dim=1)
+        logits = self.router(summary)
+        if MOE_ROUTER_TEMP != 1.0:
+            logits = logits / max(MOE_ROUTER_TEMP, 1e-6)
+        return logits
+
+    def forward(self, x):
+        logits = self._router_logits(x)
+
+        if self.routing == "hard":
+            # True top-1 compute. Router argmax is non-differentiable.
+            idx = torch.argmax(logits, dim=-1)
+            out = torch.zeros_like(x)
+            for e, expert in enumerate(self.experts):
+                mask = idx == e
+                if torch.any(mask):
+                    out[mask] = expert(x[mask])
+            return out
+
+        # Soft and straight-through modes compute all experts. This is roughly
+        # comparable compute to dense FFN when num_experts * expert_mult ~= FFN_MULT.
+        expert_outs = torch.stack([expert(x) for expert in self.experts], dim=1)  # (B, E, T, D)
+        probs = torch.softmax(logits, dim=-1)
+
+        if self.routing == "ste":
+            idx = torch.argmax(probs, dim=-1)
+            hard = F.one_hot(idx, num_classes=self.num_experts).to(dtype=probs.dtype)
+            weights = hard + probs - probs.detach()
+        else:
+            weights = probs
+
+        return (weights[:, :, None, None].to(expert_outs.dtype) * expert_outs).sum(dim=1)
+
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, use_moe_ffn=False):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SequenceMoE_FFN(d_model, MOE_NUM_EXPERTS, MOE_EXPERT_FFN_MULT) if use_moe_ffn else SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, use_moe_ffn=False):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SequenceMoE_FFN(d_model, MOE_NUM_EXPERTS, MOE_EXPERT_FFN_MULT) if use_moe_ffn else SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions.
+        # Selected blocks can use a sequence-level MoE FFN.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        moe_set = set(MOE_LAYER_IDXS) if MOE_ENABLED else set()
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            use_moe_ffn = i in moe_set
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, use_moe_ffn=use_moe_ffn))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, use_moe_ffn=use_moe_ffn))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_nbit_quant.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_nbit_quant.py
@@ -1,0 +1,2787 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = False  # removed in this quant-focused file
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+# Mixed n-bit post-training quantization.
+# This is not training-time quantization; it is an artifact-size / parameter-budget tool.
+MIXED_NBIT_QUANT = os.environ.get("MIXED_NBIT_QUANT", "1") == "1"
+MATRIX_BITS = int(os.environ.get("MATRIX_BITS", "6"))
+EMBED_BITS = int(os.environ.get("EMBED_BITS", "7"))
+HEAD_BITS = int(os.environ.get("HEAD_BITS", "7"))
+SSM_BITS = int(os.environ.get("SSM_BITS", str(MATRIX_BITS)))
+ATTN_BITS = int(os.environ.get("ATTN_BITS", str(MATRIX_BITS)))
+FFN_BITS = int(os.environ.get("FFN_BITS", str(MATRIX_BITS)))
+
+# SDClip-style clipping. clip_abs = min(row_absmax, sigma * row_std)
+MATRIX_CLIP_SIGMAS = float(os.environ.get("MATRIX_CLIP_SIGMAS", "10.0"))
+EMBED_CLIP_SIGMAS = float(os.environ.get("EMBED_CLIP_SIGMAS", "14.0"))
+HEAD_CLIP_SIGMAS = float(os.environ.get("HEAD_CLIP_SIGMAS", "14.0"))
+SSM_CLIP_SIGMAS = float(os.environ.get("SSM_CLIP_SIGMAS", str(MATRIX_CLIP_SIGMAS)))
+ATTN_CLIP_SIGMAS = float(os.environ.get("ATTN_CLIP_SIGMAS", str(MATRIX_CLIP_SIGMAS)))
+FFN_CLIP_SIGMAS = float(os.environ.get("FFN_CLIP_SIGMAS", str(MATRIX_CLIP_SIGMAS)))
+
+QUANT_PASSTHROUGH_MAX = int(os.environ.get("QUANT_PASSTHROUGH_MAX", "65536"))
+QUANT_SAVE_NAME = os.environ.get("QUANT_SAVE_NAME", "final_model.nbit.ptz")
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0(
+    f"mixed_nbit_quant: enabled={MIXED_NBIT_QUANT}, matrix={MATRIX_BITS}, embed={EMBED_BITS}, "
+    f"head={HEAD_BITS}, ssm={SSM_BITS}, attn={ATTN_BITS}, ffn={FFN_BITS}, save={QUANT_SAVE_NAME}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+
+# -----------------------------------------------------------------------------
+# Mixed n-bit quantization helpers
+# -----------------------------------------------------------------------------
+def _tensor_role_for_quant(name: str):
+    n = name.lower()
+    if "tok_emb.weight" in n or "embed_proj" in n:
+        return "embed"
+    if "lm_head" in n:
+        return "head"
+    if "qkv" in n or "out_proj" in n or "attn" in n:
+        return "attn"
+    if "ffn" in n or "mlp" in n:
+        return "ffn"
+    if "mamba" in n:
+        return "ssm"
+    return "matrix"
+
+
+def _bits_for_name(name: str):
+    role = _tensor_role_for_quant(name)
+    if role == "embed":
+        return EMBED_BITS
+    if role == "head":
+        return HEAD_BITS
+    if role == "attn":
+        return ATTN_BITS
+    if role == "ffn":
+        return FFN_BITS
+    if role == "ssm":
+        return SSM_BITS
+    return MATRIX_BITS
+
+
+def _sigmas_for_name(name: str):
+    role = _tensor_role_for_quant(name)
+    if role == "embed":
+        return EMBED_CLIP_SIGMAS
+    if role == "head":
+        return HEAD_CLIP_SIGMAS
+    if role == "attn":
+        return ATTN_CLIP_SIGMAS
+    if role == "ffn":
+        return FFN_CLIP_SIGMAS
+    if role == "ssm":
+        return SSM_CLIP_SIGMAS
+    return MATRIX_CLIP_SIGMAS
+
+
+def _pack_nbit_uint(vals_np, bits: int):
+    """Pack uint values in [0, 2**bits-1] into bytes. Supports 4, 6, 7, 8."""
+    import numpy as _np
+    vals = vals_np.astype(_np.uint8, copy=False).reshape(-1)
+    n = vals.size
+
+    if bits == 8:
+        return vals.copy(), n
+
+    if bits == 4:
+        pad = (-n) % 2
+        if pad:
+            vals = _np.pad(vals, (0, pad), constant_values=0)
+        a = vals.reshape(-1, 2)
+        packed = (a[:, 0] | (a[:, 1] << 4)).astype(_np.uint8)
+        return packed, n
+
+    if bits == 6:
+        pad = (-n) % 4
+        if pad:
+            vals = _np.pad(vals, (0, pad), constant_values=0)
+        a = vals.reshape(-1, 4).astype(_np.uint16)
+        b0 = (a[:, 0] | ((a[:, 1] & 0x03) << 6)).astype(_np.uint8)
+        b1 = ((a[:, 1] >> 2) | ((a[:, 2] & 0x0F) << 4)).astype(_np.uint8)
+        b2 = ((a[:, 2] >> 4) | (a[:, 3] << 2)).astype(_np.uint8)
+        packed = _np.stack([b0, b1, b2], axis=1).reshape(-1)
+        return packed, n
+
+    if bits == 7:
+        pad = (-n) % 8
+        if pad:
+            vals = _np.pad(vals, (0, pad), constant_values=0)
+        a = vals.reshape(-1, 8).astype(_np.uint64)
+        word = (
+            a[:, 0]
+            | (a[:, 1] << 7)
+            | (a[:, 2] << 14)
+            | (a[:, 3] << 21)
+            | (a[:, 4] << 28)
+            | (a[:, 5] << 35)
+            | (a[:, 6] << 42)
+            | (a[:, 7] << 49)
+        )
+        packed8 = word.view(_np.uint8).reshape(-1, 8)
+        packed = packed8[:, :7].reshape(-1).copy()
+        return packed, n
+
+    raise ValueError(f"Unsupported n-bit pack bits={bits}; use 4, 6, 7, or 8")
+
+
+def _unpack_nbit_uint(packed_np, bits: int, n_vals: int):
+    """Unpack bytes to uint values. Supports 4, 6, 7, 8."""
+    import numpy as _np
+    p = packed_np.astype(_np.uint8, copy=False).reshape(-1)
+
+    if bits == 8:
+        return p[:n_vals].copy()
+
+    if bits == 4:
+        out = _np.empty(p.size * 2, dtype=_np.uint8)
+        out[0::2] = p & 0x0F
+        out[1::2] = p >> 4
+        return out[:n_vals].copy()
+
+    if bits == 6:
+        a = p.reshape(-1, 3).astype(_np.uint16)
+        out = _np.empty(a.shape[0] * 4, dtype=_np.uint8)
+        out[0::4] = (a[:, 0] & 0x3F).astype(_np.uint8)
+        out[1::4] = (((a[:, 0] >> 6) | ((a[:, 1] & 0x0F) << 2)) & 0x3F).astype(_np.uint8)
+        out[2::4] = (((a[:, 1] >> 4) | ((a[:, 2] & 0x03) << 4)) & 0x3F).astype(_np.uint8)
+        out[3::4] = ((a[:, 2] >> 2) & 0x3F).astype(_np.uint8)
+        return out[:n_vals].copy()
+
+    if bits == 7:
+        groups = (p.size + 6) // 7
+        pad_len = groups * 7 - p.size
+        if pad_len:
+            p = _np.pad(p, (0, pad_len), constant_values=0)
+        p7 = p.reshape(-1, 7)
+        p8 = _np.zeros((p7.shape[0], 8), dtype=_np.uint8)
+        p8[:, :7] = p7
+        word = p8.reshape(-1).view(_np.uint64)
+        out = _np.empty(word.size * 8, dtype=_np.uint8)
+        mask = _np.uint64(0x7F)
+        for i in range(8):
+            out[i::8] = ((word >> _np.uint64(7 * i)) & mask).astype(_np.uint8)
+        return out[:n_vals].copy()
+
+    raise ValueError(f"Unsupported n-bit unpack bits={bits}; use 4, 6, 7, or 8")
+
+
+def _sdclip_quantize_tensor(name: str, t_cpu: torch.Tensor, bits: int):
+    """Return packed uint8 tensor, metadata, and scale for a floating tensor."""
+    import numpy as _np
+    t32 = t_cpu.float().contiguous()
+    qmax = (1 << (bits - 1)) - 1
+    offset = qmax
+    sigmas = _sigmas_for_name(name)
+
+    if t32.ndim == 2:
+        rows = t32.shape[0]
+        flat = t32.view(rows, -1)
+        std = flat.std(dim=1, unbiased=False).clamp_min(1e-8)
+        absmax = flat.abs().amax(dim=1).clamp_min(1e-8)
+        clip_abs = torch.minimum(absmax, std * sigmas).clamp_min(1.0 / qmax)
+        scale = (clip_abs / qmax).to(torch.float16).contiguous()
+        q = torch.round(torch.clamp(flat, -clip_abs[:, None], clip_abs[:, None]) / scale.float()[:, None])
+        q = torch.clamp(q, -qmax, qmax).to(torch.int16).view(-1)
+    else:
+        std = t32.std(unbiased=False).clamp_min(1e-8)
+        absmax = t32.abs().amax().clamp_min(1e-8)
+        clip_abs = torch.minimum(absmax, std * sigmas).clamp_min(1.0 / qmax)
+        scale = (clip_abs / qmax).to(torch.float16)
+        q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale.float())
+        q = torch.clamp(q, -qmax, qmax).to(torch.int16).view(-1)
+
+    vals = (q + offset).clamp(0, (1 << bits) - 1).to(torch.uint8).numpy()
+    packed_np, n_vals = _pack_nbit_uint(vals, bits)
+    packed = torch.from_numpy(packed_np.copy()).to(torch.uint8).contiguous()
+    meta = {
+        "bits": int(bits),
+        "shape": tuple(t_cpu.shape),
+        "n_vals": int(n_vals),
+        "qmax": int(qmax),
+    }
+    return packed, scale, meta
+
+
+def _dequantize_nbit_tensor(packed: torch.Tensor, scale: torch.Tensor, meta: dict):
+    import numpy as _np
+    bits = int(meta["bits"])
+    shape = tuple(meta["shape"])
+    n_vals = int(meta["n_vals"])
+    qmax = int(meta["qmax"])
+
+    vals = _unpack_nbit_uint(packed.cpu().numpy(), bits, n_vals).astype(_np.int16)
+    q = torch.from_numpy(vals).to(torch.int16) - qmax
+    if scale.ndim > 0:
+        rows = shape[0]
+        qf = q.float().view(rows, -1) * scale.float().view(rows, 1)
+        return qf.view(shape).to(torch.bfloat16)
+    else:
+        return (q.float().view(shape) * float(scale.item())).to(torch.bfloat16)
+
+
+def build_mixed_nbit_artifact(state_dict):
+    quantized = {}
+    scales = {}
+    metas = {}
+    passthrough = {}
+
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+
+        if (
+            (not t.is_floating_point())
+            or t.numel() <= QUANT_PASSTHROUGH_MAX
+            or t.ndim < 2
+        ):
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+
+        bits = int(_bits_for_name(name))
+        if bits not in (4, 6, 7, 8):
+            raise ValueError(f"{name}: unsupported bits={bits}; use 4, 6, 7, or 8")
+
+        packed, scale, meta = _sdclip_quantize_tensor(name, t, bits)
+        quantized[name] = packed
+        scales[name] = scale
+        metas[name] = meta
+
+    return {
+        "format": "mixed_nbit_sdclip_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "metas": metas,
+        "passthrough": passthrough,
+        "config": {
+            "matrix_bits": MATRIX_BITS,
+            "embed_bits": EMBED_BITS,
+            "head_bits": HEAD_BITS,
+            "ssm_bits": SSM_BITS,
+            "attn_bits": ATTN_BITS,
+            "ffn_bits": FFN_BITS,
+            "matrix_clip_sigmas": MATRIX_CLIP_SIGMAS,
+            "embed_clip_sigmas": EMBED_CLIP_SIGMAS,
+            "head_clip_sigmas": HEAD_CLIP_SIGMAS,
+        },
+    }
+
+
+def dequantize_mixed_nbit_artifact(obj):
+    state = {}
+    for name, packed in obj["quantized"].items():
+        state[name] = _dequantize_nbit_tensor(packed, obj["scales"][name], obj["metas"][name])
+    for name, t in obj["passthrough"].items():
+        state[name] = t
+    return state
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Mixed n-bit quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    state_dict = base_model.state_dict()
+    import io
+    if MIXED_NBIT_QUANT:
+        log0(
+            f"Quantizing model to mixed n-bit SDClip "
+            f"(matrix={MATRIX_BITS}, embed={EMBED_BITS}, head={HEAD_BITS}, "
+            f"ssm={SSM_BITS}, attn={ATTN_BITS}, ffn={FFN_BITS})..."
+        )
+        quant_obj = build_mixed_nbit_artifact(state_dict)
+    else:
+        log0("Quantizing model to legacy int8...")
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+        quant_obj = {"format": "legacy_int8", "quantized": quantized, "scales": scales, "passthrough": passthrough}
+
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    if quant_obj_rt.get("format") == "mixed_nbit_sdclip_v1":
+        dequant_state = dequantize_mixed_nbit_artifact(quant_obj_rt)
+    else:
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    if MASTER_PROCESS:
+        artifact_path = QUANT_SAVE_NAME if MIXED_NBIT_QUANT else "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_parallel_hybrid.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_parallel_hybrid.py
@@ -1,0 +1,2419 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Parallel Hybrid Block config
+# If enabled, selected layer(s) become full-width parallel SSM + full attention blocks.
+# Unlike the earlier sidecar, attention is not narrow/auxiliary: full attention and full SSM
+# process the same input, then a learned gate controls how much SSM branch is added.
+HYBRID_PARALLEL_ENABLED = os.environ.get("HYBRID_PARALLEL_ENABLED", "0") == "1"
+HYBRID_PARALLEL_IDXS = [int(x) for x in os.environ.get("HYBRID_PARALLEL_IDXS", "5").split(",") if x.strip()]
+HYBRID_PARALLEL_SSM_GATE_INIT = float(os.environ.get("HYBRID_PARALLEL_SSM_GATE_INIT", "-2.0"))
+HYBRID_PARALLEL_ZERO_ATTN_OUT = os.environ.get("HYBRID_PARALLEL_ZERO_ATTN_OUT", "1") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"hybrid_parallel: enabled={HYBRID_PARALLEL_ENABLED}, idxs={HYBRID_PARALLEL_IDXS}, ssm_gate_init={HYBRID_PARALLEL_SSM_GATE_INIT}, zero_attn_out={HYBRID_PARALLEL_ZERO_ATTN_OUT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class ParallelHybridBlock(nn.Module):
+    """Full-width parallel SSM + attention mixer."""
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, n_heads=8, ffn_mult=3):
+        super().__init__()
+        if d_model % n_heads != 0:
+            raise ValueError(f"d_model={d_model} must be divisible by n_heads={n_heads}")
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # SSM branch: compressed/fading sequence dynamics.
+        self.ssm_norm = RMSNorm(d_model)
+        self.mamba = Mamba2(d_model=d_model, d_state=d_state, d_conv=conv_kernel, expand=2)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ssm_gate = nn.Parameter(torch.full((d_model,), HYBRID_PARALLEL_SSM_GATE_INIT))
+
+        # Attention branch: exact recall / key-value lookup.
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        if HYBRID_PARALLEL_ZERO_ATTN_OUT:
+            nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+
+        # One shared FFN after merged mixer.
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_ssm_in = x + mem_mix * mem_ctx
+        else:
+            x_ssm_in = x
+
+        ssm_out = self.mamba(self.ssm_norm(x_ssm_in))
+        if isinstance(ssm_out, tuple):
+            ssm_out = ssm_out[0]
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        attn_out = self.out_proj(attn_out)
+
+        ssm_gate = torch.sigmoid(self.ssm_gate).to(ssm_out.dtype)
+        x = x + self.attn_scale[None, None, :] * attn_out
+        x = x + ssm_gate[None, None, :] * self.ssm_scale[None, None, :] * ssm_out
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + optional full-attention or parallel hybrid layers.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        parallel_set = set(HYBRID_PARALLEL_IDXS) if HYBRID_PARALLEL_ENABLED else set()
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in parallel_set:
+                layers.append(ParallelHybridBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, ATTN_N_HEADS, FFN_MULT))
+            elif i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best.py
@@ -1,0 +1,2333 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_fused.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_fused.py
@@ -1,0 +1,2960 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+# Trainable compact-FFN mode. Instead of post-hoc SVD, this trains a compact
+# FFN parameterization from scratch:
+#   - full independent FFNs on COMPACT_FFN_KEEP_FULL_IDXS, by default attention
+#     layer 6 and final layer 9
+#   - all other SSM FFNs use one shared SwiGLU base plus per-layer low-rank
+#     trainable residual/delta adapters.
+COMPACT_FFN_ENABLED = os.environ.get("COMPACT_FFN_ENABLED", "1") == "1"
+COMPACT_FFN_RANK = int(os.environ.get("COMPACT_FFN_RANK", "64"))
+COMPACT_FFN_ALPHA = float(os.environ.get("COMPACT_FFN_ALPHA", str(COMPACT_FFN_RANK)))
+# Throughput mode: fuse/materialize low-rank deltas into dense effective
+# weights inside each forward. This replaces two activation-sized skinny
+# matmuls per compact FFN with one large dense GEMM. It adds only small
+# weight-space matmuls: (out x rank) @ (rank x in), which is tiny compared
+# with B*T token matmuls at seq_len=8192.
+COMPACT_FFN_FUSE_DELTAS = os.environ.get("COMPACT_FFN_FUSE_DELTAS", "1") == "1"
+COMPACT_FFN_TARGET_LAYERS_RAW = os.environ.get("COMPACT_FFN_TARGET_LAYERS", "all_ssm")
+COMPACT_FFN_KEEP_FULL_IDXS_RAW = os.environ.get("COMPACT_FFN_KEEP_FULL_IDXS", "6,9")
+
+def _parse_idx_set(raw: str):
+    raw = str(raw).strip()
+    if raw == "":
+        return set()
+    return {int(x) for x in raw.split(",") if x.strip()}
+
+def _resolve_compact_keep_full_idxs():
+    if COMPACT_FFN_KEEP_FULL_IDXS_RAW.strip():
+        return _parse_idx_set(COMPACT_FFN_KEEP_FULL_IDXS_RAW)
+    return set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1}
+
+def _resolve_compact_target_idxs():
+    if not COMPACT_FFN_ENABLED:
+        return set()
+    keep = _resolve_compact_keep_full_idxs()
+    raw = COMPACT_FFN_TARGET_LAYERS_RAW.strip().lower()
+    if raw in ("all_ssm", "ssm", "all_non_attn"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in set(ATTN_LAYER_IDXS) and i not in keep}
+    if raw in ("all", "all_layers"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in keep}
+    if raw in ("none", "off", ""):
+        return set()
+    return _parse_idx_set(COMPACT_FFN_TARGET_LAYERS_RAW) - keep
+
+COMPACT_FFN_KEEP_FULL_IDXS = sorted(_resolve_compact_keep_full_idxs())
+COMPACT_FFN_TARGET_IDXS = sorted(_resolve_compact_target_idxs())
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(
+    f"compact_ffn_trainable: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+    f"alpha={COMPACT_FFN_ALPHA}, targets={COMPACT_FFN_TARGET_IDXS}, "
+    f"keep_full={COMPACT_FFN_KEEP_FULL_IDXS}, fuse_deltas={COMPACT_FFN_FUSE_DELTAS}"
+)
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compactffn_trainable_defaults: uploaded-best SSM backbone + full FFN at keep layers + shared-base/rank-delta FFNs for SSM layers; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class LowRankDeltaLinear(nn.Module):
+    """Trainable low-rank additive delta for a shared/base Linear weight."""
+    def __init__(self, in_features, out_features, rank, alpha):
+        super().__init__()
+        self.rank = int(rank)
+        self.scaling = float(alpha) / max(int(rank), 1)
+        # LoRA-style init: B random, A zero => exact base model at init, but A
+        # gets gradients immediately. This avoids destabilizing early training.
+        self.B = nn.Parameter(torch.empty(self.rank, in_features))
+        self.A = nn.Parameter(torch.zeros(out_features, self.rank))
+        nn.init.kaiming_uniform_(self.B, a=math.sqrt(5))
+
+    def forward(self, x):
+        return F.linear(F.linear(x, self.B), self.A) * self.scaling
+
+
+class SharedLowRankFFN(nn.Module):
+    """Shared FFN base plus per-layer trainable low-rank deltas.
+
+    Two forward modes:
+      - fused/materialized: W_eff = W_base + scale * (A @ B), then one dense
+        F.linear over the token activations. This is faster on H100 for large
+        activation batches because it avoids skinny activation GEMMs.
+      - unfused: base(x) + A(B(x)), kept as a diagnostic fallback.
+    """
+    def __init__(self, d_model, ffn_mult, layer_idxs, rank=64, alpha=64.0):
+        super().__init__()
+        self.layer_keys = {int(i): f"l{int(i)}" for i in layer_idxs}
+        hidden = d_model * ffn_mult
+        self.hidden = hidden
+        self.is_swiglu = ACTIVATION != "leaky_relu2"
+        self.rank = int(rank)
+        self.scaling = float(alpha) / max(int(rank), 1)
+        gate_out = hidden * 2 if self.is_swiglu else hidden
+        self.gate_up = nn.Linear(d_model, gate_out, bias=False)
+        self.down = nn.Linear(hidden, d_model, bias=False)
+        nn.init.zeros_(self.down.weight)
+        self.delta_gate_up = nn.ModuleDict({
+            key: LowRankDeltaLinear(d_model, gate_out, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+        self.delta_down = nn.ModuleDict({
+            key: LowRankDeltaLinear(hidden, d_model, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+
+    def _effective_weight(self, base_weight: torch.Tensor, delta: LowRankDeltaLinear) -> torch.Tensor:
+        # delta.A: (out, rank), delta.B: (rank, in) => (out, in)
+        # Keep this differentiable; grads flow into A/B and base weight.
+        # Parameter-space matmul is tiny relative to the token matmuls.
+        return base_weight + (delta.A @ delta.B).to(dtype=base_weight.dtype) * delta.scaling
+
+    def _fused_forward(self, x, key: str):
+        gate_w = self._effective_weight(self.gate_up.weight, self.delta_gate_up[key])
+        gu = F.linear(x, gate_w)
+        if self.is_swiglu:
+            gate, up = gu.chunk(2, dim=-1)
+            h = F.silu(gate) * up
+        else:
+            h = F.leaky_relu(gu, negative_slope=0.5)
+            h = h * h
+        down_w = self._effective_weight(self.down.weight, self.delta_down[key])
+        return F.linear(h, down_w)
+
+    def _unfused_forward(self, x, key: str):
+        gu = self.gate_up(x) + self.delta_gate_up[key](x)
+        if self.is_swiglu:
+            gate, up = gu.chunk(2, dim=-1)
+            h = F.silu(gate) * up
+        else:
+            h = F.leaky_relu(gu, negative_slope=0.5)
+            h = h * h
+        return self.down(h) + self.delta_down[key](h)
+
+    def forward(self, x, layer_idx: int):
+        key = self.layer_keys[int(layer_idx)]
+        if COMPACT_FFN_FUSE_DELTAS:
+            return self._fused_forward(x, key)
+        return self._unfused_forward(x, key)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions.
+        # Compact-target SSM layers do not instantiate private FFNs; instead
+        # they call shared_compact_ssm_ffn after the SSM update.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        self.compact_ffn_target_idxs = sorted(set(COMPACT_FFN_TARGET_IDXS) & ffn_active_set)
+        self.compact_ffn_target_set = set(self.compact_ffn_target_idxs)
+        self.compact_ffn_keep_full_idxs = sorted(set(COMPACT_FFN_KEEP_FULL_IDXS))
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = (i in ffn_active_set) and (i not in self.compact_ffn_target_set)
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN logically active on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"Private/full FFNs instantiated on layers: {[i for i,b in enumerate(self.blocks) if getattr(b, '_has_ffn', False)]} / {N_UNIQUE_BLOCKS}")
+
+        if COMPACT_FFN_ENABLED and self.compact_ffn_target_idxs:
+            self.shared_compact_ssm_ffn = SharedLowRankFFN(
+                D_MODEL, FFN_MULT, self.compact_ffn_target_idxs,
+                rank=COMPACT_FFN_RANK, alpha=COMPACT_FFN_ALPHA,
+            )
+            self.compact_ffn_norms = nn.ModuleDict({
+                f"l{i}": RMSNorm(D_MODEL) for i in self.compact_ffn_target_idxs
+            })
+            self.compact_ffn_scales = nn.ParameterDict({
+                f"l{i}": nn.Parameter(torch.ones(D_MODEL)) for i in self.compact_ffn_target_idxs
+            })
+        else:
+            self.shared_compact_ssm_ffn = None
+            self.compact_ffn_norms = nn.ModuleDict()
+            self.compact_ffn_scales = nn.ParameterDict()
+        log0(
+            f"compact_ffn: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+            f"alpha={COMPACT_FFN_ALPHA}, targets={self.compact_ffn_target_idxs}, "
+            f"keep_full={self.compact_ffn_keep_full_idxs}"
+        )
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_compact_ffn(self, x, layer_pos, block_idx, run_ffn):
+        if (
+            self.shared_compact_ssm_ffn is not None
+            and int(block_idx) in self.compact_ffn_target_set
+            and run_ffn
+        ):
+            key = f"l{int(block_idx)}"
+            x = x + self.compact_ffn_scales[key][None, None, :] * self.shared_compact_ssm_ffn(
+                self.compact_ffn_norms[key](x), int(block_idx)
+            )
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_fused_adamdelta2.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_fused_adamdelta2.py
@@ -1,0 +1,3050 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+# Trainable compact-FFN mode. Instead of post-hoc SVD, this trains a compact
+# FFN parameterization from scratch:
+#   - full independent FFNs on COMPACT_FFN_KEEP_FULL_IDXS, by default attention
+#     layer 6 and final layer 9
+#   - all other SSM FFNs use one shared SwiGLU base plus per-layer low-rank
+#     trainable residual/delta adapters.
+COMPACT_FFN_ENABLED = os.environ.get("COMPACT_FFN_ENABLED", "1") == "1"
+COMPACT_FFN_RANK = int(os.environ.get("COMPACT_FFN_RANK", "64"))
+COMPACT_FFN_ALPHA = float(os.environ.get("COMPACT_FFN_ALPHA", str(COMPACT_FFN_RANK)))
+# Throughput mode: fuse/materialize low-rank deltas into dense effective
+# weights inside each forward. This replaces two activation-sized skinny
+# matmuls per compact FFN with one large dense GEMM. It adds only small
+# weight-space matmuls: (out x rank) @ (rank x in), which is tiny compared
+# with B*T token matmuls at seq_len=8192.
+COMPACT_FFN_FUSE_DELTAS = os.environ.get("COMPACT_FFN_FUSE_DELTAS", "1") == "1"
+# Optimizer routing for compact low-rank adapters. Muon is excellent for big
+# dense matrices but slow/ill-suited for many skinny LoRA-style A/B factors.
+# Default: keep dense base matrices on Muon, route compact deltas to AdamW.
+COMPACT_FFN_DELTAS_OPT = os.environ.get("COMPACT_FFN_DELTAS_OPT", "adamw").lower()  # "adamw" or "muon"
+COMPACT_FFN_DELTA_LR = float(os.environ.get("COMPACT_FFN_DELTA_LR", "0.02"))
+COMPACT_FFN_DELTA_WD = float(os.environ.get("COMPACT_FFN_DELTA_WD", "0.02"))
+# Optional generic Muon filters. Defaults only catch compact delta factors.
+# Set MUON_MIN_DIM=129 or MUON_MIN_NUMEL=262144 to push tiny matrices to AdamW.
+MUON_MIN_DIM = int(os.environ.get("MUON_MIN_DIM", "129"))
+MUON_MIN_NUMEL = int(os.environ.get("MUON_MIN_NUMEL", "262144"))
+BIGRAM_OPT = os.environ.get("BIGRAM_OPT", "adamw").lower()  # "muon" or "adamw"
+COMPACT_FFN_TARGET_LAYERS_RAW = os.environ.get("COMPACT_FFN_TARGET_LAYERS", "all_ssm")
+COMPACT_FFN_KEEP_FULL_IDXS_RAW = os.environ.get("COMPACT_FFN_KEEP_FULL_IDXS", "6,9")
+
+def _parse_idx_set(raw: str):
+    raw = str(raw).strip()
+    if raw == "":
+        return set()
+    return {int(x) for x in raw.split(",") if x.strip()}
+
+def _resolve_compact_keep_full_idxs():
+    if COMPACT_FFN_KEEP_FULL_IDXS_RAW.strip():
+        return _parse_idx_set(COMPACT_FFN_KEEP_FULL_IDXS_RAW)
+    return set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1}
+
+def _resolve_compact_target_idxs():
+    if not COMPACT_FFN_ENABLED:
+        return set()
+    keep = _resolve_compact_keep_full_idxs()
+    raw = COMPACT_FFN_TARGET_LAYERS_RAW.strip().lower()
+    if raw in ("all_ssm", "ssm", "all_non_attn"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in set(ATTN_LAYER_IDXS) and i not in keep}
+    if raw in ("all", "all_layers"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in keep}
+    if raw in ("none", "off", ""):
+        return set()
+    return _parse_idx_set(COMPACT_FFN_TARGET_LAYERS_RAW) - keep
+
+COMPACT_FFN_KEEP_FULL_IDXS = sorted(_resolve_compact_keep_full_idxs())
+COMPACT_FFN_TARGET_IDXS = sorted(_resolve_compact_target_idxs())
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(
+    f"compact_ffn_trainable: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+    f"alpha={COMPACT_FFN_ALPHA}, targets={COMPACT_FFN_TARGET_IDXS}, "
+    f"keep_full={COMPACT_FFN_KEEP_FULL_IDXS}, fuse_deltas={COMPACT_FFN_FUSE_DELTAS}"
+)
+log0(
+    f"compact_ffn_delta_optimizer: opt={COMPACT_FFN_DELTAS_OPT}, "
+    f"lr={COMPACT_FFN_DELTA_LR}, wd={COMPACT_FFN_DELTA_WD}, "
+    f"muon_min_dim={MUON_MIN_DIM}, muon_min_numel={MUON_MIN_NUMEL}, bigram_opt={BIGRAM_OPT}"
+)
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compactffn_trainable_defaults: uploaded-best SSM backbone + full FFN at keep layers + shared-base/rank-delta FFNs for SSM layers; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class LowRankDeltaLinear(nn.Module):
+    """Trainable low-rank additive delta for a shared/base Linear weight."""
+    def __init__(self, in_features, out_features, rank, alpha):
+        super().__init__()
+        self.rank = int(rank)
+        self.scaling = float(alpha) / max(int(rank), 1)
+        # LoRA-style init: B random, A zero => exact base model at init, but A
+        # gets gradients immediately. This avoids destabilizing early training.
+        self.B = nn.Parameter(torch.empty(self.rank, in_features))
+        self.A = nn.Parameter(torch.zeros(out_features, self.rank))
+        nn.init.kaiming_uniform_(self.B, a=math.sqrt(5))
+
+    def forward(self, x):
+        return F.linear(F.linear(x, self.B), self.A) * self.scaling
+
+
+class SharedLowRankFFN(nn.Module):
+    """Shared FFN base plus per-layer trainable low-rank deltas.
+
+    Two forward modes:
+      - fused/materialized: W_eff = W_base + scale * (A @ B), then one dense
+        F.linear over the token activations. This is faster on H100 for large
+        activation batches because it avoids skinny activation GEMMs.
+      - unfused: base(x) + A(B(x)), kept as a diagnostic fallback.
+    """
+    def __init__(self, d_model, ffn_mult, layer_idxs, rank=64, alpha=64.0):
+        super().__init__()
+        self.layer_keys = {int(i): f"l{int(i)}" for i in layer_idxs}
+        hidden = d_model * ffn_mult
+        self.hidden = hidden
+        self.is_swiglu = ACTIVATION != "leaky_relu2"
+        self.rank = int(rank)
+        self.scaling = float(alpha) / max(int(rank), 1)
+        gate_out = hidden * 2 if self.is_swiglu else hidden
+        self.gate_up = nn.Linear(d_model, gate_out, bias=False)
+        self.down = nn.Linear(hidden, d_model, bias=False)
+        nn.init.zeros_(self.down.weight)
+        self.delta_gate_up = nn.ModuleDict({
+            key: LowRankDeltaLinear(d_model, gate_out, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+        self.delta_down = nn.ModuleDict({
+            key: LowRankDeltaLinear(hidden, d_model, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+
+    def _effective_weight(self, base_weight: torch.Tensor, delta: LowRankDeltaLinear) -> torch.Tensor:
+        # delta.A: (out, rank), delta.B: (rank, in) => (out, in)
+        # Keep this differentiable; grads flow into A/B and base weight.
+        # Parameter-space matmul is tiny relative to the token matmuls.
+        return base_weight + (delta.A @ delta.B).to(dtype=base_weight.dtype) * delta.scaling
+
+    def _fused_forward(self, x, key: str):
+        gate_w = self._effective_weight(self.gate_up.weight, self.delta_gate_up[key])
+        gu = F.linear(x, gate_w)
+        if self.is_swiglu:
+            gate, up = gu.chunk(2, dim=-1)
+            h = F.silu(gate) * up
+        else:
+            h = F.leaky_relu(gu, negative_slope=0.5)
+            h = h * h
+        down_w = self._effective_weight(self.down.weight, self.delta_down[key])
+        return F.linear(h, down_w)
+
+    def _unfused_forward(self, x, key: str):
+        gu = self.gate_up(x) + self.delta_gate_up[key](x)
+        if self.is_swiglu:
+            gate, up = gu.chunk(2, dim=-1)
+            h = F.silu(gate) * up
+        else:
+            h = F.leaky_relu(gu, negative_slope=0.5)
+            h = h * h
+        return self.down(h) + self.delta_down[key](h)
+
+    def forward(self, x, layer_idx: int):
+        key = self.layer_keys[int(layer_idx)]
+        if COMPACT_FFN_FUSE_DELTAS:
+            return self._fused_forward(x, key)
+        return self._unfused_forward(x, key)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions.
+        # Compact-target SSM layers do not instantiate private FFNs; instead
+        # they call shared_compact_ssm_ffn after the SSM update.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        self.compact_ffn_target_idxs = sorted(set(COMPACT_FFN_TARGET_IDXS) & ffn_active_set)
+        self.compact_ffn_target_set = set(self.compact_ffn_target_idxs)
+        self.compact_ffn_keep_full_idxs = sorted(set(COMPACT_FFN_KEEP_FULL_IDXS))
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = (i in ffn_active_set) and (i not in self.compact_ffn_target_set)
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN logically active on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"Private/full FFNs instantiated on layers: {[i for i,b in enumerate(self.blocks) if getattr(b, '_has_ffn', False)]} / {N_UNIQUE_BLOCKS}")
+
+        if COMPACT_FFN_ENABLED and self.compact_ffn_target_idxs:
+            self.shared_compact_ssm_ffn = SharedLowRankFFN(
+                D_MODEL, FFN_MULT, self.compact_ffn_target_idxs,
+                rank=COMPACT_FFN_RANK, alpha=COMPACT_FFN_ALPHA,
+            )
+            self.compact_ffn_norms = nn.ModuleDict({
+                f"l{i}": RMSNorm(D_MODEL) for i in self.compact_ffn_target_idxs
+            })
+            self.compact_ffn_scales = nn.ParameterDict({
+                f"l{i}": nn.Parameter(torch.ones(D_MODEL)) for i in self.compact_ffn_target_idxs
+            })
+        else:
+            self.shared_compact_ssm_ffn = None
+            self.compact_ffn_norms = nn.ModuleDict()
+            self.compact_ffn_scales = nn.ParameterDict()
+        log0(
+            f"compact_ffn: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+            f"alpha={COMPACT_FFN_ALPHA}, targets={self.compact_ffn_target_idxs}, "
+            f"keep_full={self.compact_ffn_keep_full_idxs}"
+        )
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_compact_ffn(self, x, layer_pos, block_idx, run_ffn):
+        if (
+            self.shared_compact_ssm_ffn is not None
+            and int(block_idx) in self.compact_ffn_target_set
+            and run_ffn
+        ):
+            key = f"l{int(block_idx)}"
+            x = x + self.compact_ffn_scales[key][None, None, :] * self.shared_compact_ssm_ffn(
+                self.compact_ffn_norms[key](x), int(block_idx)
+            )
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def _is_compact_ffn_delta_param(name: str) -> bool:
+    """True for per-layer low-rank compact-FFN A/B delta factors."""
+    if "shared_compact_ssm_ffn" not in name:
+        return False
+    return ("delta_gate_up" in name or "delta_down" in name) and (name.endswith(".A") or name.endswith(".B"))
+
+
+def _route_name_role(name: str) -> str:
+    if _is_compact_ffn_delta_param(name):
+        return "compact_delta"
+    if "shared_compact_ssm_ffn.gate_up.weight" in name or "shared_compact_ssm_ffn.down.weight" in name:
+        return "compact_base"
+    if ".mamba.in_proj.weight" in name:
+        return "mamba_in_proj"
+    if ".mamba.out_proj.weight" in name:
+        return "mamba_out_proj"
+    if ".qkv.weight" in name or ".out_proj.weight" in name:
+        return "attention"
+    if ".ffn.gate_up.weight" in name or ".ffn.down.weight" in name:
+        return "private_ffn"
+    if name.startswith("bigram."):
+        return "bigram"
+    if name in ("embed_proj.weight", "embed_proj_rev.weight"):
+        return "embed_proj"
+    if name in ("tok_emb.weight", "lm_head.weight"):
+        return "token_embed"
+    return "generic"
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params, compact_delta_params = [], [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    adamw_matrix_count = 0
+    role_counts_muon = {}
+    role_counts_adamw_delta = {}
+    role_counts_adamw_scalar = {}
+    role_counts_embed = {}
+    _seen_data_ptrs = set()  # handle tied params
+
+    def bump(d, k):
+        d[k] = d.get(k, 0) + 1
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        role = _route_name_role(name)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            bump(role_counts_embed, role)
+            continue
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        is_matrix_for_muon_shape = ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2))
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+        force_adamw_matrix = False
+        if _is_compact_ffn_delta_param(name) and COMPACT_FFN_DELTAS_OPT == "adamw":
+            force_adamw_matrix = True
+        if BIGRAM_OPT == "adamw" and name.startswith("bigram."):
+            force_adamw_matrix = True
+        if p.ndim == 2 and MUON_MIN_DIM > 0 and min(p.shape) <= MUON_MIN_DIM:
+            force_adamw_matrix = True
+        if p.ndim == 2 and MUON_MIN_NUMEL > 0 and p.numel() <= MUON_MIN_NUMEL:
+            force_adamw_matrix = True
+        if is_matrix_for_muon_shape and not is_control and not force_adamw_matrix:
+            mat_params.append(p)
+            bump(role_counts_muon, role)
+        elif force_adamw_matrix:
+            compact_delta_params.append(p)
+            adamw_matrix_count += 1
+            bump(role_counts_adamw_delta, role)
+        else:
+            scalar_params.append(p)
+            bump(role_counts_adamw_scalar, role)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    adamw_groups = [
+        {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR, "name": "scalar_control"},
+        {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR, "name": "embed"},
+    ]
+    if compact_delta_params:
+        adamw_groups.append({
+            "params": compact_delta_params,
+            "lr": COMPACT_FFN_DELTA_LR,
+            "weight_decay": COMPACT_FFN_DELTA_WD,
+            "base_lr": COMPACT_FFN_DELTA_LR,
+            "name": "compact_delta_matrix",
+        })
+
+    optimizer_adamw = torch.optim.AdamW(
+        adamw_groups,
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+
+    def fmt_roles(d):
+        return ", ".join(f"{k}={v}" for k, v in sorted(d.items())) if d else "none"
+
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"compact_delta_matrix={len(compact_delta_params)} (AdamW), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}; "
+        f"adamw_matrix_forced={adamw_matrix_count}"
+    )
+    log0(f"Optimizer roles Muon: {fmt_roles(role_counts_muon)}")
+    log0(f"Optimizer roles AdamW compact/matrix: {fmt_roles(role_counts_adamw_delta)}")
+    log0(f"Optimizer roles AdamW scalar/control: {fmt_roles(role_counts_adamw_scalar)}")
+    log0(f"Optimizer roles AdamW embed: {fmt_roles(role_counts_embed)}")
+    return optimizer_adamw, optimizer_muon, mat_params
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_trainable.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_compactffn_trainable.py
@@ -1,0 +1,2922 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+# Trainable compact-FFN mode. Instead of post-hoc SVD, this trains a compact
+# FFN parameterization from scratch:
+#   - full independent FFNs on COMPACT_FFN_KEEP_FULL_IDXS, by default attention
+#     layer 6 and final layer 9
+#   - all other SSM FFNs use one shared SwiGLU base plus per-layer low-rank
+#     trainable residual/delta adapters.
+COMPACT_FFN_ENABLED = os.environ.get("COMPACT_FFN_ENABLED", "1") == "1"
+COMPACT_FFN_RANK = int(os.environ.get("COMPACT_FFN_RANK", "64"))
+COMPACT_FFN_ALPHA = float(os.environ.get("COMPACT_FFN_ALPHA", str(COMPACT_FFN_RANK)))
+COMPACT_FFN_TARGET_LAYERS_RAW = os.environ.get("COMPACT_FFN_TARGET_LAYERS", "all_ssm")
+COMPACT_FFN_KEEP_FULL_IDXS_RAW = os.environ.get("COMPACT_FFN_KEEP_FULL_IDXS", "6,9")
+
+def _parse_idx_set(raw: str):
+    raw = str(raw).strip()
+    if raw == "":
+        return set()
+    return {int(x) for x in raw.split(",") if x.strip()}
+
+def _resolve_compact_keep_full_idxs():
+    if COMPACT_FFN_KEEP_FULL_IDXS_RAW.strip():
+        return _parse_idx_set(COMPACT_FFN_KEEP_FULL_IDXS_RAW)
+    return set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1}
+
+def _resolve_compact_target_idxs():
+    if not COMPACT_FFN_ENABLED:
+        return set()
+    keep = _resolve_compact_keep_full_idxs()
+    raw = COMPACT_FFN_TARGET_LAYERS_RAW.strip().lower()
+    if raw in ("all_ssm", "ssm", "all_non_attn"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in set(ATTN_LAYER_IDXS) and i not in keep}
+    if raw in ("all", "all_layers"):
+        return {i for i in range(N_UNIQUE_BLOCKS) if i not in keep}
+    if raw in ("none", "off", ""):
+        return set()
+    return _parse_idx_set(COMPACT_FFN_TARGET_LAYERS_RAW) - keep
+
+COMPACT_FFN_KEEP_FULL_IDXS = sorted(_resolve_compact_keep_full_idxs())
+COMPACT_FFN_TARGET_IDXS = sorted(_resolve_compact_target_idxs())
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(
+    f"compact_ffn_trainable: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+    f"alpha={COMPACT_FFN_ALPHA}, targets={COMPACT_FFN_TARGET_IDXS}, "
+    f"keep_full={COMPACT_FFN_KEEP_FULL_IDXS}"
+)
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compactffn_trainable_defaults: uploaded-best SSM backbone + full FFN at keep layers + shared-base/rank-delta FFNs for SSM layers; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class LowRankDeltaLinear(nn.Module):
+    """Trainable low-rank additive delta for a shared/base Linear weight."""
+    def __init__(self, in_features, out_features, rank, alpha):
+        super().__init__()
+        self.rank = int(rank)
+        self.scaling = float(alpha) / max(int(rank), 1)
+        # LoRA-style init: B random, A zero => exact base model at init, but A
+        # gets gradients immediately. This avoids destabilizing early training.
+        self.B = nn.Parameter(torch.empty(self.rank, in_features))
+        self.A = nn.Parameter(torch.zeros(out_features, self.rank))
+        nn.init.kaiming_uniform_(self.B, a=math.sqrt(5))
+
+    def forward(self, x):
+        return F.linear(F.linear(x, self.B), self.A) * self.scaling
+
+
+class SharedLowRankFFN(nn.Module):
+    """Shared FFN base plus per-layer trainable low-rank deltas."""
+    def __init__(self, d_model, ffn_mult, layer_idxs, rank=64, alpha=64.0):
+        super().__init__()
+        self.layer_keys = {int(i): f"l{int(i)}" for i in layer_idxs}
+        hidden = d_model * ffn_mult
+        self.hidden = hidden
+        self.is_swiglu = ACTIVATION != "leaky_relu2"
+        gate_out = hidden * 2 if self.is_swiglu else hidden
+        self.gate_up = nn.Linear(d_model, gate_out, bias=False)
+        self.down = nn.Linear(hidden, d_model, bias=False)
+        nn.init.zeros_(self.down.weight)
+        self.delta_gate_up = nn.ModuleDict({
+            key: LowRankDeltaLinear(d_model, gate_out, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+        self.delta_down = nn.ModuleDict({
+            key: LowRankDeltaLinear(hidden, d_model, rank, alpha)
+            for key in self.layer_keys.values()
+        })
+
+    def forward(self, x, layer_idx: int):
+        key = self.layer_keys[int(layer_idx)]
+        gu = self.gate_up(x) + self.delta_gate_up[key](x)
+        if self.is_swiglu:
+            gate, up = gu.chunk(2, dim=-1)
+            h = F.silu(gate) * up
+        else:
+            h = F.leaky_relu(gu, negative_slope=0.5)
+            h = h * h
+        return self.down(h) + self.delta_down[key](h)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions.
+        # Compact-target SSM layers do not instantiate private FFNs; instead
+        # they call shared_compact_ssm_ffn after the SSM update.
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        self.compact_ffn_target_idxs = sorted(set(COMPACT_FFN_TARGET_IDXS) & ffn_active_set)
+        self.compact_ffn_target_set = set(self.compact_ffn_target_idxs)
+        self.compact_ffn_keep_full_idxs = sorted(set(COMPACT_FFN_KEEP_FULL_IDXS))
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = (i in ffn_active_set) and (i not in self.compact_ffn_target_set)
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN logically active on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+        log0(f"Private/full FFNs instantiated on layers: {[i for i,b in enumerate(self.blocks) if getattr(b, '_has_ffn', False)]} / {N_UNIQUE_BLOCKS}")
+
+        if COMPACT_FFN_ENABLED and self.compact_ffn_target_idxs:
+            self.shared_compact_ssm_ffn = SharedLowRankFFN(
+                D_MODEL, FFN_MULT, self.compact_ffn_target_idxs,
+                rank=COMPACT_FFN_RANK, alpha=COMPACT_FFN_ALPHA,
+            )
+            self.compact_ffn_norms = nn.ModuleDict({
+                f"l{i}": RMSNorm(D_MODEL) for i in self.compact_ffn_target_idxs
+            })
+            self.compact_ffn_scales = nn.ParameterDict({
+                f"l{i}": nn.Parameter(torch.ones(D_MODEL)) for i in self.compact_ffn_target_idxs
+            })
+        else:
+            self.shared_compact_ssm_ffn = None
+            self.compact_ffn_norms = nn.ModuleDict()
+            self.compact_ffn_scales = nn.ParameterDict()
+        log0(
+            f"compact_ffn: enabled={COMPACT_FFN_ENABLED}, rank={COMPACT_FFN_RANK}, "
+            f"alpha={COMPACT_FFN_ALPHA}, targets={self.compact_ffn_target_idxs}, "
+            f"keep_full={self.compact_ffn_keep_full_idxs}"
+        )
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_compact_ffn(self, x, layer_pos, block_idx, run_ffn):
+        if (
+            self.shared_compact_ssm_ffn is not None
+            and int(block_idx) in self.compact_ffn_target_set
+            and run_ffn
+        ):
+            key = f"l{int(block_idx)}"
+            x = x + self.compact_ffn_scales[key][None, None, :] * self.shared_compact_ssm_ffn(
+                self.compact_ffn_norms[key](x), int(block_idx)
+            )
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                x = self._apply_compact_ffn(x, layer_pos, block_idx, run_ffn)
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final.py
@@ -1,0 +1,2384 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: FFN weights are instantiated only on attention layers + final block by default.
+# Set FFN_ACTIVE_POLICY=all to recover the original FFN-everywhere model.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "attn_final").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn)
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_ACTIVE_POLICY == "all":
+                if FFN_FREQ_MODE == "unroll":
+                    run_ffn = True
+                else:
+                    run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            else:
+                run_ffn = block_idx in self.ffn_active_idxs
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            if FFN_ACTIVE_POLICY == "all":
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            else:
+                run_ffn = block_idx in self.ffn_active_idxs
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final_2attn_tailrope.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final_2attn_tailrope.py
@@ -1,0 +1,2853 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: 2-attention FFN-sparse 8192-context sweep.
+# Defaults: attention layers 2,6; FFNs only on attention layers + final block; RoPE dim 32; tail-weighted train loss.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "2"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "attn_final").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "2,6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "32"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.10"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: SEQ_LEN=8192, ATTN_LAYER_IDXS=2,6, FFN_MULT=2, FFN_ACTIVE_POLICY=attn_final, ROPE_DIM=32, TAIL_LOSS_WEIGHT=0.10")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final_ssmfix.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_attn_final_ssmfix.py
@@ -1,0 +1,2786 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: FFN weights are instantiated only on attention layers + final block by default.
+# Set FFN_ACTIVE_POLICY=all to recover the original FFN-everywhere model.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "attn_final").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_svd64.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ffn_svd64.py
@@ -1,0 +1,3015 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+
+# Post-training FFN structural compression ablation.
+# Train the full model normally, then replace FFNs with a shared-base +
+# per-layer low-rank SVD residual representation and re-evaluate pre-quant.
+# This tests whether full-FFN behavior can be represented compactly without
+# retraining from scratch.
+POST_TRAIN_FFN_SVD_ENABLED = os.environ.get("POST_TRAIN_FFN_SVD_ENABLED", "1") == "1"
+POST_TRAIN_FFN_SVD_RANK = int(os.environ.get("POST_TRAIN_FFN_SVD_RANK", "64"))
+# Comma-separated physical layer ids to leave as original full FFNs. Empty = compress all FFNs.
+POST_TRAIN_FFN_SVD_KEEP_FULL_IDXS = [
+    int(x) for x in os.environ.get("POST_TRAIN_FFN_SVD_KEEP_FULL_IDXS", "").split(",") if x.strip()
+]
+# Which FFNs to include in the shared-base mean / replacement target: all, ssm, attention.
+POST_TRAIN_FFN_SVD_SCOPE = os.environ.get("POST_TRAIN_FFN_SVD_SCOPE", "all").lower()
+# Run expensive sliding eval after SVD replacement. Standard eval always runs.
+POST_TRAIN_FFN_SVD_SLIDING_EVAL = os.environ.get("POST_TRAIN_FFN_SVD_SLIDING_EVAL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"post_train_ffn_svd: enabled={POST_TRAIN_FFN_SVD_ENABLED}, rank={POST_TRAIN_FFN_SVD_RANK}, scope={POST_TRAIN_FFN_SVD_SCOPE}, keep_full={POST_TRAIN_FFN_SVD_KEEP_FULL_IDXS}, sliding_eval={POST_TRAIN_FFN_SVD_SLIDING_EVAL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("clean_ssmfix_defaults: uploaded best architecture + headdim/dt/layer_idx + seq_idx + direct-kernel carryover; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+
+
+class SharedLowRankLinear(nn.Module):
+    """
+    Linear layer represented as shared_weight + low-rank delta.
+
+    For an original Linear weight W_i, we set:
+        W_i ≈ W_shared + B_i @ A_i
+    and compute F.linear(x, W_shared) + F.linear(F.linear(x, A_i), B_i)
+    without materializing the full dense W_i each forward.
+    """
+    def __init__(self, shared_weight: nn.Parameter, delta_a: torch.Tensor, delta_b: torch.Tensor):
+        super().__init__()
+        self.shared_weight = shared_weight
+        self.delta_a = nn.Parameter(delta_a.contiguous())  # (rank, in_features)
+        self.delta_b = nn.Parameter(delta_b.contiguous())  # (out_features, rank)
+        self.in_features = int(shared_weight.shape[1])
+        self.out_features = int(shared_weight.shape[0])
+        self.rank = int(delta_a.shape[0])
+        self.bias = None
+
+    def forward(self, x):
+        y = F.linear(x, self.shared_weight)
+        if self.rank > 0:
+            y = y + F.linear(F.linear(x, self.delta_a), self.delta_b)
+        return y
+
+
+def _unique_param_count(module: nn.Module) -> int:
+    seen = set()
+    total = 0
+    for p in module.parameters():
+        ptr = p.data_ptr()
+        if ptr in seen:
+            continue
+        seen.add(ptr)
+        total += p.numel()
+    return total
+
+
+def _should_svd_compress_ffn(block_idx: int, block: nn.Module) -> bool:
+    if block_idx in set(POST_TRAIN_FFN_SVD_KEEP_FULL_IDXS):
+        return False
+    if not hasattr(block, "ffn"):
+        return False
+    scope = POST_TRAIN_FFN_SVD_SCOPE
+    is_ssm = bool(getattr(block, "_is_ssm", False))
+    if scope == "all":
+        return True
+    if scope in ("ssm", "ssm_only"):
+        return is_ssm
+    if scope in ("attn", "attention", "attention_only"):
+        return not is_ssm
+    raise ValueError(f"Unknown POST_TRAIN_FFN_SVD_SCOPE={POST_TRAIN_FFN_SVD_SCOPE!r}")
+
+
+@torch.no_grad()
+def _svd_delta(residual: torch.Tensor, rank: int):
+    """Return (A, B) such that B @ A is a rank-r approximation of residual."""
+    out_dim, in_dim = residual.shape
+    r = max(0, min(int(rank), min(out_dim, in_dim)))
+    if r == 0:
+        A = torch.empty((0, in_dim), device=residual.device, dtype=residual.dtype)
+        B = torch.empty((out_dim, 0), device=residual.device, dtype=residual.dtype)
+        return A, B
+    # SVD in fp32 for numerical stability even under bf16 AMP/storage tests.
+    U, S, Vh = torch.linalg.svd(residual.float(), full_matrices=False)
+    U_r = U[:, :r]
+    S_r = S[:r]
+    Vh_r = Vh[:r, :]
+    # Put singular values into B so delta = B @ A.
+    B = (U_r * S_r[None, :]).to(dtype=residual.dtype)
+    A = Vh_r.to(dtype=residual.dtype)
+    return A.contiguous(), B.contiguous()
+
+
+@torch.no_grad()
+def apply_post_training_ffn_svd(model: nn.Module):
+    """
+    Replace selected independent FFNs with shared-base + rank-r SVD deltas.
+
+    This is a post-training structural-compression ablation. It does not
+    fine-tune after replacement; it immediately evaluates how much of the full
+    FFN stack can be represented by one shared FFN plus layer-specific low-rank
+    residuals.
+    """
+    if not POST_TRAIN_FFN_SVD_ENABLED:
+        return None
+
+    target_items = []
+    for i, block in enumerate(model.blocks):
+        if _should_svd_compress_ffn(i, block):
+            target_items.append((i, block.ffn))
+
+    if not target_items:
+        log0("POST_TRAIN_FFN_SVD: no FFNs matched target scope; skipping.")
+        return None
+
+    # Validate all selected FFNs have compatible shapes and activation mode.
+    gate_shapes = [tuple(ffn.gate_up.weight.shape) for _, ffn in target_items]
+    down_shapes = [tuple(ffn.down.weight.shape) for _, ffn in target_items]
+    is_swiglu_vals = [bool(getattr(ffn, "is_swiglu", True)) for _, ffn in target_items]
+    if len(set(gate_shapes)) != 1 or len(set(down_shapes)) != 1 or len(set(is_swiglu_vals)) != 1:
+        raise RuntimeError(
+            f"POST_TRAIN_FFN_SVD requires compatible FFNs; "
+            f"gate_shapes={set(gate_shapes)}, down_shapes={set(down_shapes)}, "
+            f"is_swiglu={set(is_swiglu_vals)}"
+        )
+
+    before_unique_params = _unique_param_count(model)
+    target_idxs = [i for i, _ in target_items]
+
+    # Shared bases are the mean of trained FFN weights over target layers.
+    gate_stack = torch.stack([ffn.gate_up.weight.detach().float() for _, ffn in target_items], dim=0)
+    down_stack = torch.stack([ffn.down.weight.detach().float() for _, ffn in target_items], dim=0)
+    shared_gate = nn.Parameter(gate_stack.mean(dim=0).to(device=gate_stack.device, dtype=target_items[0][1].gate_up.weight.dtype).contiguous())
+    shared_down = nn.Parameter(down_stack.mean(dim=0).to(device=down_stack.device, dtype=target_items[0][1].down.weight.dtype).contiguous())
+
+    rank = int(POST_TRAIN_FFN_SVD_RANK)
+    gate_resid_err_sum = 0.0
+    gate_resid_norm_sum = 0.0
+    down_resid_err_sum = 0.0
+    down_resid_norm_sum = 0.0
+
+    # Replace each target FFN's dense gate_up/down with shared+lowrank modules.
+    for idx, ffn in target_items:
+        orig_gate = ffn.gate_up.weight.detach()
+        orig_down = ffn.down.weight.detach()
+
+        gate_resid = orig_gate - shared_gate.detach().to(dtype=orig_gate.dtype)
+        down_resid = orig_down - shared_down.detach().to(dtype=orig_down.dtype)
+
+        gate_a, gate_b = _svd_delta(gate_resid, rank)
+        down_a, down_b = _svd_delta(down_resid, rank)
+
+        # Error diagnostics, computed in fp32 Frobenius norm.
+        gate_approx_resid = gate_b.float() @ gate_a.float()
+        down_approx_resid = down_b.float() @ down_a.float()
+        gate_err = (gate_resid.float() - gate_approx_resid).pow(2).sum().item()
+        gate_norm = gate_resid.float().pow(2).sum().item()
+        down_err = (down_resid.float() - down_approx_resid).pow(2).sum().item()
+        down_norm = down_resid.float().pow(2).sum().item()
+        gate_resid_err_sum += gate_err
+        gate_resid_norm_sum += gate_norm
+        down_resid_err_sum += down_err
+        down_resid_norm_sum += down_norm
+
+        ffn.gate_up = SharedLowRankLinear(shared_gate, gate_a, gate_b)
+        ffn.down = SharedLowRankLinear(shared_down, down_a, down_b)
+
+    after_unique_params = _unique_param_count(model)
+    gate_rel_rmse = math.sqrt(gate_resid_err_sum / max(gate_resid_norm_sum, 1e-12))
+    down_rel_rmse = math.sqrt(down_resid_err_sum / max(down_resid_norm_sum, 1e-12))
+
+    # Compact FFN parameter accounting for target group.
+    gate_shape = gate_shapes[0]
+    down_shape = down_shapes[0]
+    r_gate = min(rank, min(gate_shape))
+    r_down = min(rank, min(down_shape))
+    dense_target_params = len(target_items) * (gate_shape[0] * gate_shape[1] + down_shape[0] * down_shape[1])
+    compact_target_params = (
+        gate_shape[0] * gate_shape[1] + down_shape[0] * down_shape[1]
+        + len(target_items) * (r_gate * (gate_shape[0] + gate_shape[1]) + r_down * (down_shape[0] + down_shape[1]))
+    )
+
+    log0(
+        "POST_TRAIN_FFN_SVD: "
+        f"scope={POST_TRAIN_FFN_SVD_SCOPE}, target_layers={target_idxs}, rank={rank}, "
+        f"keep_full={POST_TRAIN_FFN_SVD_KEEP_FULL_IDXS}"
+    )
+    log0(
+        "POST_TRAIN_FFN_SVD params: "
+        f"unique_before={before_unique_params:,}, unique_after={after_unique_params:,}, "
+        f"saved={before_unique_params - after_unique_params:,}; "
+        f"target_dense={dense_target_params:,}, target_compact={compact_target_params:,}"
+    )
+    log0(
+        "POST_TRAIN_FFN_SVD residual fit: "
+        f"gate_rel_rmse={gate_rel_rmse:.4f}, down_rel_rmse={down_rel_rmse:.4f}"
+    )
+    return {
+        "target_layers": target_idxs,
+        "unique_before": before_unique_params,
+        "unique_after": after_unique_params,
+        "gate_rel_rmse": gate_rel_rmse,
+        "down_rel_rmse": down_rel_rmse,
+    }
+
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Post-training FFN SVD compression ablation ---
+    # Important: evaluate the original eager base_model after structural replacement,
+    # not the torch.compile/DDP wrapper, so the changed module graph is respected.
+    if POST_TRAIN_FFN_SVD_ENABLED:
+        dist.barrier()
+        log0("=" * 60)
+        log0(
+            f"Applying post-training FFN SVD compression "
+            f"(rank={POST_TRAIN_FFN_SVD_RANK}, scope={POST_TRAIN_FFN_SVD_SCOPE})..."
+        )
+        apply_post_training_ffn_svd(base_model)
+        dist.barrier()
+        svd_vl, svd_vb = eval_val(base_model, val_tokens, bb, hs, ib)
+        log0(f"Post-FFN-SVD standard val_loss:{svd_vl:.4f} val_bpb:{svd_vb:.4f}")
+        log0(f"Post-FFN-SVD vs best standard: bpb={best_vb - svd_vb:+.4f}")
+        if POST_TRAIN_FFN_SVD_SLIDING_EVAL and EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running post-FFN-SVD sliding eval (stride={EVAL_STRIDE})...")
+            svd_sw_vl, svd_sw_vb = eval_val_sliding(base_model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-FFN-SVD sliding val_loss:{svd_sw_vl:.4f} val_bpb:{svd_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"Post-FFN-SVD vs pre-SVD sliding: bpb={pre_ttt_sw_vb - svd_sw_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_bf16storage.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_bf16storage.py
@@ -1,0 +1,2891 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Selective BF16 parameter storage. Compute already uses AMP BF16; this
+# stores projection-heavy non-recurrent weights in BF16 to reduce HBM bandwidth
+# and autocast conversion overhead. Mamba recurrent/dynamics params remain FP32
+# by default for scan/state stability.
+BF16_STORAGE_ENABLED = os.environ.get("BF16_STORAGE_ENABLED", "1") == "1"
+BF16_STORAGE_CAST_BIGRAM = os.environ.get("BF16_STORAGE_CAST_BIGRAM", "1") == "1"
+BF16_STORAGE_CAST_EMBED_PROJ = os.environ.get("BF16_STORAGE_CAST_EMBED_PROJ", "1") == "1"
+BF16_STORAGE_CAST_ATTN = os.environ.get("BF16_STORAGE_CAST_ATTN", "1") == "1"
+BF16_STORAGE_CAST_FFN = os.environ.get("BF16_STORAGE_CAST_FFN", "1") == "1"
+BF16_STORAGE_CAST_MAMBA_PROJ = os.environ.get("BF16_STORAGE_CAST_MAMBA_PROJ", "0") == "1"  # second-stage test only
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("bf16_storage_defaults: full-FFN clean model + selective BF16 storage for non-Mamba projection weights; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"bf16_storage: enabled={BF16_STORAGE_ENABLED}, attn={BF16_STORAGE_CAST_ATTN}, "
+    f"ffn={BF16_STORAGE_CAST_FFN}, embed_proj={BF16_STORAGE_CAST_EMBED_PROJ}, "
+    f"bigram={BF16_STORAGE_CAST_BIGRAM}, mamba_proj={BF16_STORAGE_CAST_MAMBA_PROJ}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def _should_cast_bf16_storage(name: str) -> bool:
+    """
+    Select projection-heavy non-recurrent weights for BF16 parameter storage.
+    Keep all Mamba dynamics/recurrent internals FP32 by default. Also keep the
+    tied token embedding / lm_head FP32 for this first test.
+    """
+    if not BF16_STORAGE_ENABLED:
+        return False
+
+    # First test keeps all mamba.* FP32. A second-stage experiment can allow
+    # only Mamba input/output projections while still protecting A_log/D/dt_bias.
+    if ".mamba." in name or name.startswith("mamba."):
+        if not BF16_STORAGE_CAST_MAMBA_PROJ:
+            return False
+        return name.endswith("mamba.in_proj.weight") or name.endswith("mamba.out_proj.weight")
+
+    # Keep token embedding / tied LM head FP32 initially.
+    if name in ("tok_emb.weight", "lm_head.weight", "lm_head.bias"):
+        return False
+
+    if BF16_STORAGE_CAST_EMBED_PROJ and (
+        name.endswith("embed_proj.weight") or name.endswith("embed_proj_rev.weight")
+    ):
+        return True
+
+    if BF16_STORAGE_CAST_BIGRAM and (
+        name.startswith("bigram.embed.") or name.startswith("bigram.proj.")
+    ):
+        return True
+
+    if BF16_STORAGE_CAST_ATTN and (
+        name.endswith("qkv.weight") or name.endswith("out_proj.weight")
+    ):
+        # This catches normal attention. Mamba out_proj is excluded above.
+        return True
+
+    if BF16_STORAGE_CAST_FFN and (
+        name.endswith("ffn.gate_up.weight") or name.endswith("ffn.down.weight")
+    ):
+        return True
+
+    return False
+
+
+def cast_projection_params_to_bf16_storage(model, dtype):
+    """
+    Store selected large non-recurrent projection weights in BF16 to reduce HBM
+    bandwidth and autocast weight-conversion overhead. This intentionally does
+    not cast Mamba recurrent/dynamics params, tok_emb/lm_head, or small control
+    tensors. Returns (n_tensors, n_params, details).
+    """
+    if dtype != torch.bfloat16 or not BF16_STORAGE_ENABLED:
+        return 0, 0, []
+
+    cast_count = 0
+    param_count = 0
+    details = []
+    for name, p in model.named_parameters():
+        if _should_cast_bf16_storage(name) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+            param_count += p.numel()
+            details.append((name, tuple(p.shape), p.numel()))
+    return cast_count, param_count, details
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+    n_storage_cast, n_storage_params, storage_details = cast_projection_params_to_bf16_storage(base_model, AMP_DTYPE)
+    log0(f"BF16 storage cast: {n_storage_cast} tensors, {n_storage_params:,} params")
+    if MASTER_PROCESS and storage_details:
+        role_counts = {}
+        for name, shape, numel in storage_details:
+            if ".mamba." in name or name.startswith("mamba."):
+                role = "mamba_proj"
+            elif ".ffn." in name:
+                role = "ffn"
+            elif name.endswith("qkv.weight") or name.endswith("out_proj.weight"):
+                role = "attention"
+            elif name.startswith("bigram"):
+                role = "bigram"
+            elif name.startswith("embed_proj"):
+                role = "embed_proj"
+            else:
+                role = "other"
+            role_counts[role] = role_counts.get(role, 0) + numel
+        log0("BF16 storage cast roles: " + ", ".join(f"{k}={v:,}" for k, v in sorted(role_counts.items())))
+        for name, shape, numel in storage_details[:32]:
+            log0(f"  bf16_storage: {name} shape={shape} params={numel:,}")
+        if len(storage_details) > 32:
+            log0(f"  ... {len(storage_details) - 32} more bf16-storage tensors")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_byteint6_lzma.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_byteint6_lzma.py
@@ -1,0 +1,2901 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+import lzma
+import io
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. This variant defaults to the byte-int6
+# + LZMA path for compression experiments; use RUN_POSTQUANT=0 for prequant-only.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+QUANT_FORMAT = os.environ.get("QUANT_FORMAT", "byte_int6_lzma").lower()
+QUANT_BITS_MATRIX = int(os.environ.get("QUANT_BITS_MATRIX", "6"))
+QUANT_BITS_EMBED = int(os.environ.get("QUANT_BITS_EMBED", "8"))
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))
+QUANT_SCALE_FLOOR_MULT = float(os.environ.get("QUANT_SCALE_FLOOR_MULT", "1.0"))
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"
+QUANT_PRUNE_ONES_FRAC = float(os.environ.get("QUANT_PRUNE_ONES_FRAC", "0.0"))
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", "9"))
+QUANT_LZMA_EXTREME = os.environ.get("QUANT_LZMA_EXTREME", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compression_defaults: full-FFN clean model + byte-stored INT6/INT8 LZMA quantization + optional ±1 pruning")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"compression_quant: format={QUANT_FORMAT}, matrix_bits={QUANT_BITS_MATRIX}, "
+    f"embed_bits={QUANT_BITS_EMBED}, passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, "
+    f"k_matrix={QUANT_K_MATRIX}, k_embed={QUANT_K_EMBED}, "
+    f"scale_floor_mult={QUANT_SCALE_FLOOR_MULT}, protect_dynamics={QUANT_PROTECT_DYNAMICS}, "
+    f"prune_ones_frac={QUANT_PRUNE_ONES_FRAC}, lzma_preset={QUANT_LZMA_PRESET}, extreme={QUANT_LZMA_EXTREME}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Byte-stored int6/int8 + LZMA compression path.
+        # -----------------------------------------------------------------------
+        # This intentionally does NOT bit-pack int6. Values live in int8 tensors
+        # constrained to [-31,31], which gives LZMA repeated byte patterns to exploit.
+        # Optional ±1 pruning zeros the lowest-error quantized ±1 values, improving
+        # compressed size while perturbing weights by only one per-row scale.
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        if QUANT_FORMAT not in ("byte_int6_lzma", "byte_int_lzma"):
+            raise RuntimeError(f"Unsupported QUANT_FORMAT={QUANT_FORMAT}; use byte_int6_lzma")
+
+        def _is_embedding_like(n: str) -> bool:
+            return (
+                n == "tok_emb.weight" or n == "lm_head.weight" or
+                n.startswith("bigram.embed") or n.startswith("bigram.proj") or
+                "embed" in n
+            )
+
+        def _qmax_for_bits(bits: int) -> int:
+            return (1 << (bits - 1)) - 1
+
+        def _quantize_float_tensor(name: str, t: torch.Tensor):
+            t32 = t.float().cpu().contiguous()
+            bits = QUANT_BITS_EMBED if _is_embedding_like(name) else QUANT_BITS_MATRIX
+            qmax_default = _qmax_for_bits(bits)
+            k = QUANT_K_EMBED if _is_embedding_like(name) else QUANT_K_MATRIX
+
+            if t32.ndim == 2:
+                rows = t32.shape[0]
+                qmax = torch.full((rows,), float(qmax_default), dtype=torch.float32)
+                # Mamba2 in_proj has dt rows at the end. Promote only those rows to int8 range.
+                if QUANT_PROTECT_DYNAMICS and name.endswith("mamba.in_proj.weight"):
+                    n_dt = max(1, (2 * D_MODEL) // max(1, HEADDIM))
+                    qmax[-min(n_dt, rows):] = 127.0
+                max_abs = t32.abs().amax(dim=1).clamp_min(1e-8)
+                std_abs = t32.float().std(dim=1).clamp_min(1e-8)
+                clip_abs = torch.minimum(max_abs, std_abs * float(k)).clamp_min(1e-8)
+                # Entropy knob: avoid tiny scales that spread values too uniformly across q range.
+                floor = float(QUANT_SCALE_FLOOR_MULT) / qmax
+                scale = (clip_abs / qmax).clamp_min(floor).to(torch.float16).contiguous()
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.round(clipped / scale.float()[:, None]).clamp(-qmax[:, None], qmax[:, None]).to(torch.int8).contiguous()
+                return q, scale
+            else:
+                qmax = float(qmax_default)
+                max_abs = float(t32.abs().max().item()) if t32.numel() else 0.0
+                std_abs = float(t32.float().std().item()) if t32.numel() else 0.0
+                clip_abs = max(1e-8, min(max_abs, std_abs * float(k)) if std_abs > 0 else max_abs)
+                scale = max(clip_abs / qmax, float(QUANT_SCALE_FLOOR_MULT) / qmax)
+                q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale).clamp(-qmax, qmax).to(torch.int8).contiguous()
+                return q, torch.tensor(scale, dtype=torch.float16)
+
+        log0("Quantizing model with byte-stored INT6/INT8 + LZMA...")
+        state_dict = base_model.state_dict()
+        quantized, scales, passthrough, aliases = {}, {}, {}, {}
+        q_stats = {"quant_tensors": 0, "passthrough": 0, "alias": 0, "q_numel": 0, "fp_numel": 0}
+
+        # Avoid serializing tied input/output embedding twice.
+        tied_lm_weight = (
+            "tok_emb.weight" in state_dict and "lm_head.weight" in state_dict and
+            state_dict["tok_emb.weight"].shape == state_dict["lm_head.weight"].shape
+        )
+
+        for name, t in state_dict.items():
+            if tied_lm_weight and name == "lm_head.weight":
+                aliases[name] = "tok_emb.weight"
+                q_stats["alias"] += 1
+                continue
+            tcpu = t.detach().cpu().contiguous()
+            if (not tcpu.is_floating_point()) or tcpu.numel() <= QUANT_PASSTHROUGH_NUMEL:
+                if tcpu.is_floating_point() and tcpu.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = tcpu.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = tcpu
+                q_stats["passthrough"] += 1
+                q_stats["fp_numel"] += tcpu.numel()
+                continue
+            q, scale = _quantize_float_tensor(name, tcpu)
+            quantized[name] = q
+            scales[name] = scale
+            q_stats["quant_tensors"] += 1
+            q_stats["q_numel"] += q.numel()
+
+        # Optional global low-error ±1 pruning. Error of q=±1 -> 0 is scale[row]^2.
+        if QUANT_PRUNE_ONES_FRAC > 0:
+            errs = []
+            total_ones = 0
+            for name, q in quantized.items():
+                s = scales[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                counts = (q.abs() == 1).sum(dim=1).cpu()
+                if int(counts.sum().item()) == 0:
+                    continue
+                row_err = s.float().pow(2).cpu()
+                errs.append(torch.repeat_interleave(row_err, counts))
+                total_ones += int(counts.sum().item())
+            if total_ones > 0 and errs:
+                all_err = torch.cat(errs)
+                n_prune_target = int(max(0, min(total_ones, round(total_ones * QUANT_PRUNE_ONES_FRAC))))
+                if n_prune_target > 0:
+                    # kthvalue gives a threshold; ties can prune slightly more/less than requested.
+                    kth = max(1, min(n_prune_target, all_err.numel()))
+                    threshold = float(torch.kthvalue(all_err, kth).values.item())
+                    pruned = 0
+                    for name, q in quantized.items():
+                        s = scales[name]
+                        if q.ndim != 2 or s.ndim != 1:
+                            continue
+                        row_mask = (s.float().pow(2) <= threshold).view(-1, *([1] * (q.ndim - 1)))
+                        mask = (q.abs() == 1) & row_mask
+                        pruned += int(mask.sum().item())
+                        q[mask] = 0
+                    log0(f"±1 pruning: requested_frac={QUANT_PRUNE_ONES_FRAC:.3f}, candidates={total_ones:,}, pruned={pruned:,}, threshold_err={threshold:.3e}")
+                else:
+                    log0(f"±1 pruning: candidates={total_ones:,}, requested 0 prunes")
+            else:
+                log0("±1 pruning: no candidates found")
+
+        quant_obj = {
+            "format": QUANT_FORMAT,
+            "quantized": quantized,
+            "scales": scales,
+            "passthrough": passthrough,
+            "aliases": aliases,
+            "meta": {
+                "matrix_bits": QUANT_BITS_MATRIX,
+                "embed_bits": QUANT_BITS_EMBED,
+                "scale_floor_mult": QUANT_SCALE_FLOOR_MULT,
+                "protect_dynamics": QUANT_PROTECT_DYNAMICS,
+                "prune_ones_frac": QUANT_PRUNE_ONES_FRAC,
+            },
+        }
+
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+        lzma_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+        quant_blob = lzma.compress(quant_raw, preset=lzma_preset)
+        compressed_bytes = len(quant_blob)
+        raw_bytes = len(quant_raw)
+        q_raw_bytes = q_stats["q_numel"] + sum(v.numel() * v.element_size() for v in scales.values()) + sum(v.numel() * v.element_size() for v in passthrough.values())
+        log0(
+            f"Quant summary: q_tensors={q_stats['quant_tensors']}, passthrough={q_stats['passthrough']}, "
+            f"alias={q_stats['alias']}, q_numel={q_stats['q_numel']:,}, approx_payload={q_raw_bytes/1024/1024:.2f} MiB"
+        )
+        log0(f"Serialized raw torch.save: {raw_bytes:,} bytes ({raw_bytes/1024/1024:.2f} MiB)")
+        log0(f"Compressed model (lzma{QUANT_LZMA_PRESET}{'+extreme' if QUANT_LZMA_EXTREME else ''}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MiB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate.
+        quant_obj_rt = torch.load(io.BytesIO(lzma.decompress(quant_blob)), map_location="cpu")
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+        for name, src_name in quant_obj_rt.get("aliases", {}).items():
+            dequant_state[name] = dequant_state[src_name]
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        if MASTER_PROCESS:
+            artifact_path = f"final_model.{QUANT_FORMAT}.lzma"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_hybrid_int5_lzma.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_fullffn_hybrid_int5_lzma.py
@@ -1,0 +1,3024 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+import lzma
+import io
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. This variant defaults to the byte-int6
+# + LZMA path for compression experiments; use RUN_POSTQUANT=0 for prequant-only.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+# Hybrid artifact path:
+#   - FFN gate_up/down weights: packed signed INT5 by default
+#   - Mamba/attention/projection matrices: byte-stored INT6
+#   - Embeddings/bigram/embed projections: INT8 with optional per-row clip search
+#   - Small/control tensors: fp16 passthrough
+#   - Container compression: LZMA-9 extreme
+QUANT_FORMAT = os.environ.get("QUANT_FORMAT", "hybrid_ffn_int5_lzma").lower()
+QUANT_BITS_MATRIX = int(os.environ.get("QUANT_BITS_MATRIX", "6"))
+QUANT_BITS_FFN = int(os.environ.get("QUANT_BITS_FFN", "5"))
+QUANT_BITS_EMBED = int(os.environ.get("QUANT_BITS_EMBED", "8"))
+QUANT_PACK_FFN_INT5 = os.environ.get("QUANT_PACK_FFN_INT5", "1") == "1"
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))
+QUANT_K_FFN = float(os.environ.get("QUANT_K_FFN", str(QUANT_K_MATRIX)))
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))
+QUANT_SCALE_FLOOR_MULT = float(os.environ.get("QUANT_SCALE_FLOOR_MULT", "1.0"))
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"
+QUANT_OPTCLIP_STEPS = int(os.environ.get("QUANT_OPTCLIP_STEPS", "12"))
+QUANT_OPTCLIP_MIN_FRAC = float(os.environ.get("QUANT_OPTCLIP_MIN_FRAC", "0.55"))
+QUANT_OPTCLIP_MAX_FRAC = float(os.environ.get("QUANT_OPTCLIP_MAX_FRAC", "1.00"))
+QUANT_PRUNE_ONES_FRAC = float(os.environ.get("QUANT_PRUNE_ONES_FRAC", "0.0"))
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", "9"))
+QUANT_LZMA_EXTREME = os.environ.get("QUANT_LZMA_EXTREME", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compression_defaults: full-FFN clean model + hybrid FFN packed-INT5 + byte INT6/INT8 LZMA quantization")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"compression_quant: format={QUANT_FORMAT}, matrix_bits={QUANT_BITS_MATRIX}, "
+    f"ffn_bits={QUANT_BITS_FFN}, pack_ffn_int5={QUANT_PACK_FFN_INT5}, "
+    f"embed_bits={QUANT_BITS_EMBED}, passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, "
+    f"k_matrix={QUANT_K_MATRIX}, k_ffn={QUANT_K_FFN}, k_embed={QUANT_K_EMBED}, "
+    f"scale_floor_mult={QUANT_SCALE_FLOOR_MULT}, protect_dynamics={QUANT_PROTECT_DYNAMICS}, "
+    f"optclip_embed={QUANT_OPTCLIP_EMBED}, prune_ones_frac={QUANT_PRUNE_ONES_FRAC}, "
+    f"lzma_preset={QUANT_LZMA_PRESET}, extreme={QUANT_LZMA_EXTREME}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Byte-stored int6/int8 + LZMA compression path.
+        # -----------------------------------------------------------------------
+        # This intentionally does NOT bit-pack int6. Values live in int8 tensors
+        # constrained to [-31,31], which gives LZMA repeated byte patterns to exploit.
+        # Optional ±1 pruning zeros the lowest-error quantized ±1 values, improving
+        # compressed size while perturbing weights by only one per-row scale.
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        if QUANT_FORMAT not in ("hybrid_ffn_int5_lzma", "byte_int6_lzma", "byte_int_lzma"):
+            raise RuntimeError(
+                f"Unsupported QUANT_FORMAT={QUANT_FORMAT}; use hybrid_ffn_int5_lzma or byte_int6_lzma"
+            )
+
+        def _is_embedding_like(n: str) -> bool:
+            return (
+                n == "tok_emb.weight" or n == "lm_head.weight" or
+                n.startswith("bigram.embed") or n.startswith("bigram.proj") or
+                "embed" in n
+            )
+
+        def _is_ffn_weight(n: str) -> bool:
+            return (".ffn.gate_up.weight" in n) or (".ffn.down.weight" in n)
+
+        def _qmax_for_bits(bits: int) -> int:
+            return (1 << (bits - 1)) - 1
+
+        def _pack_signed_q_to_uint5(q: torch.Tensor, qmax: int):
+            """Pack signed int5 values in [-15, 15] into 5 bytes per 8 values."""
+            if qmax != 15:
+                raise ValueError(f"uint5 pack expects qmax=15, got {qmax}")
+            shape = tuple(q.shape)
+            flat = (q.to(torch.int16).reshape(-1).cpu() + 15).clamp(0, 31).to(torch.uint8)
+            n = int(flat.numel())
+            pad = (-n) % 8
+            if pad:
+                flat = torch.cat([flat, torch.zeros(pad, dtype=torch.uint8)])
+            x = flat.view(-1, 8).to(torch.int64)
+            word = torch.zeros(x.shape[0], dtype=torch.int64)
+            for i in range(8):
+                word |= (x[:, i] << (5 * i))
+            out = torch.empty((x.shape[0], 5), dtype=torch.uint8)
+            for j in range(5):
+                out[:, j] = ((word >> (8 * j)) & 0xFF).to(torch.uint8)
+            return out.contiguous().view(-1), shape, n
+
+        def _unpack_uint5_to_signed_q(packed: torch.Tensor, shape, n: int):
+            b = packed.cpu().contiguous().view(-1, 5).to(torch.int64)
+            word = torch.zeros(b.shape[0], dtype=torch.int64)
+            for j in range(5):
+                word |= (b[:, j] << (8 * j))
+            vals = []
+            for i in range(8):
+                vals.append(((word >> (5 * i)) & 31).to(torch.int16))
+            flat = torch.stack(vals, dim=1).reshape(-1)[:n]
+            q = (flat - 15).to(torch.int8).view(*shape).contiguous()
+            return q
+
+        def _choose_bits_and_k(name: str):
+            if _is_embedding_like(name):
+                return QUANT_BITS_EMBED, QUANT_K_EMBED
+            if _is_ffn_weight(name) and QUANT_FORMAT == "hybrid_ffn_int5_lzma":
+                return QUANT_BITS_FFN, QUANT_K_FFN
+            return QUANT_BITS_MATRIX, QUANT_K_MATRIX
+
+        def _quantize_float_tensor(name: str, t: torch.Tensor):
+            t32 = t.float().cpu().contiguous()
+            bits, k = _choose_bits_and_k(name)
+            qmax_default = _qmax_for_bits(bits)
+
+            if t32.ndim == 2:
+                rows = t32.shape[0]
+                qmax = torch.full((rows,), float(qmax_default), dtype=torch.float32)
+                # Mamba2 in_proj has dt rows at the end. Promote only those rows to int8 range.
+                if QUANT_PROTECT_DYNAMICS and name.endswith("mamba.in_proj.weight"):
+                    n_dt = max(1, (2 * D_MODEL) // max(1, HEADDIM))
+                    qmax[-min(n_dt, rows):] = 127.0
+                max_abs = t32.abs().amax(dim=1).clamp_min(1e-8)
+                std_abs = t32.float().std(dim=1).clamp_min(1e-8)
+                base_clip = torch.minimum(max_abs, std_abs * float(k)).clamp_min(1e-8)
+
+                # Embedding-like rows are heterogeneous. Search a small per-row clip grid
+                # and keep the clip that minimizes reconstruction MSE.
+                if _is_embedding_like(name) and QUANT_OPTCLIP_EMBED and QUANT_OPTCLIP_STEPS > 1:
+                    best_err = torch.full((rows,), float("inf"), dtype=torch.float32)
+                    best_q = None
+                    best_scale = None
+                    fracs = torch.linspace(
+                        float(QUANT_OPTCLIP_MIN_FRAC),
+                        float(QUANT_OPTCLIP_MAX_FRAC),
+                        steps=int(QUANT_OPTCLIP_STEPS),
+                        dtype=torch.float32,
+                    )
+                    for frac in fracs:
+                        clip_abs = (base_clip * float(frac)).clamp_min(1e-8)
+                        floor = float(QUANT_SCALE_FLOOR_MULT) / qmax
+                        scale_f = (clip_abs / qmax).clamp_min(floor)
+                        q_try = torch.round(torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None]) / scale_f[:, None]).clamp(-qmax[:, None], qmax[:, None])
+                        rec = q_try * scale_f[:, None]
+                        err = (rec - t32).pow(2).mean(dim=1)
+                        mask = err < best_err
+                        if best_q is None:
+                            best_q = q_try.to(torch.int8)
+                            best_scale = scale_f
+                            best_err = err
+                        else:
+                            best_q[mask] = q_try[mask].to(torch.int8)
+                            best_scale[mask] = scale_f[mask]
+                            best_err[mask] = err[mask]
+                    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+
+                clip_abs = base_clip
+                # Entropy knob: avoid tiny scales that spread values too uniformly across q range.
+                floor = float(QUANT_SCALE_FLOOR_MULT) / qmax
+                scale = (clip_abs / qmax).clamp_min(floor).to(torch.float16).contiguous()
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.round(clipped / scale.float()[:, None]).clamp(-qmax[:, None], qmax[:, None]).to(torch.int8).contiguous()
+                return q, scale
+            else:
+                qmax = float(qmax_default)
+                max_abs = float(t32.abs().max().item()) if t32.numel() else 0.0
+                std_abs = float(t32.float().std().item()) if t32.numel() else 0.0
+                clip_abs = max(1e-8, min(max_abs, std_abs * float(k)) if std_abs > 0 else max_abs)
+                scale = max(clip_abs / qmax, float(QUANT_SCALE_FLOOR_MULT) / qmax)
+                q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale).clamp(-qmax, qmax).to(torch.int8).contiguous()
+                return q, torch.tensor(scale, dtype=torch.float16)
+
+        log0("Quantizing model with hybrid FFN packed-INT5 + byte INT6/INT8 + LZMA...")
+        state_dict = base_model.state_dict()
+        quantized, packed_quantized, scales, passthrough, aliases = {}, {}, {}, {}, {}
+        q_stats = {
+            "quant_tensors": 0, "packed_tensors": 0, "passthrough": 0, "alias": 0,
+            "q_numel": 0, "packed_bytes": 0, "fp_numel": 0, "ffn_packed_numel": 0
+        }
+
+        # Avoid serializing tied input/output embedding twice.
+        tied_lm_weight = (
+            "tok_emb.weight" in state_dict and "lm_head.weight" in state_dict and
+            state_dict["tok_emb.weight"].shape == state_dict["lm_head.weight"].shape
+        )
+
+        for name, t in state_dict.items():
+            if tied_lm_weight and name == "lm_head.weight":
+                aliases[name] = "tok_emb.weight"
+                q_stats["alias"] += 1
+                continue
+            tcpu = t.detach().cpu().contiguous()
+            if (not tcpu.is_floating_point()) or tcpu.numel() <= QUANT_PASSTHROUGH_NUMEL:
+                if tcpu.is_floating_point() and tcpu.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = tcpu.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = tcpu
+                q_stats["passthrough"] += 1
+                q_stats["fp_numel"] += tcpu.numel()
+                continue
+            q, scale = _quantize_float_tensor(name, tcpu)
+            scales[name] = scale
+            # FFN gate_up/down dominate size. Store them as true packed int5
+            # when using the hybrid artifact; store all other quant tensors as byte int6/int8.
+            if (
+                QUANT_FORMAT == "hybrid_ffn_int5_lzma" and
+                QUANT_PACK_FFN_INT5 and
+                _is_ffn_weight(name) and
+                QUANT_BITS_FFN == 5
+            ):
+                packed, shape, n = _pack_signed_q_to_uint5(q, _qmax_for_bits(QUANT_BITS_FFN))
+                packed_quantized[name] = {"data": packed, "shape": shape, "numel": int(n), "bits": 5, "qmax": 15}
+                q_stats["packed_tensors"] += 1
+                q_stats["packed_bytes"] += int(packed.numel())
+                q_stats["ffn_packed_numel"] += q.numel()
+            else:
+                quantized[name] = q
+                q_stats["quant_tensors"] += 1
+                q_stats["q_numel"] += q.numel()
+
+        # Optional global low-error ±1 pruning. Error of q=±1 -> 0 is scale[row]^2.
+        if QUANT_PRUNE_ONES_FRAC > 0:
+            errs = []
+            total_ones = 0
+            for name, q in quantized.items():
+                s = scales[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                counts = (q.abs() == 1).sum(dim=1).cpu()
+                if int(counts.sum().item()) == 0:
+                    continue
+                row_err = s.float().pow(2).cpu()
+                errs.append(torch.repeat_interleave(row_err, counts))
+                total_ones += int(counts.sum().item())
+            if total_ones > 0 and errs:
+                all_err = torch.cat(errs)
+                n_prune_target = int(max(0, min(total_ones, round(total_ones * QUANT_PRUNE_ONES_FRAC))))
+                if n_prune_target > 0:
+                    # kthvalue gives a threshold; ties can prune slightly more/less than requested.
+                    kth = max(1, min(n_prune_target, all_err.numel()))
+                    threshold = float(torch.kthvalue(all_err, kth).values.item())
+                    pruned = 0
+                    for name, q in quantized.items():
+                        s = scales[name]
+                        if q.ndim != 2 or s.ndim != 1:
+                            continue
+                        row_mask = (s.float().pow(2) <= threshold).view(-1, *([1] * (q.ndim - 1)))
+                        mask = (q.abs() == 1) & row_mask
+                        pruned += int(mask.sum().item())
+                        q[mask] = 0
+                    log0(f"±1 pruning: requested_frac={QUANT_PRUNE_ONES_FRAC:.3f}, candidates={total_ones:,}, pruned={pruned:,}, threshold_err={threshold:.3e}")
+                else:
+                    log0(f"±1 pruning: candidates={total_ones:,}, requested 0 prunes")
+            else:
+                log0("±1 pruning: no candidates found")
+
+        quant_obj = {
+            "format": QUANT_FORMAT,
+            "quantized": quantized,
+            "packed_quantized": packed_quantized,
+            "scales": scales,
+            "passthrough": passthrough,
+            "aliases": aliases,
+            "meta": {
+                "matrix_bits": QUANT_BITS_MATRIX,
+                "ffn_bits": QUANT_BITS_FFN,
+                "embed_bits": QUANT_BITS_EMBED,
+                "pack_ffn_int5": QUANT_PACK_FFN_INT5,
+                "scale_floor_mult": QUANT_SCALE_FLOOR_MULT,
+                "protect_dynamics": QUANT_PROTECT_DYNAMICS,
+                "optclip_embed": QUANT_OPTCLIP_EMBED,
+                "prune_ones_frac": QUANT_PRUNE_ONES_FRAC,
+            },
+        }
+
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+        lzma_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+        quant_blob = lzma.compress(quant_raw, preset=lzma_preset)
+        compressed_bytes = len(quant_blob)
+        raw_bytes = len(quant_raw)
+        q_raw_bytes = (
+            q_stats["q_numel"] + q_stats["packed_bytes"] +
+            sum(v.numel() * v.element_size() for v in scales.values()) +
+            sum(v.numel() * v.element_size() for v in passthrough.values())
+        )
+        log0(
+            f"Quant summary: byte_q_tensors={q_stats['quant_tensors']}, packed_q_tensors={q_stats['packed_tensors']}, "
+            f"passthrough={q_stats['passthrough']}, alias={q_stats['alias']}, "
+            f"byte_q_numel={q_stats['q_numel']:,}, packed_bytes={q_stats['packed_bytes']:,}, "
+            f"ffn_packed_numel={q_stats['ffn_packed_numel']:,}, approx_payload={q_raw_bytes/1024/1024:.2f} MiB"
+        )
+        log0(f"Serialized raw torch.save: {raw_bytes:,} bytes ({raw_bytes/1024/1024:.2f} MiB)")
+        log0(f"Compressed model (lzma{QUANT_LZMA_PRESET}{'+extreme' if QUANT_LZMA_EXTREME else ''}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MiB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate.
+        quant_obj_rt = torch.load(io.BytesIO(lzma.decompress(quant_blob)), map_location="cpu")
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, pack_obj in quant_obj_rt.get("packed_quantized", {}).items():
+            q = _unpack_uint5_to_signed_q(pack_obj["data"], tuple(pack_obj["shape"]), int(pack_obj["numel"]))
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+        for name, src_name in quant_obj_rt.get("aliases", {}).items():
+            dequant_state[name] = dequant_state[src_name]
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        if MASTER_PROCESS:
+            artifact_path = f"final_model.{QUANT_FORMAT}.lzma"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ssmfix_clean.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_race_best_ssmfix_clean.py
@@ -1,0 +1,2786 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("clean_ssmfix_defaults: uploaded best architecture + headdim/dt/layer_idx + seq_idx + direct-kernel carryover; quant off by default")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_rope.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_rope.py
@@ -1,0 +1,1719 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loader.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader = _make_loader(SEQ_LEN, prefetch_depth=3)
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = STREAM_CHUNKS
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+
+    # Sliding window eval
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={vb - sw_vb:+.4f}")
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_rope_curriculum.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_rope_curriculum.py
@@ -1,0 +1,2505 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_sharedffn_attncorr.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_sharedffn_attncorr.py
@@ -1,0 +1,2948 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Variant: sparse-FFN SSM base with shared compute capacity.
+# Defaults: 10 blocks, attention at layer 6, full FFNs only on layers 6 and 9,
+# shared final FFN reused on selected SSM layers, and optional shared attention
+# correction after selected SSM layers. No quant/TTT/carryover by default.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: instantiate/run FFNs only in attention blocks plus the final block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "custom").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "6,9")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE for attention. This is parameter-free contextual capacity: the
+# first ROPE_DIM channels of each attention head encode relative position while
+# the remaining channels stay content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# Tail-weighted training objective. Eval still uses ordinary CE; this only
+# affects training mode. Sliding eval scores tail tokens, so a small tail term
+# encourages using the full 8192-token context without adding parameters.
+TAIL_LOSS_WEIGHT = float(os.environ.get("TAIL_LOSS_WEIGHT", "0.0"))
+TAIL_LOSS_TOKENS = int(os.environ.get("TAIL_LOSS_TOKENS", "1024"))
+
+# No-param / low-param capacity reuse.
+def _parse_int_list_env(name, default):
+    raw = os.environ.get(name, default)
+    return sorted({int(x) for x in raw.split(",") if x.strip()})
+
+# 1) Shared final FFN: instantiate FFNs only on FFN_ACTIVE_IDXS, but reuse the
+# final block's FFN as extra nonlinear compute on selected SSM layers.
+SHARED_FINAL_FFN_ENABLED = os.environ.get("SHARED_FINAL_FFN_ENABLED", "1") == "1"
+SHARED_FINAL_FFN_SOURCE_IDX = int(os.environ.get("SHARED_FINAL_FFN_SOURCE_IDX", str(N_UNIQUE_BLOCKS - 1)))
+SHARED_FINAL_FFN_LAYERS = _parse_int_list_env("SHARED_FINAL_FFN_LAYERS", "3,5,7,9")
+
+# 2) Shared attention correction: one small shared attention sidecar, reused
+# after selected SSM layers. It adds low params and more recall compute without
+# replacing any SSM block. Set SHARED_ATTN_CORR_ENABLED=0 to disable.
+SHARED_ATTN_CORR_ENABLED = os.environ.get("SHARED_ATTN_CORR_ENABLED", "1") == "1"
+SHARED_ATTN_CORR_LAYERS = _parse_int_list_env("SHARED_ATTN_CORR_LAYERS", "2,5")
+SHARED_ATTN_CORR_DIM = int(os.environ.get("SHARED_ATTN_CORR_DIM", "256"))
+SHARED_ATTN_CORR_HEADS = int(os.environ.get("SHARED_ATTN_CORR_HEADS", "4"))
+SHARED_ATTN_CORR_GATE_INIT = float(os.environ.get("SHARED_ATTN_CORR_GATE_INIT", "-2.5"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path. Default keeps original behavior; set RUN_POSTQUANT=0 for architecture-only sweeps.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(f"tail_loss: weight={TAIL_LOSS_WEIGHT}, tokens={TAIL_LOSS_TOKENS}")
+log0("variant_defaults: SEQ_LEN=8192, ATTN_LAYER_IDXS=6, FFN_MULT=3, FFN_ACTIVE_IDXS=6,9, ROPE_DIM=16, TAIL_LOSS_WEIGHT=0")
+log0(f"shared_final_ffn: enabled={SHARED_FINAL_FFN_ENABLED}, source={SHARED_FINAL_FFN_SOURCE_IDX}, layers={SHARED_FINAL_FFN_LAYERS}")
+log0(f"shared_attn_corr: enabled={SHARED_ATTN_CORR_ENABLED}, layers={SHARED_ATTN_CORR_LAYERS}, dim={SHARED_ATTN_CORR_DIM}, heads={SHARED_ATTN_CORR_HEADS}, gate_init={SHARED_ATTN_CORR_GATE_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D_head).
+    Only the first rotary_dim dimensions are rotated; the rest stay content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack(
+            (x_even * cos - x_odd * sin, x_even * sin + x_odd * cos),
+            dim=-1,
+        ).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+
+class SharedAttentionCorrection(nn.Module):
+    """Small shared causal-attention sidecar reused after selected SSM layers."""
+    def __init__(self, d_model, inner_dim=256, n_heads=4, gate_init=-2.5):
+        super().__init__()
+        if inner_dim % n_heads != 0:
+            raise ValueError(f"SHARED_ATTN_CORR_DIM={inner_dim} must be divisible by heads={n_heads}")
+        self.inner_dim = int(inner_dim)
+        self.n_heads = int(n_heads)
+        self.head_dim = self.inner_dim // self.n_heads
+        self.norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * self.inner_dim, bias=False)
+        self.out_proj = nn.Linear(self.inner_dim, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((self.n_heads,), QK_GAIN_INIT))
+        self.gate = nn.Parameter(torch.tensor(float(gate_init)))
+
+    def forward(self, x):
+        B, T, _ = x.shape
+        h = self.norm(x)
+        qkv = self.qkv(h).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, self.inner_dim)
+        return x + torch.sigmoid(self.gate).to(x.dtype) * self.out_proj(attn_out)
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated only on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.shared_final_ffn_source_idx = int(SHARED_FINAL_FFN_SOURCE_IDX)
+        self.shared_final_ffn_layers = set(SHARED_FINAL_FFN_LAYERS)
+        if SHARED_FINAL_FFN_ENABLED:
+            if not (0 <= self.shared_final_ffn_source_idx < len(self.blocks)):
+                raise ValueError(f"SHARED_FINAL_FFN_SOURCE_IDX={self.shared_final_ffn_source_idx} out of range")
+            src = self.blocks[self.shared_final_ffn_source_idx]
+            if not getattr(src, "_has_ffn", False):
+                raise ValueError(
+                    f"Shared final FFN source layer {self.shared_final_ffn_source_idx} has no FFN. "
+                    f"Add it to FFN_ACTIVE_IDXS, currently {self.ffn_active_idxs}."
+                )
+
+        self.shared_attn_correction = (
+            SharedAttentionCorrection(
+                D_MODEL,
+                inner_dim=SHARED_ATTN_CORR_DIM,
+                n_heads=SHARED_ATTN_CORR_HEADS,
+                gate_init=SHARED_ATTN_CORR_GATE_INIT,
+            ) if SHARED_ATTN_CORR_ENABLED else None
+        )
+        self.shared_attn_corr_layers = set(SHARED_ATTN_CORR_LAYERS)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _apply_shared_capacity(self, x, block_idx, regular_ffn_ran=False):
+        # Shared attention correction first, then shared final FFN. For the
+        # intended layer 5 case this gives: SSM -> attention correction -> FFN.
+        if self.shared_attn_correction is not None and block_idx in self.shared_attn_corr_layers:
+            x = self.shared_attn_correction(x)
+
+        if SHARED_FINAL_FFN_ENABLED and block_idx in self.shared_final_ffn_layers:
+            src_idx = self.shared_final_ffn_source_idx
+            # If the source layer just ran its own FFN, do not double-apply it.
+            if not (block_idx == src_idx and regular_ffn_ran):
+                src = self.blocks[src_idx]
+                x = x + src.mlp_scale[None, None, :] * src.ffn(src.ffn_norm(x))
+        return x
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            x = self._apply_shared_capacity(x, block_idx, regular_ffn_ran=(run_ffn and getattr(block, "_has_ffn", False)))
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    full_loss = F.cross_entropy(logits.float(), y, reduction="mean")
+
+    # Tail-weighted loss is train-only. Standard/sliding eval calls core.eval(),
+    # so reported validation remains ordinary CE/BPB.
+    use_tail = bool(core.training and TAIL_LOSS_WEIGHT > 0.0 and targets.ndim == 2)
+    if use_tail:
+        bsz, tlen = targets.shape
+        tail_len = max(1, min(int(TAIL_LOSS_TOKENS), int(tlen)))
+        vocab = logits.shape[-1]
+        tail_logits = logits.reshape(bsz, tlen, vocab)[:, -tail_len:, :].reshape(-1, vocab)
+        tail_y = targets[:, -tail_len:].reshape(-1)
+        tail_loss = F.cross_entropy(tail_logits.float(), tail_y, reduction="mean")
+        w = max(0.0, min(1.0, float(TAIL_LOSS_WEIGHT)))
+        loss = (1.0 - w) * full_loss + w * tail_loss
+    else:
+        loss = full_loss
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Int8 quantization + compression + roundtrip validation
+        # -----------------------------------------------------------------------
+        # Load best weights for quantization
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        log0("Quantizing model to int8...")
+        state_dict = base_model.state_dict()
+        quantized = {}
+        scales = {}
+        passthrough = {}
+        for name, t in state_dict.items():
+            t = t.detach().cpu().contiguous()
+            if not t.is_floating_point() or t.numel() <= 65536:
+                # Small tensors / non-float: keep as fp16
+                if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = t.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = t
+                continue
+            # Per-row int8 quantization for 2D, per-tensor for others
+            t32 = t.float()
+            if t32.ndim == 2:
+                clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+                scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+                clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+                q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+                scales[name] = scale.to(torch.float16).contiguous()
+            else:
+                clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+                scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+                q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+                scales[name] = torch.tensor(scale, dtype=torch.float32)
+            quantized[name] = q.contiguous()
+
+        quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+        import io
+        quant_buf = io.BytesIO()
+        torch.save(quant_obj, quant_buf)
+        quant_raw = quant_buf.getvalue()
+
+        if _COMPRESSOR == "zstd":
+            cctx = zstandard.ZstdCompressor(level=22)
+            quant_blob = cctx.compress(quant_raw)
+        else:
+            quant_blob = zlib.compress(quant_raw, level=9)
+
+        compressed_bytes = len(quant_blob)
+        log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate
+        if _COMPRESSOR == "zstd":
+            dctx = zstandard.ZstdDecompressor()
+            quant_raw_rt = dctx.decompress(quant_blob)
+        else:
+            quant_raw_rt = zlib.decompress(quant_blob)
+        quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+        # Dequantize
+        dequant_state = {}
+        for name, q in quant_obj_rt["quantized"].items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        # Save compressed artifact
+        if MASTER_PROCESS:
+            artifact_path = "final_model.int8.ptz"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_smeargate.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_smeargate.py
@@ -1,0 +1,2546 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+# BOS-aware SmearGate.
+# Cheap learned previous-token mixing:
+#   x[t] <- x[t] + sigmoid(g) * x[t-1]
+# but masked where current token is BOS so packed-document boundaries do not leak.
+SMEAR_GATE_ENABLED = os.environ.get("SMEAR_GATE_ENABLED", "0") == "1"
+SMEAR_GATE_INIT = float(os.environ.get("SMEAR_GATE_INIT", "-3.0"))
+SMEAR_GATE_SCALE = float(os.environ.get("SMEAR_GATE_SCALE", "1.0"))
+SMEAR_BOS_ID = int(os.environ.get("SMEAR_BOS_ID", "1"))
+SMEAR_AFTER_BIGRAM = os.environ.get("SMEAR_AFTER_BIGRAM", "1") == "1"
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+    "smear_gate",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0(
+    f"smeargate: enabled={SMEAR_GATE_ENABLED}, init={SMEAR_GATE_INIT}, "
+    f"scale={SMEAR_GATE_SCALE}, bos_id={SMEAR_BOS_ID}, after_bigram={SMEAR_AFTER_BIGRAM}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BOS-aware SmearGate.
+        if SMEAR_GATE_ENABLED:
+            self.smear_gate = nn.Parameter(torch.full((D_MODEL,), SMEAR_GATE_INIT))
+        else:
+            self.smear_gate = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def apply_smear_gate(self, x, ids):
+        if self.smear_gate is None:
+            return x
+        if x.shape[1] <= 1:
+            return x
+
+        gate = torch.sigmoid(self.smear_gate).to(dtype=x.dtype, device=x.device)
+        gate = gate[None, None, :] * float(SMEAR_GATE_SCALE)
+
+        # Prevent packed-document leakage into BOS positions.
+        if SMEAR_BOS_ID >= 0:
+            not_bos = (ids[:, 1:] != SMEAR_BOS_ID).to(dtype=x.dtype, device=x.device).unsqueeze(-1)
+        else:
+            not_bos = 1.0
+
+        x0 = x[:, :1, :]
+        x_rest = x[:, 1:, :] + gate * x[:, :-1, :] * not_bos
+        return torch.cat([x0, x_rest], dim=1)
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        if SMEAR_GATE_ENABLED and SMEAR_AFTER_BIGRAM:
+            x = self.apply_smear_gate(x, ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_ssm_attn_gate.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_ssm_attn_gate.py
@@ -1,0 +1,2602 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+# BOS-aware SmearGate.
+# Cheap learned previous-token mixing:
+#   x[t] <- x[t] + sigmoid(g) * x[t-1]
+# but masked where current token is BOS so packed-document boundaries do not leak.
+SMEAR_GATE_ENABLED = os.environ.get("SMEAR_GATE_ENABLED", "0") == "1"
+SMEAR_GATE_INIT = float(os.environ.get("SMEAR_GATE_INIT", "-3.0"))
+SMEAR_GATE_SCALE = float(os.environ.get("SMEAR_GATE_SCALE", "1.0"))
+SMEAR_BOS_ID = int(os.environ.get("SMEAR_BOS_ID", "1"))
+SMEAR_AFTER_BIGRAM = os.environ.get("SMEAR_AFTER_BIGRAM", "1") == "1"
+
+# SSM-conditioned attention gate.
+# The attention block reads the SSM-processed hidden stream entering attention
+# and uses it to modulate q per head. Zero-init keeps initial behavior identical.
+SSM_ATTN_GATE_ENABLED = os.environ.get("SSM_ATTN_GATE_ENABLED", "0") == "1"
+SSM_ATTN_GATE_MODE = os.environ.get("SSM_ATTN_GATE_MODE", "summary").lower()  # token|summary|both
+SSM_ATTN_GATE_SCALE = float(os.environ.get("SSM_ATTN_GATE_SCALE", "0.5"))
+SSM_ATTN_GATE_ZERO_INIT = os.environ.get("SSM_ATTN_GATE_ZERO_INIT", "1") == "1"
+SSM_ATTN_GATE_BIAS_INIT = float(os.environ.get("SSM_ATTN_GATE_BIAS_INIT", "0.0"))
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+    "ssm_attn_gate",
+    "smear_gate",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0(
+    f"smeargate: enabled={SMEAR_GATE_ENABLED}, init={SMEAR_GATE_INIT}, "
+    f"scale={SMEAR_GATE_SCALE}, bos_id={SMEAR_BOS_ID}, after_bigram={SMEAR_AFTER_BIGRAM}"
+)
+log0(
+    f"ssm_attn_gate: enabled={SSM_ATTN_GATE_ENABLED}, mode={SSM_ATTN_GATE_MODE}, "
+    f"scale={SSM_ATTN_GATE_SCALE}, zero_init={SSM_ATTN_GATE_ZERO_INIT}, "
+    f"bias_init={SSM_ATTN_GATE_BIAS_INIT}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        # SSM-conditioned per-head q gate. The attention input has already
+        # passed through previous SSM layers, so this lets the SSM state control
+        # attention sharpness without adding another attention layer.
+        if SSM_ATTN_GATE_ENABLED:
+            self.ssm_attn_gate_norm = RMSNorm(d_model)
+            self.ssm_attn_gate = nn.Linear(d_model, n_heads, bias=True)
+            with torch.no_grad():
+                if SSM_ATTN_GATE_ZERO_INIT:
+                    self.ssm_attn_gate.weight.zero_()
+                else:
+                    nn.init.normal_(self.ssm_attn_gate.weight, std=0.01)
+                self.ssm_attn_gate.bias.fill_(SSM_ATTN_GATE_BIAS_INIT)
+        else:
+            self.ssm_attn_gate_norm = None
+            self.ssm_attn_gate = None
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def _ssm_conditioned_q_gate(self, normed):
+        if self.ssm_attn_gate is None:
+            return None
+
+        src = self.ssm_attn_gate_norm(normed)
+
+        if SSM_ATTN_GATE_MODE == "summary":
+            denom = torch.arange(1, src.shape[1] + 1, device=src.device, dtype=src.dtype)[None, :, None]
+            src = torch.cumsum(src, dim=1) / denom
+        elif SSM_ATTN_GATE_MODE == "both":
+            denom = torch.arange(1, src.shape[1] + 1, device=src.device, dtype=src.dtype)[None, :, None]
+            summary = torch.cumsum(src, dim=1) / denom
+            src = 0.5 * src + 0.5 * summary
+        elif SSM_ATTN_GATE_MODE != "token":
+            denom = torch.arange(1, src.shape[1] + 1, device=src.device, dtype=src.dtype)[None, :, None]
+            src = torch.cumsum(src, dim=1) / denom
+
+        gate_logits = self.ssm_attn_gate(src).to(normed.dtype)  # (B,T,H)
+        # Zero-init => multiplier exactly 1. Bounded for stability.
+        mult = 1.0 + float(SSM_ATTN_GATE_SCALE) * torch.tanh(gate_logits)
+        return mult.permute(0, 2, 1).unsqueeze(-1)  # (B,H,T,1)
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        ssm_gate = self._ssm_conditioned_q_gate(normed)
+        if ssm_gate is not None:
+            q = q * ssm_gate.to(q.dtype)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BOS-aware SmearGate.
+        if SMEAR_GATE_ENABLED:
+            self.smear_gate = nn.Parameter(torch.full((D_MODEL,), SMEAR_GATE_INIT))
+        else:
+            self.smear_gate = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def apply_smear_gate(self, x, ids):
+        if self.smear_gate is None:
+            return x
+        if x.shape[1] <= 1:
+            return x
+
+        gate = torch.sigmoid(self.smear_gate).to(dtype=x.dtype, device=x.device)
+        gate = gate[None, None, :] * float(SMEAR_GATE_SCALE)
+
+        # Prevent packed-document leakage into BOS positions.
+        if SMEAR_BOS_ID >= 0:
+            not_bos = (ids[:, 1:] != SMEAR_BOS_ID).to(dtype=x.dtype, device=x.device).unsqueeze(-1)
+        else:
+            not_bos = 1.0
+
+        x0 = x[:, :1, :]
+        x_rest = x[:, 1:, :] + gate * x[:, :-1, :] * not_bos
+        return torch.cat([x0, x_rest], dim=1)
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        if SMEAR_GATE_ENABLED and SMEAR_AFTER_BIGRAM:
+            x = self.apply_smear_gate(x, ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_stateful_eval.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_stateful_eval.py
@@ -1,0 +1,2503 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Stateful eval — carries the explicit USE_MEMORY SSM memory across contiguous chunks.
+# Note: this does NOT carry Mamba's internal selective-scan state; it carries the
+# optional learned memory vector implemented in SelectiveSSMBlock when USE_MEMORY=1.
+STATEFUL_EVAL_ENABLED = os.environ.get("STATEFUL_EVAL_ENABLED", "1") == "1"
+STATEFUL_EVAL_CHUNK_TOKENS = int(os.environ.get("STATEFUL_EVAL_CHUNK_TOKENS", str(SEQ_LEN)))
+STATEFUL_EVAL_LANES = int(os.environ.get("STATEFUL_EVAL_LANES", "1"))  # 1 = most faithful; >1 = faster but resets memory per lane
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"stateful_eval: enabled={STATEFUL_EVAL_ENABLED}, chunk_tokens={STATEFUL_EVAL_CHUNK_TOKENS}, lanes={STATEFUL_EVAL_LANES}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+def _state_batch_from_lane_states(lane_states, bsz, device, dtype, memory_dim):
+    """Stack per-lane explicit memory states for batched stateful eval."""
+    if not USE_MEMORY:
+        return None
+    mems = []
+    for st in lane_states:
+        if st is None or st.get("mem", None) is None:
+            mems.append(torch.zeros(1, memory_dim, device=device, dtype=dtype))
+        else:
+            mems.append(st["mem"].detach().to(device=device, dtype=dtype))
+    return {"mem": torch.cat(mems, dim=0)}
+
+
+def _split_batch_state_to_lanes(next_state, active_lanes):
+    """Split a batched state dict back into per-lane state dicts."""
+    out = {}
+    if next_state is None or not USE_MEMORY or next_state.get("mem", None) is None:
+        for lane in active_lanes:
+            out[lane] = None
+        return out
+    mem = next_state["mem"].detach()
+    for j, lane in enumerate(active_lanes):
+        out[lane] = {"mem": mem[j : j + 1].contiguous()}
+    return out
+
+
+@torch.no_grad()
+def eval_val_stateful(model_or_ddp, val_tokens, bb, hs, ib, chunk_len=None, lanes=None):
+    """
+    Stateful validation over contiguous chunks.
+
+    This carries the explicit SSM memory vector returned by SSM_LM.forward(...,
+    return_state=True) from chunk to chunk. It is score-first by construction:
+    chunk k is scored using only memory from chunks < k, then the returned memory
+    is carried forward to chunk k+1.
+
+    Important limitation: this carries only the optional USE_MEMORY pathway. It
+    does not carry Mamba2's internal scan state across calls.
+    """
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+
+    if chunk_len is None:
+        chunk_len = STATEFUL_EVAL_CHUNK_TOKENS
+    chunk_len = int(chunk_len)
+    if chunk_len <= 0:
+        raise ValueError(f"STATEFUL_EVAL_CHUNK_TOKENS must be > 0, got {chunk_len}")
+
+    total_pairs = val_tokens.size - 1
+    total_chunks = total_pairs // chunk_len
+    chunk_start = (total_chunks * RANK) // WORLD_SIZE
+    chunk_end = (total_chunks * (RANK + 1)) // WORLD_SIZE
+    local_chunks = chunk_end - chunk_start
+
+    lanes = int(STATEFUL_EVAL_LANES if lanes is None else lanes)
+    lanes = max(1, min(lanes, max(local_chunks, 1)))
+
+    # Each lane processes a contiguous chunk range. More lanes = faster batching,
+    # but state resets at each lane boundary. lanes=1 is most faithful.
+    lane_starts = [chunk_start + (local_chunks * i) // lanes for i in range(lanes)]
+    lane_ends = [chunk_start + (local_chunks * (i + 1)) // lanes for i in range(lanes)]
+    lane_pos = lane_starts[:]
+    lane_states = [None for _ in range(lanes)]
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every = max(1, local_chunks // 10)
+    chunks_done = 0
+
+    if MASTER_PROCESS and not USE_MEMORY:
+        log0("  stateful_eval warning: USE_MEMORY=0, so no explicit SSM memory is carried; this is a contiguous chunk eval only.")
+
+    while True:
+        active = [i for i in range(lanes) if lane_pos[i] < lane_ends[i]]
+        if not active:
+            break
+
+        x_list, y_list = [], []
+        for lane in active:
+            pos = lane_pos[lane] * chunk_len
+            x_list.append(val_tokens[pos : pos + chunk_len])
+            y_list.append(val_tokens[pos + 1 : pos + chunk_len + 1])
+
+        xn = np.stack(x_list)
+        yn = np.stack(y_list)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        state_in = _state_batch_from_lane_states(
+            [lane_states[i] for i in active],
+            bsz=len(active),
+            device=DEVICE,
+            dtype=AMP_DTYPE,
+            memory_dim=core.memory_dim,
+        )
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, next_state = core(x, state=state_in, return_state=True)
+
+        flat_y = y.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+        p_flat = xn.reshape(-1)
+        t_flat = yn.reshape(-1)
+        b = bb[t_flat].astype(np.int16, copy=True)
+        b += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        split_states = _split_batch_state_to_lanes(next_state, active)
+        for lane in active:
+            lane_states[lane] = split_states[lane]
+            lane_pos[lane] += 1
+
+        chunks_done += len(active)
+        if chunks_done % log_every == 0 or chunks_done >= local_chunks:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / max(chunks_done, 1) * max(local_chunks - chunks_done, 0)
+            log0(
+                f"  stateful_eval: {100.0 * chunks_done / max(local_chunks, 1):.0f}% "
+                f"({chunks_done}/{local_chunks} chunks, running_bpb:{running_bpb:.4f}, eta:{eta:.0f}s)"
+            )
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(
+        f"  stateful_eval: {local_chunks} chunks/rank, chunk_len={chunk_len}, lanes={lanes}, "
+        f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s"
+    )
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # Stateful eval carries the explicit SSM memory across contiguous chunks.
+    pre_ttt_stateful_vb = None
+    if STATEFUL_EVAL_ENABLED:
+        log0(f"Running stateful eval (chunk={STATEFUL_EVAL_CHUNK_TOKENS}, lanes={STATEFUL_EVAL_LANES})...")
+        st_vl, st_vb = eval_val_stateful(model, val_tokens, bb, hs, ib)
+        log0(f"Stateful val_loss:{st_vl:.4f} val_bpb:{st_vb:.4f}")
+        log0(f"Stateful vs standard: bpb={best_vb - st_vb:+.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Stateful vs sliding: bpb={pre_ttt_sw_vb - st_vb:+.4f}")
+        pre_ttt_stateful_vb = st_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+    if STATEFUL_EVAL_ENABLED:
+        q_st_vl, q_st_vb = eval_val_stateful(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant stateful val_loss:{q_st_vl:.4f} val_bpb:{q_st_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_tail_loss.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_tail_loss.py
@@ -1,0 +1,2390 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "1") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # 0 = disabled (full D_MODEL)
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "2.25"))  # learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "50"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "700"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# Tail-weighted training objective.
+# Standard training optimizes every position equally, but sliding eval scores
+# tail positions with near-full context. This lets late training shift part of
+# the objective toward the final TAIL_TOKENS positions of each sequence.
+LOSS_MODE = os.environ.get("LOSS_MODE", "standard").lower()  # "standard" or "tail_mixed"
+TAIL_START_FRAC = float(os.environ.get("TAIL_START_FRAC", "0.70"))
+TAIL_RAMP_FRAC = float(os.environ.get("TAIL_RAMP_FRAC", "0.05"))
+TAIL_TOKENS = int(os.environ.get("TAIL_TOKENS", "512"))
+TAIL_WEIGHT = float(os.environ.get("TAIL_WEIGHT", "0.75"))
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "1") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "1") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "1") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(
+    f"loss_mode={LOSS_MODE}, tail_start_frac={TAIL_START_FRAC}, "
+    f"tail_ramp_frac={TAIL_RAMP_FRAC}, tail_tokens={TAIL_TOKENS}, "
+    f"tail_weight={TAIL_WEIGHT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def tail_loss_alpha(elapsed_sec: float) -> float:
+    """
+    Returns the mixture weight on tail loss for the current wallclock progress.
+    0.0 = standard full-token CE.
+    TAIL_WEIGHT = final weight on CE over last TAIL_TOKENS positions.
+    """
+    if LOSS_MODE != "tail_mixed":
+        return 0.0
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 0.0
+    frac = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+    if frac < TAIL_START_FRAC:
+        return 0.0
+    if TAIL_RAMP_FRAC <= 0:
+        return max(0.0, min(1.0, TAIL_WEIGHT))
+    ramp = (frac - TAIL_START_FRAC) / max(TAIL_RAMP_FRAC, 1e-8)
+    return max(0.0, min(1.0, TAIL_WEIGHT * min(1.0, ramp)))
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False,
+            tail_alpha: float = 0.0, tail_tokens: int = 0):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+
+    # Normal path: keep the original efficient reduction for eval and most train steps.
+    if tail_alpha <= 0.0 or tail_tokens <= 0:
+        loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    else:
+        # Tail-mixed objective:
+        # loss = (1-a) * CE(all positions) + a * CE(last N positions)
+        # This better matches sliding eval, where each scored token has long context.
+        B, T = targets.shape
+        loss_per = F.cross_entropy(logits.float(), y, reduction="none").view(B, T)
+        loss_all = loss_per.mean()
+        n_tail = max(1, min(int(tail_tokens), T))
+        loss_tail = loss_per[:, -n_tail:].mean()
+        a = max(0.0, min(1.0, float(tail_alpha)))
+        loss = (1.0 - a) * loss_all + a * loss_tail
+
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = 50  # check wallclock via broadcast every N steps
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.60"))  # 0=disabled, else replay at this frac
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        tail_alpha_step = tail_loss_alpha(elapsed)
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(
+                            model, xs, ys,
+                            tail_alpha=tail_alpha_step,
+                            tail_tokens=TAIL_TOKENS,
+                        )
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        tail_alpha_c = tail_alpha_step if c == (active_stream_chunks - 1) else 0.0
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(
+                                model, xs, ys, state=state, return_state=True,
+                                tail_alpha=tail_alpha_c,
+                                tail_tokens=TAIL_TOKENS,
+                            )
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            extra = f" tail_a:{tail_alpha_step:.2f}" if LOSS_MODE == "tail_mixed" else ""
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f}{extra} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    loader.shutdown()
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_trigram_skipgram.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_trigram_skipgram.py
@@ -1,0 +1,2487 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Trigram / skipgram lexical hash features.
+TRIGRAM_ENABLED = os.environ.get("TRIGRAM_ENABLED", "1") == "1"
+TRIGRAM_BUCKETS = int(os.environ.get("TRIGRAM_BUCKETS", "32768"))
+TRIGRAM_DIM = int(os.environ.get("TRIGRAM_DIM", "64"))
+SKIPGRAM_ENABLED = os.environ.get("SKIPGRAM_ENABLED", "1") == "1"
+SKIPGRAM_BUCKETS = int(os.environ.get("SKIPGRAM_BUCKETS", "16384"))
+SKIPGRAM_DIM = int(os.environ.get("SKIPGRAM_DIM", "64"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(
+    f"trigram: enabled={TRIGRAM_ENABLED}, buckets={TRIGRAM_BUCKETS}, dim={TRIGRAM_DIM}; "
+    f"skipgram: enabled={SKIPGRAM_ENABLED}, buckets={SKIPGRAM_BUCKETS}, dim={SKIPGRAM_DIM}"
+)
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+
+class TrigramSkipgramHash(nn.Module):
+    """Learned trigram(prev2, prev1, token) and skipgram(prev2, token) embedding features."""
+    def __init__(self, trigram_buckets, trigram_dim, skipgram_buckets, skipgram_dim, d_model):
+        super().__init__()
+        self.use_trigram = TRIGRAM_ENABLED
+        self.use_skipgram = SKIPGRAM_ENABLED
+        self.trigram_buckets = trigram_buckets
+        self.skipgram_buckets = skipgram_buckets
+
+        if self.use_trigram:
+            self.tri_embed = nn.Embedding(trigram_buckets, trigram_dim)
+            self.tri_proj = nn.Linear(trigram_dim, d_model, bias=False)
+            nn.init.normal_(self.tri_embed.weight, std=0.01)
+            nn.init.normal_(self.tri_proj.weight, std=0.01)
+        else:
+            self.tri_embed = None
+            self.tri_proj = None
+
+        if self.use_skipgram:
+            self.skip_embed = nn.Embedding(skipgram_buckets, skipgram_dim)
+            self.skip_proj = nn.Linear(skipgram_dim, d_model, bias=False)
+            nn.init.normal_(self.skip_embed.weight, std=0.01)
+            nn.init.normal_(self.skip_proj.weight, std=0.01)
+        else:
+            self.skip_embed = None
+            self.skip_proj = None
+
+    def forward(self, ids):
+        prev1 = F.pad(ids[:, :-1], (1, 0), value=0)
+        prev2 = F.pad(ids[:, :-2], (2, 0), value=0)
+        out = None
+
+        if self.use_trigram:
+            tri_hash = (prev2 * 1000003 + prev1 * 1009 + ids) % self.trigram_buckets
+            tri = self.tri_proj(self.tri_embed(tri_hash))
+            out = tri if out is None else out + tri
+
+        if self.use_skipgram:
+            skip_hash = (prev2 * 65537 + ids) % self.skipgram_buckets
+            skip = self.skip_proj(self.skip_embed(skip_hash))
+            out = skip if out is None else out + skip
+
+        return out
+
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+        self.ngram = TrigramSkipgramHash(
+            TRIGRAM_BUCKETS, TRIGRAM_DIM,
+            SKIPGRAM_BUCKETS, SKIPGRAM_DIM,
+            D_MODEL,
+        ) if (TRIGRAM_ENABLED or SKIPGRAM_ENABLED) else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        if self.ngram is not None:
+            x = x + self.ngram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_wide.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_recall_sota_sp8192_wide.py
@@ -1,0 +1,2506 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = int(os.environ.get("D_MODEL", "640"))  # wide-shallow test default
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = int(os.environ.get("MEMORY_DIM", "256"))
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "1") == "1"
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "0") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0("wide_shallow_patch: D_MODEL and MEMORY_DIM are env-configurable")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("race_defaults: EMBED_DIM=512, ATTN_LAYER_IDXS=6, QK_GAIN_INIT=5.25, LOG_EVERY=500, EMA/SWA/TTT off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3):
+        super().__init__()
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        y = self.mamba(self.ssm_norm(x_in))
+        x = x + self.ssm_scale[None, None, :] * y
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3):
+        super().__init__()
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + optional partial RoPE + learnable per-head query gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                layers.append(CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT))
+            else:
+                layers.append(SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT))
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        logits = core.output_logits_from_hidden(hidden_tail)
+        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                logits = core.output_logits_from_hidden(hidden_tail)
+                logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=seq_len - stride)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Int8 quantization + compression + roundtrip validation
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    log0("Quantizing model to int8...")
+    state_dict = base_model.state_dict()
+    quantized = {}
+    scales = {}
+    passthrough = {}
+    for name, t in state_dict.items():
+        t = t.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            # Small tensors / non-float: keep as fp16
+            if t.is_floating_point() and t.dtype in (torch.float32, torch.bfloat16):
+                passthrough[name] = t.to(torch.float16).contiguous()
+            else:
+                passthrough[name] = t
+            continue
+        # Per-row int8 quantization for 2D, per-tensor for others
+        t32 = t.float()
+        if t32.ndim == 2:
+            clip_abs = torch.quantile(t32.abs(), 0.9999984, dim=1)
+            scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+            clipped = torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None])
+            q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8)
+            scales[name] = scale.to(torch.float16).contiguous()
+        else:
+            clip_abs = float(torch.quantile(t32.abs().flatten(), 0.9999984).item()) if t32.numel() else 0.0
+            scale = clip_abs / 127.0 if clip_abs > 0 else 1.0
+            q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8)
+            scales[name] = torch.tensor(scale, dtype=torch.float32)
+        quantized[name] = q.contiguous()
+
+    quant_obj = {"quantized": quantized, "scales": scales, "passthrough": passthrough}
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    if _COMPRESSOR == "zstd":
+        cctx = zstandard.ZstdCompressor(level=22)
+        quant_blob = cctx.compress(quant_raw)
+    else:
+        quant_blob = zlib.compress(quant_raw, level=9)
+
+    compressed_bytes = len(quant_blob)
+    log0(f"Compressed model ({_COMPRESSOR}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MB)")
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    if _COMPRESSOR == "zstd":
+        dctx = zstandard.ZstdDecompressor()
+        quant_raw_rt = dctx.decompress(quant_blob)
+    else:
+        quant_raw_rt = zlib.decompress(quant_blob)
+    quant_obj_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    # Dequantize
+    dequant_state = {}
+    for name, q in quant_obj_rt["quantized"].items():
+        s = quant_obj_rt["scales"][name]
+        if s.ndim > 0:
+            dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+        else:
+            dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+    for name, t in quant_obj_rt["passthrough"].items():
+        dequant_state[name] = t
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        artifact_path = "final_model.int8.ptz"
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_ropebridge_taskmuon.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/ablations/ssm_ropebridge_taskmuon.py
@@ -1,0 +1,4581 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None  # state-carryover eval will be unavailable
+# Direct kernel access for proper chunked state passing — InferenceParams
+# routes through step() one token at a time and silently no-ops state
+# carryover on the chunked path. mamba_chunk_scan_combined natively supports
+# initial_states / return_final_states.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+# Brotli for compressed artifact (preferred over zstd).
+try:
+    import brotli  # type: ignore
+    _HAS_BROTLI = True
+except ImportError:
+    _HAS_BROTLI = False
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+# torch._dynamo specializes on each block instance reference inside the
+# forward loop (10 distinct block objects → 10 recompiles for the dispatch
+# wrapper). Default cache_size_limit is 8, so we hit the warning and dynamo
+# falls back to eager for that frame. Bump it well above n_blocks.
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = 64
+    torch._dynamo.config.accumulated_cache_size_limit = 256
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "8192"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))  # tested 128 — added ~17% throughput cost without recovering it in BPB at 10min training budget. 64 wins empirically here.
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Mamba2-specific knobs (passed to mamba_ssm.modules.mamba2.Mamba2)
+HEADDIM = int(os.environ.get("HEADDIM", "64"))   # tested 32 — slower kernel path at this size, didn't pay back in BPB
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))  # sharper than Mamba2 default 0.001
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))    # sharper than Mamba2 default 0.1
+FFN_MULT = int(os.environ.get("FFN_MULT", "2"))  # was 3 — FFN dominates the param budget; cutting to 2 saves ~8M params (~6MB compressed) at modest BPB cost
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document boundary handling for SSM training. SSMs accumulate state across
+# the entire sequence, so when multiple short docs are packed into a single
+# 8192-token training row, doc B's state is contaminated by doc A. Mamba2's
+# chunk-scan kernel accepts a `seq_idx` (B, T) int32 that zeros state
+# transitions at chunk boundaries where seq_idx changes. Reset granularity
+# is the chunk_size of the scan (256 by default), so contamination is
+# bounded to <=256 tokens after each boundary instead of unbounded.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))  # this tokenizer has bos=1 (<s>), pad=0; <s> appears every ~811 tokens in val data → real doc separator
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "256"))  # genuine factoring: tok_emb is 8192x256, embed_proj 256->512. Saves ~2.1M raw on tok_emb, costs ~131K on embed_proj. Net ~1.5MB compressed savings vs EMBED_DIM=512 (which is no-op factoring).
+
+# Untied output head + neural copy/pointer head.
+# Goal: improve token-output expressivity and exact/contextual token reuse.
+UNTIE_LM_HEAD = os.environ.get("UNTIE_LM_HEAD", "0") == "1"  # default tied: saves 4.2M params at vocab=8192. Untied costs ~3MB compressed for ~0.005 BPB; not worth it under 16MB cap.
+LM_HEAD_BIAS = os.environ.get("LM_HEAD_BIAS", "1") == "1"
+COPY_HEAD_ENABLED = os.environ.get("COPY_HEAD_ENABLED", "0") == "1"
+COPY_DIM = int(os.environ.get("COPY_DIM", "64"))
+COPY_GATE_BIAS_INIT = float(os.environ.get("COPY_GATE_BIAS_INIT", "-2.0"))
+COPY_SCALE_INIT = float(os.environ.get("COPY_SCALE_INIT", "1.0"))
+COPY_USE_QK_NORM = os.environ.get("COPY_USE_QK_NORM", "1") == "1"
+
+# Hybrid attention config
+# This file's new default is mode D: two hard RoPE attention teachers at 2,5,
+# followed by cheap context bridges into later SSM layers.
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "2,5").split(",") if x.strip()]
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))
+
+# Attention/SSM fusion experiments.
+# FUSION_MODE:
+#   NONE: original hard SSM/attention block replacement
+#   A: attention-corrected SSM block. FUSION_LAYERS stay SSM blocks and get a gated attention residual after Mamba.
+#   B: attention-before-Mamba injection. FUSION_LAYERS stay SSM blocks and get a small attention residual before Mamba's input projection.
+#   C: SSM/current-hidden-conditioned Q/K gain inside regular attention blocks.
+#   D: RoPE-Bridge-C: existing RoPE attention layers teach context; later SSM layers carry it cheaply.
+FUSION_MODE = os.environ.get("FUSION_MODE", "D").strip().upper()
+if FUSION_MODE == "":
+    FUSION_MODE = "D"
+if FUSION_MODE not in ("NONE", "A", "B", "C", "D"):
+    raise ValueError(f"FUSION_MODE must be one of NONE,A,B,C,D; got {FUSION_MODE!r}")
+
+def _parse_int_list_env(name: str, default: str):
+    raw = os.environ.get(name, default)
+    return [int(x) for x in raw.split(",") if x.strip()]
+
+def _parse_layer_value_map(raw: str, cast=float):
+    out = {}
+    if not raw:
+        return out
+    for item in raw.split(","):
+        item = item.strip()
+        if not item or ":" not in item:
+            continue
+        k, v = item.split(":", 1)
+        out[int(k.strip())] = cast(v.strip())
+    return out
+
+def _layer_value(layer_idx, mapping, default):
+    if layer_idx is None:
+        return default
+    return mapping.get(int(layer_idx), default)
+
+_default_fusion_layers = "2,5" if FUSION_MODE == "A" else ("2" if FUSION_MODE == "B" else "")
+FUSION_LAYERS = _parse_int_list_env("FUSION_LAYERS", _default_fusion_layers)
+FUSION_ATTN_HEADS = int(os.environ.get("FUSION_ATTN_HEADS", "4"))
+FUSION_ATTENTION_GATE_INIT = float(os.environ.get("FUSION_ATTENTION_GATE_INIT", "-2.5"))
+FUSION_PRE_GATE_INIT = float(os.environ.get("FUSION_PRE_GATE_INIT", "0.0"))
+FUSION_PRE_SCALE = float(os.environ.get("FUSION_PRE_SCALE", "0.1"))
+FUSION_QK_DELTA_SCALE = float(os.environ.get("FUSION_QK_DELTA_SCALE", "0.1"))
+
+# RoPE-Bridge mode D: no extra full attention modules. Existing attention
+# blocks produce RoPE-aware teacher context; later SSM blocks receive it through
+# a tiny low-rank bridge before Mamba's input projection.
+CONTEXT_BRIDGE_ENABLED = os.environ.get("CONTEXT_BRIDGE_ENABLED", "1" if FUSION_MODE == "D" else "0") == "1"
+CONTEXT_BRIDGE_LAYERS = _parse_int_list_env("CONTEXT_BRIDGE_LAYERS", "3,4,6,7" if FUSION_MODE == "D" else "")
+CONTEXT_BRIDGE_DIM = int(os.environ.get("CONTEXT_BRIDGE_DIM", "64"))
+CONTEXT_BRIDGE_GATE_INIT = float(os.environ.get("CONTEXT_BRIDGE_GATE_INIT", "-2.0"))
+CONTEXT_BRIDGE_CTX_DECAY = float(os.environ.get("CONTEXT_BRIDGE_CTX_DECAY", "0.70"))
+SKIP_INIT = float(os.environ.get("SKIP_INIT", "0.5" if FUSION_MODE == "D" else "1.0"))
+
+# Partial RoPE in the attention checkpoint.
+# Useful for 8192-context tests: lets a subset of each attention head encode relative position
+# while leaving the remaining dimensions content-only.
+ROPE_ENABLED = os.environ.get("ROPE_ENABLED", "1") == "1"
+ROPE_DIM = int(os.environ.get("ROPE_DIM", "16"))
+ROPE_BASE = float(os.environ.get("ROPE_BASE", "10000.0"))
+ROPE_LAYER_DIM_MAP = _parse_layer_value_map(os.environ.get("ROPE_LAYER_DIMS", "2:16,5:32" if FUSION_MODE == "D" else ""), cast=int)
+ROPE_LAYER_BASE_MAP = _parse_layer_value_map(os.environ.get("ROPE_LAYER_BASES", "2:10000,5:50000" if FUSION_MODE == "D" else ""), cast=float)
+Q_GAIN_SPLIT = os.environ.get("Q_GAIN_SPLIT", "1" if FUSION_MODE == "D" else "0") == "1"
+Q_GAIN_ROPE_INIT = float(os.environ.get("Q_GAIN_ROPE_INIT", str(QK_GAIN_INIT)))
+Q_GAIN_CONTENT_INIT = float(os.environ.get("Q_GAIN_CONTENT_INIT", str(QK_GAIN_INIT)))
+
+# 2048 -> 8192 length curriculum.
+# Keep SEQ_LEN=8192 for final/eval shape, but early training batches use shorter
+# 2048 sequences with the same TOK_PER_RANK token budget. This attempts to combine
+# faster/more diverse 2048 optimization with late 8192 context learning.
+LENGTH_CURRICULUM_ENABLED = os.environ.get("LENGTH_CURRICULUM_ENABLED", "0") == "1"
+CURRICULUM_SHORT_SEQ_LEN = int(os.environ.get("CURRICULUM_SHORT_SEQ_LEN", "2048"))
+CURRICULUM_SWITCH_FRAC = float(os.environ.get("CURRICULUM_SWITCH_FRAC", "0.60"))
+
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # conservative default: your known-good SwiGLU; try leaky_relu2 only as an ablation
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))  # conservative default: restore baseline schedule; try 0.10 only as an ablation
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.20"))  # 80% warmdown (was 0.28 = 72%); EMA/SWA do not work for this SSM, so the schedule itself has to land precisely
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "0") == "1"  # off by default: saves ~1MB compressed (1.4M params), BPB cost ~0.002-0.005. Bigram hash gave marginal lift; not worth the bytes given the 16MB cap.
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# State carryover at eval — SSM-native: thread Mamba2 hidden state across
+# non-overlapping seq_len blocks of the val set so every scored token has the
+# entire validation prefix in its recurrent state (transformers can't do this).
+# Implementation: mamba_ssm InferenceParams cache, seqlen_offset held at 0 so
+# the chunked scan path is used with carried initial_states. Attention layers
+# (which can't carryover) see only their own block, matching training context.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"  # disabled by default — model not trained for stateful init, has been net-negative across 12+ runs. Re-enable with stateful-overlap to test.
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))  # stateful-overlap: each block = overlap + score_region. Mamba state carries; attention sees overlap+score_region; only score_region scored. PR #1644 reports this matches sliding within 0.3 mBPB.
+# Warmup tokens at the start of the val stream where Mamba state is still
+# "cold" (consumed too few tokens to be informative). These are processed to
+# advance state but their losses are not counted. Default to one full block
+# so the cold-start block is always excluded. Set to 0 to score everything.
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+# Direct chunk-scan path (Task 3): bypasses Mamba2.forward and calls the
+# triton kernel mamba_chunk_scan_combined with explicit initial_states /
+# return_final_states. This is the only path that actually carries SSM state
+# across non-overlapping val blocks at chunked-scan throughput. Set to "0"
+# to fall back to the (broken) inference_params version for diagnosis.
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Compression / quantization config — int6 GPTQ-lite + Brotli-11 stack.
+# Goal: <16,000,000-byte artifact. Naive int8+zstd lands ~35MB; int6 packed
+# + Brotli-11 + tied LM head should land ~13-15MB.
+QUANT_MODE = os.environ.get("QUANT_MODE", "int6_packed").lower()  # "int6_packed", "int8" (legacy)
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))  # SDClip k for matrix tensors (int6); SOTA value from PR #1394
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))    # SDClip k for embedding-like tensors (int8); higher k = less aggressive clipping
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "0"))  # quantize all 2D float tensors by default; keeps 1D/3D fp16 and helps stay under 16MB
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"  # PR #1890 / Q-Mamba: promote dt rows of mamba.in_proj.weight to INT8 to protect SSM recurrence from quant noise. ~16 extra bytes/row, big post-quant BPB recovery.
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"  # GPTQ-lite for embeddings: per-row optimal clip search instead of single global k. Targets rare-token rows whose distribution differs from common rows. ~0.005-0.010 BPB recovery on post-quant.
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1 = float(os.environ.get("BETA1", "0.9"))
+BETA2 = float(os.environ.get("BETA2", "0.95"))  # restore baseline optimizer default; use BETA2=0.99 only as an ablation
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"  # default OFF for architecture sweeps
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.003"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "1"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+# LoRA-scoped TTT params (legal score-first TTT per reviewer / PR #1797)
+SCORE_FIRST_TTT_USE_LORA = os.environ.get("SCORE_FIRST_TTT_USE_LORA", "1") == "1"  # adapt only LoRA params instead of all model params. Required for legal score-first TTT (otherwise the adaptation is too unstable and was the root cause of the previous all-params getting-stuck bug).
+SCORE_FIRST_TTT_LORA_RANK = int(os.environ.get("SCORE_FIRST_TTT_LORA_RANK", "32"))  # conservative default for eval-time cost; try 64 only after smoke testing
+SCORE_FIRST_TTT_LORA_ALPHA = float(os.environ.get("SCORE_FIRST_TTT_LORA_ALPHA", "64.0"))  # alpha/rank scaling
+SCORE_FIRST_TTT_OPT = os.environ.get("SCORE_FIRST_TTT_OPT", "adamw").lower()  # "adamw" or "sgd"
+SCORE_FIRST_TTT_BETA2 = float(os.environ.get("SCORE_FIRST_TTT_BETA2", "0.99"))  # AdamW beta2 (PR #1797 uses 0.99)
+SCORE_FIRST_TTT_WD = float(os.environ.get("SCORE_FIRST_TTT_WD", "0.1"))  # AdamW weight decay
+SCORE_FIRST_TTT_NO_ALLREDUCE = os.environ.get("SCORE_FIRST_TTT_NO_ALLREDUCE", "1") == "1"  # CRITICAL: ranks process disjoint val slices, so all-reducing TTT grads leaks future tokens between ranks. Default to rank-local TTT.
+SCORE_FIRST_TTT_TARGETS = tuple(x.strip() for x in os.environ.get("SCORE_FIRST_TTT_TARGETS", "qkv,out_proj,gate_up,down").split(",") if x.strip())
+SCORE_FIRST_TTT_WRAP_MAMBA = os.environ.get("SCORE_FIRST_TTT_WRAP_MAMBA", "0") == "1"  # default false: mamba_ssm.forward reads .weight directly and naive LoRA wrappers crash/deopt
+RUN_PREQUANT_SCORE_FIRST_TTT = os.environ.get("RUN_PREQUANT_SCORE_FIRST_TTT", "0") == "1"  # default OFF for architecture sweeps
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "0") == "1"  # eval-only sweep default: skip quant/post-quant/artifact
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+# TaskMuon: component-aware Muon for this SSM/attention hybrid.
+# Set TASKMUON_ENABLED=0 to fall back to the original one-bucket Muon.
+TASKMUON_ENABLED = os.environ.get("TASKMUON_ENABLED", "1") == "1"
+TASKMUON_ROW_BALANCE = os.environ.get("TASKMUON_ROW_BALANCE", "1" if FUSION_MODE == "D" else "0") == "1"
+TASKMUON_TRUST_CLIP = os.environ.get("TASKMUON_TRUST_CLIP", "1" if FUSION_MODE == "D" else "0") == "1"
+TASKMUON_TRUST_MULT = float(os.environ.get("TASKMUON_TRUST_MULT", "8.0"))
+TASKMUON_TRUST_FLOOR = float(os.environ.get("TASKMUON_TRUST_FLOOR", "1e-3"))
+TASKMUON_QKV_LR_MULT = float(os.environ.get("TASKMUON_QKV_LR_MULT", "1.00"))
+TASKMUON_QK_ROPE_LR_MULT = float(os.environ.get("TASKMUON_QK_ROPE_LR_MULT", "0.55"))
+TASKMUON_QK_CONTENT_LR_MULT = float(os.environ.get("TASKMUON_QK_CONTENT_LR_MULT", "1.00"))
+TASKMUON_V_LR_MULT = float(os.environ.get("TASKMUON_V_LR_MULT", "0.90"))
+TASKMUON_ATTN_OUT_LR_MULT = float(os.environ.get("TASKMUON_ATTN_OUT_LR_MULT", "0.75"))
+TASKMUON_MAMBA_ZX_LR_MULT = float(os.environ.get("TASKMUON_MAMBA_ZX_LR_MULT", "0.75"))
+TASKMUON_MAMBA_BC_LR_MULT = float(os.environ.get("TASKMUON_MAMBA_BC_LR_MULT", "0.45"))
+TASKMUON_MAMBA_DT_LR_MULT = float(os.environ.get("TASKMUON_MAMBA_DT_LR_MULT", "0.25"))
+TASKMUON_MAMBA_OUT_LR_MULT = float(os.environ.get("TASKMUON_MAMBA_OUT_LR_MULT", "0.65"))
+TASKMUON_FFN_LR_MULT = float(os.environ.get("TASKMUON_FFN_LR_MULT", "1.00"))
+TASKMUON_FFN_GATE_LR_MULT = float(os.environ.get("TASKMUON_FFN_GATE_LR_MULT", "1.00"))
+TASKMUON_FFN_UP_LR_MULT = float(os.environ.get("TASKMUON_FFN_UP_LR_MULT", "1.00"))
+TASKMUON_FFN_DOWN_LR_MULT = float(os.environ.get("TASKMUON_FFN_DOWN_LR_MULT", "0.75"))
+TASKMUON_BRIDGE_LR_MULT = float(os.environ.get("TASKMUON_BRIDGE_LR_MULT", "0.75"))
+TASKMUON_GENERIC_LR_MULT = float(os.environ.get("TASKMUON_GENERIC_LR_MULT", "1.00"))
+TASKMUON_QKV_SHAPE_CAP = float(os.environ.get("TASKMUON_QKV_SHAPE_CAP", "1.75"))
+TASKMUON_QK_ROPE_SHAPE_CAP = float(os.environ.get("TASKMUON_QK_ROPE_SHAPE_CAP", "1.00"))
+TASKMUON_MAMBA_IN_SHAPE_CAP = float(os.environ.get("TASKMUON_MAMBA_IN_SHAPE_CAP", "1.25"))
+TASKMUON_MAMBA_BC_SHAPE_CAP = float(os.environ.get("TASKMUON_MAMBA_BC_SHAPE_CAP", "1.00"))
+TASKMUON_MAMBA_OUT_SHAPE_CAP = float(os.environ.get("TASKMUON_MAMBA_OUT_SHAPE_CAP", "1.00"))
+TASKMUON_FFN_SHAPE_CAP = float(os.environ.get("TASKMUON_FFN_SHAPE_CAP", "0.0"))  # 0 = no cap
+TASKMUON_ATTN_WD = float(os.environ.get("TASKMUON_ATTN_WD", str(WEIGHT_DECAY)))
+TASKMUON_QK_ROPE_WD = float(os.environ.get("TASKMUON_QK_ROPE_WD", "0.0"))
+TASKMUON_QK_CONTENT_WD = float(os.environ.get("TASKMUON_QK_CONTENT_WD", str(WEIGHT_DECAY)))
+TASKMUON_V_WD = float(os.environ.get("TASKMUON_V_WD", str(WEIGHT_DECAY)))
+TASKMUON_MAMBA_ZX_WD = float(os.environ.get("TASKMUON_MAMBA_ZX_WD", "0.06"))
+TASKMUON_MAMBA_BC_WD = float(os.environ.get("TASKMUON_MAMBA_BC_WD", "0.02"))
+TASKMUON_MAMBA_DT_WD = float(os.environ.get("TASKMUON_MAMBA_DT_WD", "0.0"))
+TASKMUON_MAMBA_OUT_WD = float(os.environ.get("TASKMUON_MAMBA_OUT_WD", "0.04"))
+TASKMUON_FFN_WD = float(os.environ.get("TASKMUON_FFN_WD", "0.12"))
+TASKMUON_FFN_DOWN_WD = float(os.environ.get("TASKMUON_FFN_DOWN_WD", "0.08"))
+TASKMUON_BRIDGE_WD = float(os.environ.get("TASKMUON_BRIDGE_WD", "0.05"))
+TASKMUON_GENERIC_WD = float(os.environ.get("TASKMUON_GENERIC_WD", str(WEIGHT_DECAY)))
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+    "fusion_gate",
+    "fusion_pre_gate",
+    "q_gain_delta",
+    "q_gain_rope",
+    "q_gain_content",
+    "ctx_gate",
+)
+
+# -----------------------------------------------------------------------------
+# Optional single-file ABC launcher
+# -----------------------------------------------------------------------------
+def _maybe_launch_abc_sweep():
+    """When run as `python this_file.py`, launch A -> B -> C under torchrun.
+
+    Child torchrun workers have RANK/WORLD_SIZE set, so they skip this launcher
+    and execute the normal distributed training path below.
+    """
+    if "RANK" in os.environ and "WORLD_SIZE" in os.environ:
+        return
+    if os.environ.get("RUN_ABC_SWEEP", "1") != "1":
+        return
+
+    modes = [m.strip().upper() for m in os.environ.get("ABC_MODES", "D").split(",") if m.strip()]
+    bad = [m for m in modes if m not in ("A", "B", "C", "D")]
+    if bad:
+        raise ValueError(f"ABC_MODES may only contain A,B,C,D; got {bad}")
+
+    script = Path(__file__).resolve()
+    nproc = int(os.environ.get("ABC_NPROC", os.environ.get("NPROC_PER_NODE", "8")))
+    log_dir = Path(os.environ.get("ABC_LOG_DIR", "./fusion_abc_runs")).resolve()
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    # Conservative defaults that can still be overridden by the caller's env.
+    common = {
+        "ABC_SWEEP_CHILD": "1",
+        "SCORE_FIRST_TTT_ENABLED": "0",       # architecture sweep: TTT off by default
+        "RUN_PREQUANT_SCORE_FIRST_TTT": "0",
+        "RUN_POSTQUANT": "0",                 # skip quant/post-quant/artifact during architecture sweeps
+        "SCORE_FIRST_TTT_WRAP_MAMBA": "0",
+        "SCORE_FIRST_TTT_TARGETS": "qkv,out_proj,gate_up,down",
+        "QUANT_PASSTHROUGH_NUMEL": "0",
+        "STOP_CHECK_EVERY": "10",
+        "TASKMUON_ENABLED": "1",            # use component-aware optimizer for this sweep
+        "ARTIFACT_DIR": str(log_dir),
+    }
+
+    # Per-mode architecture defaults. These are only defaults: any value already
+    # set in the shell wins, except FUSION_MODE/RUN_TAG which are mode-specific.
+    per_mode = {
+        # A: SSM blocks at layers 2,5 with attention correction after Mamba.
+        "A": {
+            "FUSION_MODE": "A",
+            "FUSION_LAYERS": "2,5",
+            "ATTN_LAYER_IDXS": "",
+            "N_UNIQUE_BLOCKS": "8",
+            "FUSION_ATTN_HEADS": "4",
+            "FUSION_ATTENTION_GATE_INIT": "-2.5",
+        },
+        # B: one early attention injection before Mamba's input projection.
+        "B": {
+            "FUSION_MODE": "B",
+            "FUSION_LAYERS": "2",
+            "ATTN_LAYER_IDXS": "",
+            "N_UNIQUE_BLOCKS": "8",
+            "FUSION_ATTN_HEADS": "4",
+            "FUSION_PRE_SCALE": "0.1",
+            "FUSION_PRE_GATE_INIT": "0.0",
+        },
+        # C: regular hard attention layers, but Q/K gain is conditioned on current hidden state.
+        "C": {
+            "FUSION_MODE": "C",
+            "ATTN_LAYER_IDXS": "2,5",
+            "N_UNIQUE_BLOCKS": "8",
+            "FUSION_QK_DELTA_SCALE": "0.1",
+        },
+        # D: RoPE attention at 2,5 produces teacher context; SSM layers 3,4,6,7 carry it via low-rank bridges.
+        "D": {
+            "FUSION_MODE": "D",
+            "ATTN_LAYER_IDXS": "2,5",
+            "N_UNIQUE_BLOCKS": "8",
+            "CONTEXT_BRIDGE_ENABLED": "1",
+            "CONTEXT_BRIDGE_LAYERS": "3,4,6,7",
+            "CONTEXT_BRIDGE_DIM": "64",
+            "CONTEXT_BRIDGE_GATE_INIT": "-2.0",
+            "CONTEXT_BRIDGE_CTX_DECAY": "0.70",
+            "ROPE_LAYER_DIMS": "2:16,5:32",
+            "ROPE_LAYER_BASES": "2:10000,5:50000",
+            "Q_GAIN_SPLIT": "1",
+            "SKIP_INIT": "0.5",
+            "TASKMUON_ENABLED": "1",
+            "TASKMUON_ROW_BALANCE": "1",
+            "TASKMUON_TRUST_CLIP": "1",
+        },
+    }
+
+    print(f"ABCD/RoPE-Bridge sweep launcher: modes={modes}, nproc={nproc}, log_dir={log_dir}", flush=True)
+    for mode in modes:
+        env = os.environ.copy()
+        respect_common_env = os.environ.get("ABC_RESPECT_COMMON_ENV", "0") == "1"
+        for k, v in common.items():
+            if respect_common_env:
+                env.setdefault(k, v)
+            else:
+                env[k] = v
+        respect_mode_env = os.environ.get("ABC_RESPECT_MODE_ENV", "0") == "1"
+        for k, v in per_mode[mode].items():
+            # By default, mode-defining architecture values are forced so A/B/C
+            # really mean A/B/C even if the shell still has old ablation envs set.
+            # Set ABC_RESPECT_MODE_ENV=1 if you intentionally want shell values to win.
+            if respect_mode_env and k != "FUSION_MODE":
+                env.setdefault(k, v)
+            else:
+                env[k] = v
+        env["RUN_TAG"] = env.get("RUN_TAG", f"fusion_{mode.lower()}")
+        if os.environ.get("ABC_APPEND_MODE_TO_TAG", "1") == "1":
+            base_tag = os.environ.get("RUN_TAG", "fusion")
+            env["RUN_TAG"] = f"{base_tag}_{mode.lower()}"
+        log_path = log_dir / f"{env['RUN_TAG']}.log"
+        cmd = ["torchrun", "--standalone", "--nproc_per_node", str(nproc), str(script)]
+        print("=" * 80, flush=True)
+        print(f"Launching fusion {mode}: {' '.join(cmd)}", flush=True)
+        print(f"  RUN_TAG={env['RUN_TAG']} FUSION_MODE={env['FUSION_MODE']} "
+              f"ATTN_LAYER_IDXS={env.get('ATTN_LAYER_IDXS','')} "
+              f"FUSION_LAYERS={env.get('FUSION_LAYERS','')} "
+              f"N_UNIQUE_BLOCKS={env.get('N_UNIQUE_BLOCKS','')}", flush=True)
+        print(f"  log: {log_path}", flush=True)
+        with open(log_path, "w", buffering=1) as lf:
+            proc = subprocess.Popen(cmd, env=env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+            assert proc.stdout is not None
+            for line in proc.stdout:
+                print(line, end="", flush=True)
+                lf.write(line)
+            rc = proc.wait()
+        if rc != 0:
+            print(f"Fusion mode {mode} failed with exit code {rc}. Stopping sweep.", flush=True)
+            sys.exit(rc)
+    print("ABCD/RoPE-Bridge sweep complete.", flush=True)
+    sys.exit(0)
+
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 8xGPU by default)
+# -----------------------------------------------------------------------------
+_maybe_launch_abc_sweep()
+
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch, or run it normally as "
+        "`python ssm_fusion_abc_sweep.py` to launch A->B->C automatically."
+    )
+EXPECTED_WORLD_SIZE = int(os.environ.get("EXPECTED_WORLD_SIZE", "8"))
+if WORLD_SIZE != EXPECTED_WORLD_SIZE:
+    raise RuntimeError(f"Expected WORLD_SIZE={EXPECTED_WORLD_SIZE}, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(
+    f"output_copy: untie_lm_head={UNTIE_LM_HEAD}, lm_head_bias={LM_HEAD_BIAS}, "
+    f"copy_enabled={COPY_HEAD_ENABLED}, copy_dim={COPY_DIM}, "
+    f"copy_gate_bias_init={COPY_GATE_BIAS_INIT}, copy_scale_init={COPY_SCALE_INIT}"
+)
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0(f"fusion: mode={FUSION_MODE}, layers={FUSION_LAYERS}, fusion_heads={FUSION_ATTN_HEADS}, gate_init={FUSION_ATTENTION_GATE_INIT}, pre_scale={FUSION_PRE_SCALE}, qk_delta_scale={FUSION_QK_DELTA_SCALE}")
+log0(f"rope_bridge: enabled={CONTEXT_BRIDGE_ENABLED}, bridge_layers={CONTEXT_BRIDGE_LAYERS}, bridge_dim={CONTEXT_BRIDGE_DIM}, gate_init={CONTEXT_BRIDGE_GATE_INIT}, ctx_decay={CONTEXT_BRIDGE_CTX_DECAY}, skip_init={SKIP_INIT}")
+log0(f"rope: enabled={ROPE_ENABLED}, dim={ROPE_DIM}, base={ROPE_BASE}, layer_dims={ROPE_LAYER_DIM_MAP}, layer_bases={ROPE_LAYER_BASE_MAP}, q_gain_split={Q_GAIN_SPLIT}")
+log0(
+    f"length_curriculum: enabled={LENGTH_CURRICULUM_ENABLED}, "
+    f"short_seq={CURRICULUM_SHORT_SEQ_LEN}, switch_frac={CURRICULUM_SWITCH_FRAC}, final_seq={SEQ_LEN}"
+)
+log0("current_defaults: RoPE-Bridge mode D, ATTN_LAYER_IDXS=2,5, context bridges 3,4,6,7, TaskMuon/RopeTaskMuon on, TTT/postquant off")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, prequant={RUN_PREQUANT_SCORE_FIRST_TTT}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}, targets={SCORE_FIRST_TTT_TARGETS}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT} (0 = skip quant/post-quant/artifact for sweeps)")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"quant: mode={QUANT_MODE}, k_matrix={QUANT_K_MATRIX}, k_embed={QUANT_K_EMBED}, passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, brotli={_HAS_BROTLI}")
+log0(f"lr_schedule: {LR_SCHEDULE}, warmdown_start={LR_WARMDOWN_START_FRAC} ({(1.0-LR_WARMDOWN_START_FRAC)*100:.0f}% warmdown)")
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: taskmuon={TASKMUON_ENABLED}, muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}, "
+    f"taskmuon_row_balance={TASKMUON_ROW_BALANCE}, taskmuon_trust_clip={TASKMUON_TRUST_CLIP}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+
+def _apply_fusion_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """RoPE helper for the small fusion attention modules, defined early so
+    SelectiveSSMBlock can use attention before the regular CausalAttentionBlock
+    class is declared.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)
+    cos = freqs.cos()[None, None, :, :]
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+class CausalFusionAttention(nn.Module):
+    """Small causal attention core used to fuse attention into SSM blocks.
+
+    It intentionally has no FFN and returns only a residual correction. The
+    out_proj is zero-initialized, so variants A/B begin as the base SSM model
+    and learn the fusion path only if useful.
+    """
+    def __init__(self, d_model, n_heads=4):
+        super().__init__()
+        if d_model % n_heads != 0:
+            raise ValueError(f"d_model={d_model} must be divisible by fusion n_heads={n_heads}")
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+    def forward(self, x):
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = _apply_fusion_rope(q, k, ROPE_DIM, ROPE_BASE)
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        return self.out_proj(attn_out)
+
+class ContextBridge(nn.Module):
+    """Cheap RoPE-context bridge from attention teacher output into later SSM inputs.
+
+    This deliberately does not add another attention module. It takes the
+    RoPE-aware attention context produced by existing attention layers and
+    injects a low-rank, gated residual before Mamba's in_proj so the SSM can
+    store/carry that contextual signal.
+    """
+    def __init__(self, d_model, rank=64, gate_init=-2.0):
+        super().__init__()
+        rank = max(1, int(rank))
+        self.ctx_norm = RMSNorm(d_model)
+        self.ctx_down = nn.Linear(d_model, rank, bias=False)
+        self.ctx_up = nn.Linear(rank, d_model, bias=False)
+        self.ctx_gate = nn.Parameter(torch.full((d_model,), float(gate_init)))
+        nn.init.normal_(self.ctx_down.weight, std=0.01)
+        nn.init.zeros_(self.ctx_up.weight)
+
+    def forward(self, x, ctx):
+        if ctx is None:
+            return x
+        # ctx has the same (B,T,D) shape as x. Cast only at the end to keep the
+        # low-rank bridge numerically calm under autocast.
+        h = self.ctx_down(self.ctx_norm(ctx))
+        h = F.silu(h)
+        delta = self.ctx_up(h)
+        gate = torch.sigmoid(self.ctx_gate).to(dtype=x.dtype, device=x.device)
+        return x + gate[None, None, :] * delta.to(dtype=x.dtype)
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3, layer_idx=None):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,  # required for inference_params cache (state-carryover eval)
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.ffn_norm = RMSNorm(d_model)
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Fusion variants A/B keep this as an SSM block but add a small attention path.
+        self.fusion_mode = FUSION_MODE
+        self.fusion_enabled = (layer_idx in set(FUSION_LAYERS)) and (FUSION_MODE in ("A", "B"))
+        if self.fusion_enabled:
+            self.fusion_attn = CausalFusionAttention(d_model, FUSION_ATTN_HEADS)
+            if FUSION_MODE == "A":
+                self.fusion_gate = nn.Parameter(torch.full((d_model,), FUSION_ATTENTION_GATE_INIT))
+                self.fusion_pre_gate = None
+            else:
+                self.fusion_gate = None
+                self.fusion_pre_gate = nn.Parameter(torch.tensor(float(FUSION_PRE_GATE_INIT)))
+        else:
+            self.fusion_attn = None
+            self.fusion_gate = None
+            self.fusion_pre_gate = None
+
+        self.context_bridge = (
+            ContextBridge(d_model, CONTEXT_BRIDGE_DIM, CONTEXT_BRIDGE_GATE_INIT)
+            if CONTEXT_BRIDGE_ENABLED and (layer_idx in set(CONTEXT_BRIDGE_LAYERS))
+            else None
+        )
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None, ctx=None):
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        # Mode D: inject RoPE-aware teacher context from previous attention
+        # blocks before Mamba's in_proj, so the recurrent stream can store it.
+        if self.context_bridge is not None and ctx is not None:
+            x_in = self.context_bridge(x_in, ctx)
+
+        # Variant B: let a tiny causal attention path steer Mamba's input
+        # projection, so attention can influence z/x/B/C/dt rather than only
+        # adding a post-hoc residual.
+        if self.fusion_enabled and self.fusion_mode == "B":
+            a = self.fusion_attn(x_in)
+            gate = torch.sigmoid(self.fusion_pre_gate).to(dtype=x_in.dtype, device=x_in.device)
+            x_in = x_in + (FUSION_PRE_SCALE * gate) * a
+
+        # When inference_params is given the Mamba2 chunked scan reads the
+        # carried initial_states from the cache and writes back the final
+        # state. We hold seqlen_offset at 0 so we never enter the step path.
+        # seq_idx (B, T) int32 zeroes state transitions at chunk-aligned
+        # document boundaries.
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x_mixed + self.ssm_scale[None, None, :] * y
+
+        # Variant A: attention-corrected SSM. The block remains recurrent, but
+        # a gated attention residual fixes local/exact-token mistakes.
+        if self.fusion_enabled and self.fusion_mode == "A":
+            a = self.fusion_attn(x)
+            gate = torch.sigmoid(self.fusion_gate).to(dtype=x.dtype, device=x.device)
+            x = x + gate[None, None, :] * a
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via the
+        triton kernel. Bypasses Mamba2.forward (whose inference_params path
+        goes through step() one token at a time, which silently no-ops the
+        chunked-scan state).
+
+        u: (B, L, d_model)
+        initial_ssm_state: (B, nheads, headdim, d_state) or None
+        prev_conv_input: (B, d_conv-1, conv_channels) or None.
+            Last d_conv-1 inputs to conv1d from previous block; None on
+            first block. With d_conv=4 this is 3 timesteps.
+        seq_idx: (B, L) int32 or None — document boundaries within block.
+            State transitions are zeroed at chunk-aligned positions where
+            seq_idx changes.
+
+        Returns: (y, final_ssm_state, last_conv_input)
+        """
+        m = self.mamba
+        B, L, _ = u.shape
+
+        # in_proj split — handle optional d_mlp path defensively
+        zxbcdt = m.in_proj(u)  # (B, L, total)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+        d_mlp = (full - expected) // 2
+
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_mlp, d_mlp, d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+        else:
+            z, xBC, dt = torch.split(
+                zxbcdt,
+                [d_inner, conv_channels, nheads],
+                dim=-1,
+            )
+            z0 = x0_mlp = None
+
+        # Conv1d with state-passing. Mamba2's conv1d is depthwise (groups=C)
+        # with kernel d_conv. To carry state across blocks we prepend the
+        # previous block's last (d_conv-1) inputs and run with padding=0,
+        # producing exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()  # (B, C, L)
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()  # (B, C, d_conv-1)
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)  # (B, C, L + d_conv - 1)
+            xBC_conv = F.conv1d(
+                xBC_padded,
+                m.conv1d.weight,
+                m.conv1d.bias,
+                stride=1, padding=0, dilation=1,
+                groups=conv_channels,
+            )  # (B, C, L)
+        else:
+            # First block of stream — let the module's own conv handle causal
+            # padding, then trim trailing positions.
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)  # (B, L, C)
+
+        x, Bm, Cm = torch.split(
+            xBC_conv,
+            [d_inner, ngroups * d_state, ngroups * d_state],
+            dim=-1,
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+
+        A = -torch.exp(m.A_log.float())  # (nheads,)
+
+        z_for_scan = (
+            rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+        )
+
+        # Direct kernel call — this is the only path that actually carries
+        # SSM state across calls at chunked-scan throughput.
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size,
+            D=m.D,
+            z=z_for_scan,
+            dt_bias=m.dt_bias,
+            dt_softplus=True,
+            initial_states=initial_ssm_state,
+            seq_idx=seq_idx,
+            return_final_states=True,
+        )
+
+        y = rearrange(y, "b l h p -> b l (h p)")
+
+        if rmsnorm:
+            y = m.norm(y, z)
+
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Mirror of forward() that threads SSM and conv state across blocks.
+        Returns (x_out, mem, final_ssm_state, last_conv_input).
+        """
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        if self.fusion_enabled and self.fusion_mode == "B":
+            a = self.fusion_attn(x_in)
+            gate = torch.sigmoid(self.fusion_pre_gate).to(dtype=x_in.dtype, device=x_in.device)
+            x_in = x_in + (FUSION_PRE_SCALE * gate) * a
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.fusion_enabled and self.fusion_mode == "A":
+            a = self.fusion_attn(x_out)
+            gate = torch.sigmoid(self.fusion_gate).to(dtype=x_out.dtype, device=x_out.device)
+            x_out = x_out + gate[None, None, :] * a
+
+        if run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+
+def apply_partial_rope(q: torch.Tensor, k: torch.Tensor, rotary_dim: int, base: float):
+    """
+    Apply partial RoPE to q/k tensors shaped (B, H, T, D).
+    Only the first rotary_dim dimensions are rotated; remaining dims are content-only.
+    """
+    if not ROPE_ENABLED or rotary_dim <= 0:
+        return q, k
+    head_dim = q.shape[-1]
+    rd = min(int(rotary_dim), head_dim)
+    rd = rd - (rd % 2)
+    if rd <= 0:
+        return q, k
+
+    device = q.device
+    T = q.shape[-2]
+    inv_freq = 1.0 / (base ** (torch.arange(0, rd, 2, device=device, dtype=torch.float32) / rd))
+    pos = torch.arange(T, device=device, dtype=torch.float32)
+    freqs = torch.outer(pos, inv_freq)  # (T, rd/2)
+    cos = freqs.cos()[None, None, :, :]  # (1,1,T,rd/2)
+    sin = freqs.sin()[None, None, :, :]
+
+    def rotate(x):
+        x_rope = x[..., :rd].float()
+        x_pass = x[..., rd:]
+        x_even = x_rope[..., 0::2]
+        x_odd = x_rope[..., 1::2]
+        x_rot = torch.stack((x_even * cos - x_odd * sin,
+                             x_even * sin + x_odd * cos), dim=-1).flatten(-2)
+        return torch.cat((x_rot.to(dtype=x.dtype), x_pass), dim=-1)
+
+    return rotate(q), rotate(k)
+
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal RoPE attention teacher with optional split RoPE/content Q gain."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, layer_idx=None):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+        self.rope_dim = int(_layer_value(layer_idx, ROPE_LAYER_DIM_MAP, ROPE_DIM))
+        self.rope_base = float(_layer_value(layer_idx, ROPE_LAYER_BASE_MAP, ROPE_BASE))
+        self.rope_dim = max(0, min(self.rope_dim, self.head_dim))
+        self.rope_dim -= self.rope_dim % 2
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Q gain: split RoPE positional subspace from content subspace in mode D.
+        # Do not leave an unused q_gain Parameter when split is enabled: DDP
+        # find_unused_parameters=False would otherwise break.
+        if Q_GAIN_SPLIT:
+            self.register_buffer("q_gain", torch.empty(0), persistent=False)
+            self.q_gain_rope = nn.Parameter(torch.full((n_heads,), Q_GAIN_ROPE_INIT))
+            self.q_gain_content = nn.Parameter(torch.full((n_heads,), Q_GAIN_CONTENT_INIT))
+        else:
+            self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+            self.q_gain_rope = None
+            self.q_gain_content = None
+
+        if FUSION_MODE == "C":
+            # Variant C: current-hidden-conditioned Q/K gain.
+            self.q_gain_delta = nn.Linear(d_model, n_heads, bias=False)
+            nn.init.zeros_(self.q_gain_delta.weight)
+        else:
+            self.q_gain_delta = None
+
+        self.ffn_norm = RMSNorm(d_model)
+        self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def _apply_q_gain(self, q, normed):
+        if Q_GAIN_SPLIT and self.q_gain_content is not None:
+            rd = min(self.rope_dim, q.shape[-1])
+            rope_gain = self.q_gain_rope.to(q.dtype)[None, :, None, None]
+            content_gain = self.q_gain_content.to(q.dtype)[None, :, None, None]
+            if self.q_gain_delta is not None:
+                delta = self.q_gain_delta(normed).permute(0, 2, 1).unsqueeze(-1)
+                delta = FUSION_QK_DELTA_SCALE * torch.tanh(delta).to(q.dtype)
+                rope_gain = rope_gain + delta
+                content_gain = content_gain + delta
+            if rd > 0:
+                q_rope = q[..., :rd] * rope_gain
+                q_content = q[..., rd:] * content_gain
+                return torch.cat((q_rope, q_content), dim=-1)
+            return q * content_gain
+
+        gain = self.q_gain.to(q.dtype)[None, :, None, None]
+        if self.q_gain_delta is not None:
+            delta = self.q_gain_delta(normed).permute(0, 2, 1).unsqueeze(-1)
+            gain = gain + FUSION_QK_DELTA_SCALE * torch.tanh(delta).to(q.dtype)
+        return q * gain
+
+    def forward(self, x, x0, mem, run_ffn=True, return_context=False):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + layer-specific partial RoPE + split learnable Q gain.
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q, k = apply_partial_rope(q, k, self.rope_dim, self.rope_base)
+        q = self._apply_q_gain(q, normed)
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_ctx = attn_out.transpose(1, 2).reshape(B, T, D)
+        projected = self.out_proj(attn_ctx)
+        x = x + self.attn_scale[None, None, :] * projected
+
+        if run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if return_context:
+            # Return unprojected attention context. It carries RoPE-relative
+            # structure without relying on out_proj, which is zero-init.
+            return x, mem, attn_ctx
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=LM_HEAD_BIAS)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+            if UNTIE_LM_HEAD:
+                # Start from the tied solution for stability, then let output
+                # classifier specialize separately from input embeddings.
+                if self.lm_head.weight.shape == self.tok_emb.weight.shape:
+                    self.lm_head.weight.copy_(self.tok_emb.weight)
+                else:
+                    self.lm_head.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+            else:
+                # Keep tied weights; optional bias remains separate.
+                self.lm_head.weight = self.tok_emb.weight
+                if self.lm_head.bias is not None:
+                    self.lm_head.bias.zero_()
+
+        # Neural copy/pointer head.
+        # It computes learned Q/K over hidden states, scatters attention mass
+        # onto source token IDs in the causal context, and adds a small gated
+        # positive bonus to those vocabulary logits.
+        if COPY_HEAD_ENABLED:
+            self.copy_q_norm = RMSNorm(D_MODEL)
+            self.copy_k_norm = RMSNorm(D_MODEL)
+            self.copy_q = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_k = nn.Linear(D_MODEL, COPY_DIM, bias=False)
+            self.copy_gate = nn.Linear(D_MODEL, 1, bias=True)
+            self.copy_scale = nn.Parameter(torch.tensor(float(COPY_SCALE_INIT)))
+            with torch.no_grad():
+                self.copy_gate.weight.zero_()
+                self.copy_gate.bias.fill_(COPY_GATE_BIAS_INIT)
+        else:
+            self.copy_q_norm = None
+            self.copy_k_norm = None
+            self.copy_q = None
+            self.copy_k = None
+            self.copy_gate = None
+            self.copy_scale = None
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        for i in range(N_UNIQUE_BLOCKS):
+            if i in attn_set:
+                blk = CausalAttentionBlock(D_MODEL, ATTN_N_HEADS, FFN_MULT, layer_idx=i)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, layer_idx=i)
+                blk._is_ssm = True
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.full((self.n_skip, D_MODEL), float(SKIP_INIT)))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+        # Depth-scaled init for mamba_ssm's internal Mamba2.out_proj.weight.
+        # mamba_ssm's standalone Mamba2 class uses kaiming_uniform with no
+        # depth correction; depth scaling (1/sqrt(2*n_layer)) is only applied
+        # by the official MambaConfig _init_weights hook, which we don't use.
+        # Without this, `out_proj` is the only residual-output projection
+        # initialized "loud" at start of training (FFN.down and attention's
+        # out_proj are both zero-initialized in our code). Confirmed via
+        # verify_init_and_fp32.py: mamba.out_proj.weight std=0.018 vs the
+        # depth-scaled target of 0.004 — about 4.5x too large.
+        n_layer_for_init = N_UNIQUE_BLOCKS * N_UNROLLS
+        depth_init_scale = 1.0 / math.sqrt(2 * n_layer_for_init)
+        with torch.no_grad():
+            n_scaled = 0
+            for pname, p in self.named_parameters():
+                if pname.endswith("mamba.out_proj.weight"):
+                    p.mul_(depth_init_scale)
+                    n_scaled += 1
+            log0(f"depth-scaled init: scaled {n_scaled} mamba.out_proj.weight tensors by {depth_init_scale:.4f} (1/sqrt(2*{n_layer_for_init}))")
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(
+                h_proj,
+                self.lm_head.weight.to(h_proj.dtype),
+                self.lm_head.bias.to(h_proj.dtype) if self.lm_head.bias is not None else None,
+            )
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(
+                flat_h,
+                self.lm_head.weight.to(flat_h.dtype),
+                self.lm_head.bias.to(flat_h.dtype) if self.lm_head.bias is not None else None,
+            )
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def add_copy_logits(self, logits, query_hidden, source_hidden, source_ids, query_start=None):
+        """
+        query_hidden: (B, U, D), positions being scored.
+        source_hidden: (B, T, D), full visible context hidden states.
+        source_ids: (B, T), token IDs corresponding to source_hidden.
+        query_start: index in source sequence of query_hidden[:, 0].
+        """
+        if not COPY_HEAD_ENABLED:
+            return logits
+
+        B, U, _ = query_hidden.shape
+        T = source_hidden.shape[1]
+        if query_start is None:
+            query_start = T - U
+
+        q = self.copy_q(self.copy_q_norm(query_hidden))
+        k = self.copy_k(self.copy_k_norm(source_hidden))
+        if COPY_USE_QK_NORM:
+            q = F.rms_norm(q, (COPY_DIM,))
+            k = F.rms_norm(k, (COPY_DIM,))
+
+        scores = torch.matmul(q, k.transpose(-1, -2)) / math.sqrt(max(COPY_DIM, 1))
+
+        q_pos = torch.arange(query_start, query_start + U, device=query_hidden.device)
+        k_pos = torch.arange(T, device=query_hidden.device)
+        future_mask = k_pos[None, :] > q_pos[:, None]
+        scores = scores.masked_fill(future_mask[None, :, :], float("-inf"))
+
+        attn = torch.softmax(scores.float(), dim=-1).to(query_hidden.dtype)  # (B, U, T)
+
+        copy_probs = torch.zeros(B, U, VOCAB_SIZE, device=logits.device, dtype=query_hidden.dtype)
+        copy_index = source_ids[:, None, :].expand(B, U, T)
+        copy_probs.scatter_add_(dim=2, index=copy_index, src=attn)
+
+        gate = torch.sigmoid(self.copy_gate(query_hidden)).reshape(B * U, 1).to(logits.dtype)
+        scale = F.softplus(self.copy_scale).to(dtype=logits.dtype, device=logits.device)
+        copy_bonus = copy_probs.reshape(B * U, VOCAB_SIZE).to(logits.dtype)
+        return logits + gate * scale * copy_bonus
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        # Auto-compute seq_idx from the input ids if not provided. This is
+        # what tells Mamba2's chunk-scan kernel to zero state transitions at
+        # document boundaries (chunk-aligned). Disabled when DOC_BOUNDARY_TOKEN
+        # is negative or SEQ_IDX_ENABLED is off.
+        if seq_idx is None and SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_enc_eff = len(enc_indices)
+        n_dec_eff = len(dec_indices)
+        n_skip_eff = min(n_enc_eff, n_dec_eff, self.n_skip)
+
+        # State carryover: only pass inference_params to SSM blocks (attention
+        # blocks have no recurrent state to carry; they see only the current
+        # input window). When loop is active and inference_params is set, we
+        # would update the same block's state multiple times in one pass,
+        # which double-counts: explicitly forbid that combination.
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params is incompatible with depth recurrence "
+                "(would update Mamba state multiple times per forward). "
+                "Disable LOOP_START/LOOP_END for state-carryover eval."
+            )
+
+        skips = []
+        rope_ctx = None  # Mode D: rolling RoPE-attention teacher context
+        # Encoder. Inline dispatch (no closure) so torch.compile compiles
+        # each block once with stable arg shapes rather than re-specializing
+        # a wrapper per block id.
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx,
+                               ctx=rope_ctx)
+            else:
+                if CONTEXT_BRIDGE_ENABLED:
+                    x, mem, attn_ctx = block(x, x0, mem, run_ffn=run_ffn, return_context=True)
+                    rope_ctx = attn_ctx if rope_ctx is None else (CONTEXT_BRIDGE_CTX_DECAY * rope_ctx + (1.0 - CONTEXT_BRIDGE_CTX_DECAY) * attn_ctx)
+                else:
+                    x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx,
+                               ctx=rope_ctx)
+            else:
+                if CONTEXT_BRIDGE_ENABLED:
+                    x, mem, attn_ctx = block(x, x0, mem, run_ffn=run_ffn, return_context=True)
+                    rope_ctx = attn_ctx if rope_ctx is None else (CONTEXT_BRIDGE_CTX_DECAY * rope_ctx + (1.0 - CONTEXT_BRIDGE_CTX_DECAY) * attn_ctx)
+                else:
+                    x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads
+        Mamba2 SSM state and conv1d state across calls via direct kernel
+        access (mamba_chunk_scan_combined). Attention blocks see only the
+        current block (no recurrent state to carry).
+
+        ids: (B, L)
+        layer_states: dict {block_idx: (ssm_state, conv_input)} or None.
+            On first call pass None; the returned dict is fed back in for
+            the next block.
+        seq_idx_base: int — counter offset to keep doc ids monotonic across
+            blocks. The new last seq_idx value is returned so the caller
+            can pass it as seq_idx_base for the next block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — "
+                "direct-kernel state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with carryover not implemented
+
+        # Build seq_idx for this block. Monotonic across blocks via
+        # seq_idx_base — when state is being carried, doc ids must keep
+        # incrementing so a doc boundary at block boundary correctly
+        # zeroes the carried state's contribution.
+        #
+        # NOTE: empirically this offset-by-seq_idx_base behavior is what
+        # works. We tried "reset seq_idx to 0 at every block" thinking the
+        # kernel's internal seq_idx=0 start was an assertion about carried
+        # state — that interpretation produced a -0.04 BPB regression. The
+        # original behavior, which silently zeroes the carried state on
+        # block boundaries via seq_idx mismatch, is actually less harmful
+        # than letting stale state from millions of tokens ago flow into
+        # the next block's first chunk. The model never trained for non-
+        # zero initial_states, so OOD carryover is worse than fresh start.
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        # Carryover is incompatible with depth recurrence (would update the
+        # same block's state multiple times per forward).
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError(
+                "forward_with_state is incompatible with depth recurrence."
+            )
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            if FFN_FREQ_MODE == "unroll":
+                run_ffn = True
+            else:
+                run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = (layer_pos % max(FFN_EVERY, 1)) == 0
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if block._is_ssm:
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    logits = core.output_logits_from_hidden(hidden)
+    logits = core.add_copy_logits(logits, hidden, hidden, ids, query_start=0)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Original one-bucket Muon optimizer for matrix-shaped parameters.
+    Kept for ablations via TASKMUON_ENABLED=0.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def _taskmuon_row_balance(G: torch.Tensor, eps: float = 1e-8, max_gain: float = 10.0) -> torch.Tensor:
+    """MuonEq-lite row balancing before the NS iteration."""
+    Gf = G.float()
+    global_rms = Gf.pow(2).mean().sqrt().clamp_min(eps)
+    row_rms = Gf.pow(2).mean(dim=1, keepdim=True).sqrt().clamp_min(eps)
+    gain = (global_rms / row_rms).clamp(max=max_gain)
+    return (Gf * gain).to(dtype=G.dtype)
+
+
+def _taskmuon_shape_scale(rows: int, cols: int, cap: float) -> float:
+    scale = math.sqrt(max(1.0, float(rows) / max(float(cols), 1.0)))
+    if cap and cap > 0:
+        scale = min(scale, float(cap))
+    return float(scale)
+
+
+class TaskMuon(torch.optim.Optimizer):
+    """
+    Component-aware Muon for the Parameter Golf SSM/attention hybrid.
+
+    What changes versus generic Muon:
+      - attention qkv is optimized as q/k/v row blocks, not one fused matrix
+      - Mamba in_proj is split into feature rows (z/x), dynamics rows (B/C), and dt rows
+      - dt rows use AdamW-style updates instead of NS/Muon
+      - Mamba projections use lower LR/WD and capped rectangular scaling
+      - optional MuonEq-lite row balancing before Newton-Schulz
+    """
+    def __init__(self, param_groups, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True):
+        defaults = dict(lr=lr, base_lr=lr, momentum=momentum,
+                        backend_steps=backend_steps, nesterov=nesterov,
+                        weight_decay=WEIGHT_DECAY)
+        super().__init__(param_groups, defaults)
+
+    @torch.no_grad()
+    def _muon_update_2d(self, upd_2d: torch.Tensor, *, backend_steps: int,
+                        row_balance: bool, shape_cap: float,
+                        trust_clip: bool) -> torch.Tensor:
+        raw = upd_2d
+        work = _taskmuon_row_balance(raw) if row_balance else raw
+        upd_orth = zeropower_via_newtonschulz5(work, steps=backend_steps)
+        upd_orth = upd_orth * _taskmuon_shape_scale(upd_orth.size(0), upd_orth.size(1), shape_cap)
+        if trust_clip:
+            raw_rms = raw.float().pow(2).mean().sqrt().clamp_min(1e-12)
+            orth_rms = upd_orth.float().pow(2).mean().sqrt().clamp_min(1e-12)
+            max_rms = torch.clamp(raw_rms * TASKMUON_TRUST_MULT, min=TASKMUON_TRUST_FLOOR)
+            if bool((orth_rms > max_rms).item()):
+                upd_orth = upd_orth * (max_rms / orth_rms).to(upd_orth.dtype)
+        return upd_orth
+
+    @torch.no_grad()
+    def _step_adamw_rows(self, p: torch.Tensor, g: torch.Tensor, state: dict,
+                         sl: slice, *, lr: float, wd: float, seg_key: str):
+        if wd > 0:
+            p[sl].mul_(1.0 - lr * wd)
+        g_seg = g[sl].float()
+        m_key = f"adam_m_{seg_key}"
+        v_key = f"adam_v_{seg_key}"
+        step_key = f"adam_step_{seg_key}"
+        if m_key not in state:
+            state[m_key] = torch.zeros_like(g_seg)
+            state[v_key] = torch.zeros_like(g_seg)
+            state[step_key] = 0
+        exp_avg = state[m_key]
+        exp_avg_sq = state[v_key]
+        state[step_key] += 1
+        step_i = int(state[step_key])
+        exp_avg.mul_(BETA1).add_(g_seg, alpha=1.0 - BETA1)
+        exp_avg_sq.mul_(BETA2).addcmul_(g_seg, g_seg, value=1.0 - BETA2)
+        bc1 = 1.0 - (BETA1 ** step_i)
+        bc2 = 1.0 - (BETA2 ** step_i)
+        denom = (exp_avg_sq.sqrt() / math.sqrt(max(bc2, 1e-12))).add_(ADAM_EPS)
+        update = (exp_avg / denom).to(dtype=p.dtype)
+        p[sl].add_(update, alpha=-(lr / max(bc1, 1e-12)))
+
+    @torch.no_grad()
+    def _step_muon_rows(self, p: torch.Tensor, g: torch.Tensor, state: dict,
+                        sl: slice, *, lr: float, wd: float, momentum: float,
+                        backend_steps: int, nesterov: bool, shape_cap: float,
+                        row_balance: bool, trust_clip: bool, seg_key: str):
+        if wd > 0:
+            p[sl].mul_(1.0 - lr * wd)
+        if "momentum_buffer" not in state:
+            state["momentum_buffer"] = torch.zeros_like(g)
+        buf = state["momentum_buffer"]
+        g_seg = g[sl]
+        buf_seg = buf[sl]
+        buf_seg.mul_(momentum).add_(g_seg)
+        upd = g_seg.add(buf_seg, alpha=momentum) if nesterov else buf_seg
+        orig_shape = upd.shape
+        upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+        if upd_2d.ndim >= 2:
+            upd_orth = self._muon_update_2d(
+                upd_2d,
+                backend_steps=backend_steps,
+                row_balance=row_balance,
+                shape_cap=shape_cap,
+                trust_clip=trust_clip,
+            )
+            upd = upd_orth.reshape(orig_shape)
+        p[sl].add_(upd.to(dtype=p.dtype), alpha=-lr)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr_base = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            default_wd = group.get("weight_decay", WEIGHT_DECAY)
+            default_lr_mult = group.get("lr_mult", 1.0)
+            default_shape_cap = group.get("shape_cap", 0.0)
+            default_row_balance = group.get("row_balance", TASKMUON_ROW_BALANCE)
+            default_trust_clip = group.get("trust_clip", TASKMUON_TRUST_CLIP)
+            segments = group.get("segments", None)
+
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                g = p.grad
+                state = self.state[p]
+                if not segments:
+                    sl = slice(0, p.shape[0])
+                    self._step_muon_rows(
+                        p, g, state, sl,
+                        lr=lr_base * default_lr_mult,
+                        wd=default_wd,
+                        momentum=momentum,
+                        backend_steps=backend_steps,
+                        nesterov=nesterov,
+                        shape_cap=default_shape_cap,
+                        row_balance=default_row_balance,
+                        trust_clip=default_trust_clip,
+                        seg_key="full",
+                    )
+                    continue
+
+                for si, seg in enumerate(segments):
+                    st, en = int(seg["start"]), int(seg["end"])
+                    if en <= st:
+                        continue
+                    sl = slice(st, en)
+                    lr = lr_base * float(seg.get("lr_mult", default_lr_mult))
+                    wd = float(seg.get("weight_decay", default_wd))
+                    seg_key = f"{si}_{seg.get('name', 'seg')}"
+                    if seg.get("optimizer", "muon") == "adamw":
+                        self._step_adamw_rows(p, g, state, sl, lr=lr, wd=wd, seg_key=seg_key)
+                    else:
+                        self._step_muon_rows(
+                            p, g, state, sl,
+                            lr=lr,
+                            wd=wd,
+                            momentum=momentum,
+                            backend_steps=int(seg.get("backend_steps", backend_steps)),
+                            nesterov=nesterov,
+                            shape_cap=float(seg.get("shape_cap", default_shape_cap)),
+                            row_balance=bool(seg.get("row_balance", default_row_balance)),
+                            trust_clip=bool(seg.get("trust_clip", default_trust_clip)),
+                            seg_key=seg_key,
+                        )
+        return loss
+
+
+def _seg(name, start, end, lr_mult, weight_decay, shape_cap, row_balance=True,
+         optimizer="muon", trust_clip=None, backend_steps=None):
+    out = dict(
+        name=name,
+        start=int(start),
+        end=int(end),
+        lr_mult=float(lr_mult),
+        weight_decay=float(weight_decay),
+        shape_cap=float(shape_cap),
+        row_balance=bool(row_balance),
+        optimizer=optimizer,
+    )
+    if trust_clip is not None:
+        out["trust_clip"] = bool(trust_clip)
+    if backend_steps is not None:
+        out["backend_steps"] = int(backend_steps)
+    return out
+
+
+def _qkv_rope_segments(name: str, p: torch.nn.Parameter, modules: dict):
+    """Split fused attention qkv into Q/K RoPE rows, Q/K content rows, and V.
+
+    Rows are laid out q(0:D), k(D:2D), v(2D:3D). Within q/k, each head is a
+    contiguous block of head_dim rows, and the first rope_dim rows per head are
+    the RoPE positional subspace.
+    """
+    parent_name = name.rsplit(".qkv.weight", 1)[0]
+    m = modules.get(parent_name, None)
+    if m is None:
+        return None
+    try:
+        rows = int(p.shape[0])
+        if rows % 3 != 0:
+            return None
+        d = rows // 3
+        n_heads = int(getattr(m, "n_heads"))
+        head_dim = int(getattr(m, "head_dim"))
+        rope_dim = int(getattr(m, "rope_dim", ROPE_DIM))
+        rope_dim = max(0, min(rope_dim, head_dim))
+        rope_dim -= rope_dim % 2
+        if d != n_heads * head_dim:
+            return None
+        segs = []
+        for block_name, block_off in (("q", 0), ("k", d)):
+            for h in range(n_heads):
+                h0 = block_off + h * head_dim
+                if rope_dim > 0:
+                    segs.append(_seg(
+                        f"{block_name}{h}_rope", h0, h0 + rope_dim,
+                        TASKMUON_QK_ROPE_LR_MULT, TASKMUON_QK_ROPE_WD,
+                        TASKMUON_QK_ROPE_SHAPE_CAP,
+                        row_balance=False,
+                        trust_clip=True,
+                    ))
+                if rope_dim < head_dim:
+                    segs.append(_seg(
+                        f"{block_name}{h}_content", h0 + rope_dim, h0 + head_dim,
+                        TASKMUON_QK_CONTENT_LR_MULT, TASKMUON_QK_CONTENT_WD,
+                        TASKMUON_QKV_SHAPE_CAP,
+                        row_balance=TASKMUON_ROW_BALANCE,
+                        trust_clip=TASKMUON_TRUST_CLIP,
+                    ))
+        segs.append(_seg(
+            "v", 2 * d, 3 * d,
+            TASKMUON_V_LR_MULT, TASKMUON_V_WD,
+            TASKMUON_QKV_SHAPE_CAP,
+            row_balance=TASKMUON_ROW_BALANCE,
+        ))
+        return segs
+    except Exception:
+        return None
+
+
+def _ffn_gate_up_segments(name: str, p: torch.nn.Parameter, modules: dict):
+    """Split SwiGLU gate_up into gate and up halves for Muon geometry."""
+    parent_name = name.rsplit(".gate_up.weight", 1)[0]
+    m = modules.get(parent_name, None)
+    if m is None:
+        return None
+    rows = int(p.shape[0])
+    try:
+        if bool(getattr(m, "is_swiglu", False)) and rows % 2 == 0:
+            half = rows // 2
+            return [
+                _seg("ffn_gate", 0, half, TASKMUON_FFN_GATE_LR_MULT, TASKMUON_FFN_WD,
+                     TASKMUON_FFN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE),
+                _seg("ffn_up", half, rows, TASKMUON_FFN_UP_LR_MULT, TASKMUON_FFN_WD,
+                     TASKMUON_FFN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE),
+            ]
+        return [
+            _seg("ffn_up", 0, rows, TASKMUON_FFN_UP_LR_MULT, TASKMUON_FFN_WD,
+                 TASKMUON_FFN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE)
+        ]
+    except Exception:
+        return None
+
+
+def _mamba_in_proj_segments(name: str, p: torch.nn.Parameter, modules: dict):
+    parent_name = name.rsplit(".in_proj.weight", 1)[0]
+    m = modules.get(parent_name, None)
+    if m is None:
+        return None
+    try:
+        rows = int(p.shape[0])
+        d_inner = int(getattr(m, "d_inner", getattr(m, "d_ssm", 0)))
+        nheads = int(getattr(m, "nheads"))
+        ngroups = int(getattr(m, "ngroups", 1))
+        d_state = int(getattr(m, "d_state"))
+        conv_channels = d_inner + 2 * ngroups * d_state
+        expected = 2 * d_inner + 2 * ngroups * d_state + nheads
+        d_mlp = (rows - expected) // 2
+        if d_inner <= 0 or d_mlp < 0 or (rows - expected) % 2 != 0:
+            return None
+        segs = []
+        offset = 0
+        if d_mlp > 0:
+            # Optional Mamba2 MLP branch rows. Treat as feature rows, not dynamics.
+            segs.append(_seg("mamba_mlp", offset, offset + 2 * d_mlp,
+                             TASKMUON_MAMBA_ZX_LR_MULT, TASKMUON_MAMBA_ZX_WD,
+                             TASKMUON_MAMBA_IN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE))
+            offset += 2 * d_mlp
+        # z rows
+        segs.append(_seg("mamba_z", offset, offset + d_inner,
+                         TASKMUON_MAMBA_ZX_LR_MULT, TASKMUON_MAMBA_ZX_WD,
+                         TASKMUON_MAMBA_IN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE))
+        offset += d_inner
+        # x rows inside xBC
+        segs.append(_seg("mamba_x", offset, offset + d_inner,
+                         TASKMUON_MAMBA_ZX_LR_MULT, TASKMUON_MAMBA_ZX_WD,
+                         TASKMUON_MAMBA_IN_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE))
+        offset += d_inner
+        bc = ngroups * d_state
+        segs.append(_seg("mamba_B", offset, offset + bc,
+                         TASKMUON_MAMBA_BC_LR_MULT, TASKMUON_MAMBA_BC_WD,
+                         TASKMUON_MAMBA_BC_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE,
+                         trust_clip=TASKMUON_TRUST_CLIP))
+        offset += bc
+        segs.append(_seg("mamba_C", offset, offset + bc,
+                         TASKMUON_MAMBA_BC_LR_MULT, TASKMUON_MAMBA_BC_WD,
+                         TASKMUON_MAMBA_BC_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE,
+                         trust_clip=TASKMUON_TRUST_CLIP))
+        offset += bc
+        segs.append(_seg("mamba_dt", offset, offset + nheads,
+                         TASKMUON_MAMBA_DT_LR_MULT, TASKMUON_MAMBA_DT_WD,
+                         1.0, row_balance=False, optimizer="adamw"))
+        offset += nheads
+        if offset != rows:
+            return None
+        return segs
+    except Exception:
+        return None
+
+
+def _taskmuon_group_for_param(name: str, p: torch.nn.Parameter, modules: dict):
+    """Return a per-parameter TaskMuon group dict, or None for non-Muon params."""
+    if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) is False:
+        return None
+    if any(c in name for c in CTRL_PATTERNS):
+        return None
+
+    base = {
+        "params": [p],
+        "name": name,
+        "lr": MATRIX_LR,
+        "base_lr": MATRIX_LR,
+        "momentum": MUON_MOMENTUM,
+        "backend_steps": MUON_BACKEND_STEPS,
+        "nesterov": MUON_NESTEROV,
+    }
+
+    if name.endswith(".qkv.weight") and p.shape[0] % 3 == 0:
+        rope_segs = _qkv_rope_segments(name, p, modules) if Q_GAIN_SPLIT else None
+        if rope_segs is not None:
+            base.update(
+                role="attn_qkv_rope_split",
+                weight_decay=TASKMUON_ATTN_WD,
+                lr_mult=TASKMUON_QKV_LR_MULT,
+                shape_cap=TASKMUON_QKV_SHAPE_CAP,
+                row_balance=TASKMUON_ROW_BALANCE,
+                segments=rope_segs,
+            )
+        else:
+            n = int(p.shape[0]) // 3
+            base.update(
+                role="attn_qkv_split",
+                weight_decay=TASKMUON_ATTN_WD,
+                lr_mult=TASKMUON_QKV_LR_MULT,
+                shape_cap=TASKMUON_QKV_SHAPE_CAP,
+                row_balance=TASKMUON_ROW_BALANCE,
+                segments=[
+                    _seg("q", 0, n, TASKMUON_QKV_LR_MULT, TASKMUON_ATTN_WD, TASKMUON_QKV_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE),
+                    _seg("k", n, 2 * n, TASKMUON_QKV_LR_MULT, TASKMUON_ATTN_WD, TASKMUON_QKV_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE),
+                    _seg("v", 2 * n, 3 * n, TASKMUON_QKV_LR_MULT, TASKMUON_ATTN_WD, TASKMUON_QKV_SHAPE_CAP, row_balance=TASKMUON_ROW_BALANCE),
+                ],
+            )
+        return base
+
+    if name.endswith(".mamba.in_proj.weight"):
+        segs = _mamba_in_proj_segments(name, p, modules)
+        if segs is not None:
+            base.update(
+                role="mamba_in_proj_split",
+                weight_decay=TASKMUON_MAMBA_ZX_WD,
+                lr_mult=TASKMUON_MAMBA_ZX_LR_MULT,
+                shape_cap=TASKMUON_MAMBA_IN_SHAPE_CAP,
+                row_balance=TASKMUON_ROW_BALANCE,
+                segments=segs,
+            )
+            return base
+
+    if name.endswith(".mamba.out_proj.weight"):
+        base.update(
+            role="mamba_out_proj",
+            weight_decay=TASKMUON_MAMBA_OUT_WD,
+            lr_mult=TASKMUON_MAMBA_OUT_LR_MULT,
+            shape_cap=TASKMUON_MAMBA_OUT_SHAPE_CAP,
+            row_balance=False,
+        )
+        return base
+
+    if name.endswith(".out_proj.weight"):
+        base.update(
+            role="attn_out_proj",
+            weight_decay=TASKMUON_ATTN_WD,
+            lr_mult=TASKMUON_ATTN_OUT_LR_MULT,
+            shape_cap=1.0,
+            row_balance=False,
+        )
+        return base
+
+    if name.endswith(".gate_up.weight"):
+        segs = _ffn_gate_up_segments(name, p, modules)
+        base.update(
+            role="ffn_gate_up_split" if segs is not None else "ffn",
+            weight_decay=TASKMUON_FFN_WD,
+            lr_mult=TASKMUON_FFN_LR_MULT,
+            shape_cap=TASKMUON_FFN_SHAPE_CAP,
+            row_balance=TASKMUON_ROW_BALANCE,
+            segments=segs,
+        )
+        return base
+
+    if name.endswith(".down.weight"):
+        base.update(
+            role="ffn_down",
+            weight_decay=TASKMUON_FFN_DOWN_WD,
+            lr_mult=TASKMUON_FFN_DOWN_LR_MULT,
+            shape_cap=TASKMUON_FFN_SHAPE_CAP,
+            row_balance=TASKMUON_ROW_BALANCE,
+        )
+        return base
+
+    if ".context_bridge." in name and name.endswith(".weight"):
+        base.update(
+            role="context_bridge",
+            weight_decay=TASKMUON_BRIDGE_WD,
+            lr_mult=TASKMUON_BRIDGE_LR_MULT,
+            shape_cap=1.0,
+            row_balance=False,
+        )
+        return base
+
+    # Keep all other eligible matrices under TaskMuon with generic settings so
+    # embeddings projections, fusion projections, etc. do not silently move to AdamW.
+    base.update(
+        role="generic",
+        weight_decay=TASKMUON_GENERIC_WD,
+        lr_mult=TASKMUON_GENERIC_LR_MULT,
+        shape_cap=0.0,
+        row_balance=False,
+    )
+    return base
+
+
+def build_optimizers(model):
+    scalar_wd_params, no_wd_params, embed_params = [], [], []
+    mat_params = []
+    task_groups = []
+    role_counts = {}
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    modules = dict(model.named_modules())
+    _seen_data_ptrs = set()  # handle tied params
+
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+            continue
+
+        no_wd = (
+            getattr(p, "_no_weight_decay", False)
+            or name.endswith(".bias")
+            or p.ndim < 2
+        )
+        if no_wd:
+            no_wd_params.append(p)
+            continue
+
+        is_control = any(c in name for c in CTRL_PATTERNS)
+        if p.ndim == 2 and not is_control:
+            muon_eligible_2d += 1
+        elif p.ndim > 2 and not is_control:
+            muon_eligible_nd += 1
+
+        if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+            if TASKMUON_ENABLED:
+                g = _taskmuon_group_for_param(name, p, modules)
+                if g is not None:
+                    task_groups.append(g)
+                    mat_params.append(p)
+                    role_counts[g.get("role", "unknown")] = role_counts.get(g.get("role", "unknown"), 0) + 1
+                else:
+                    scalar_wd_params.append(p)
+            else:
+                mat_params.append(p)
+        else:
+            scalar_wd_params.append(p)
+
+    if TASKMUON_ENABLED:
+        optimizer_muon = TaskMuon(
+            task_groups,
+            lr=MATRIX_LR,
+            momentum=MUON_MOMENTUM,
+            backend_steps=MUON_BACKEND_STEPS,
+            nesterov=MUON_NESTEROV,
+        ) if len(task_groups) > 0 else None
+    else:
+        optimizer_muon = Muon(
+            mat_params,
+            lr=MATRIX_LR,
+            momentum=MUON_MOMENTUM,
+            backend_steps=MUON_BACKEND_STEPS,
+            nesterov=MUON_NESTEROV,
+            weight_decay=WEIGHT_DECAY,
+        ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_wd_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": no_wd_params, "lr": SCALAR_LR, "weight_decay": 0.0, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    opt_name = "TaskMuon" if TASKMUON_ENABLED else "Muon"
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} ({opt_name}), "
+        f"scalar_wd={len(scalar_wd_params)} (AdamW wd={WEIGHT_DECAY}), "
+        f"no_wd={len(no_wd_params)} (AdamW wd=0), "
+        f"embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: taskmuon={int(TASKMUON_ENABLED)} muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    if TASKMUON_ENABLED:
+        role_summary = ", ".join(f"{k}={v}" for k, v in sorted(role_counts.items()))
+        log0(f"TaskMuon roles: {role_summary}")
+        log0(
+            "TaskMuon knobs: "
+            f"qkv_lr={TASKMUON_QKV_LR_MULT}, attn_out_lr={TASKMUON_ATTN_OUT_LR_MULT}, "
+            f"mamba_zx_lr={TASKMUON_MAMBA_ZX_LR_MULT}, mamba_bc_lr={TASKMUON_MAMBA_BC_LR_MULT}, "
+            f"mamba_dt_lr={TASKMUON_MAMBA_DT_LR_MULT}, mamba_out_lr={TASKMUON_MAMBA_OUT_LR_MULT}, "
+            f"qk_rope_lr={TASKMUON_QK_ROPE_LR_MULT}, qk_content_lr={TASKMUON_QK_CONTENT_LR_MULT}, "
+            f"v_lr={TASKMUON_V_LR_MULT}, ffn_gate/up/down_lr="
+            f"{TASKMUON_FFN_GATE_LR_MULT}/{TASKMUON_FFN_UP_LR_MULT}/{TASKMUON_FFN_DOWN_LR_MULT}, "
+            f"bridge_lr={TASKMUON_BRIDGE_LR_MULT}"
+        )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding with no dropped remainder items."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+def _sliding_score_records(total_tokens: int, seq_len: int, stride: int,
+                           score_start: int = 0, score_end=None):
+    """Yield full-length causal windows that score each target position once.
+
+    A record is (window_start, tail_start, tail_len). The input window is
+    val_tokens[window_start : window_start + seq_len], and only
+    [tail_start : tail_start + tail_len] positions in that window are scored.
+
+    The first prefix is scored from a normal full-length window starting at 0,
+    so Mamba/attention kernels still see the regular SEQ_LEN shape.
+    """
+    total_tokens = int(total_tokens)
+    seq_len = int(seq_len)
+    stride = int(stride)
+    if score_end is None:
+        score_end = total_tokens
+    score_start = max(0, int(score_start))
+    score_end = min(total_tokens, int(score_end))
+    if score_end <= score_start:
+        return
+
+    cur = score_start
+    if cur < min(score_end, seq_len):
+        prefix_end = min(score_end, seq_len)
+        yield 0, cur, prefix_end - cur
+        cur = prefix_end
+
+    while cur < score_end:
+        se = min(cur + stride, score_end)
+        window_start = max(0, se - seq_len)
+        if window_start + seq_len > total_tokens:
+            window_start = max(0, total_tokens - seq_len)
+        tail_start = cur - window_start
+        tail_len = se - cur
+        if tail_len > 0:
+            yield window_start, tail_start, tail_len
+        cur = se
+
+
+def _iter_sliding_score_batches(val_tokens, record_indices, seq_len: int, batch_windows: int):
+    """Batch sliding-score records by compatible tail slice."""
+    pending_x, pending_y = [], []
+    pending_key = None
+
+    def flush():
+        nonlocal pending_x, pending_y, pending_key
+        if not pending_x:
+            return None
+        xn = np.stack(pending_x)
+        yn = np.stack(pending_y)
+        tail_start, tail_len = pending_key
+        pending_x, pending_y, pending_key = [], [], None
+        return xn, yn, tail_start, tail_len
+
+    for window_start, tail_start, tail_len in record_indices:
+        key = (int(tail_start), int(tail_len))
+        if pending_key is not None and (key != pending_key or len(pending_x) >= batch_windows):
+            item = flush()
+            if item is not None:
+                yield item
+        pending_key = key
+        pending_x.append(val_tokens[window_start : window_start + seq_len])
+        pending_y.append(val_tokens[window_start + 1 : window_start + seq_len + 1])
+
+    item = flush()
+    if item is not None:
+        yield item
+
+
+def lm_loss_tail(core, ids, targets, tail_start: int, tail_len: int):
+    """LM loss restricted to already-scored tail tokens for legal TTT."""
+    hidden = core(ids, state=None, return_state=False)
+    tail_start = int(tail_start)
+    tail_len = int(tail_len)
+    hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+    y_tail = targets[:, tail_start : tail_start + tail_len]
+    logits = core.output_logits_from_hidden(hidden_tail)
+    logits = core.add_copy_logits(logits, hidden_tail, hidden, ids, query_start=tail_start)
+    return F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="mean")
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Exact sliding-window evaluation.
+
+    Scores every target token exactly once. The first prefix is scored from a
+    full SEQ_LEN window starting at 0; subsequent tokens are scored in `stride`
+    tails from windows ending at the scored segment. Remainder records are
+    sharded exactly across ranks.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    total_tokens = val_tokens.size - 1
+
+    records = list(_sliding_score_records(total_tokens, seq_len, stride))
+    rec_start, rec_end = _rank_bounds(len(records))
+    local_records = records[rec_start:rec_end]
+
+    batch_windows = max(1, 131072 // seq_len)
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = max(1, (len(local_records) + batch_windows - 1) // batch_windows)
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+            val_tokens, local_records, seq_len, batch_windows):
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+            hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+            y_tail = y[:, tail_start : tail_start + tail_len]
+            logits = core.output_logits_from_hidden(hidden_tail)
+            logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+            loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+        cnt = float(y_tail.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+        t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * max(0, total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {len(local_records)} records/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib,
+                       block_len=None, warmup_tokens=None):
+    """
+    SSM-native state-carryover eval.
+
+    Process the val set as non-overlapping `block_len`-token blocks. The
+    Mamba2 SSM hidden state and conv1d state for every layer are threaded
+    across blocks via the direct kernel call (mamba_chunk_scan_combined
+    with initial_states / return_final_states), so a token at position p
+    sees ALL p preceding tokens via the recurrence (not just the SEQ_LEN
+    window an attention model would have). Attention layers (which can't
+    carry state) see only the current block, matching training context.
+
+    Each rank gets a contiguous slice of the val stream so state passing
+    stays causal within rank. The first `warmup_tokens` of each rank's
+    slice are processed to warm the recurrent state but their losses are
+    not scored (otherwise positions with near-empty state would be unfairly
+    counted).
+
+    If CARRYOVER_DIRECT_KERNEL is False, falls back to the inference_params
+    path (broken in current mamba_ssm builds — kept for diagnosis only).
+
+    Returns (val_loss, val_bpb).
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    warmup_blocks = warmup_tokens // block_len  # round down to block boundary
+
+    use_direct = CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None
+    if not use_direct:
+        if not _HAS_CHUNK_SCAN:
+            log0("[carryover_eval] mamba_chunk_scan_combined unavailable")
+        if rearrange is None:
+            log0("[carryover_eval] einops not importable")
+        if InferenceParams is None:
+            raise RuntimeError("no carryover path available (no chunk_scan, no InferenceParams)")
+        log0("[carryover_eval] falling back to InferenceParams path (likely broken)")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+
+    if getattr(core, "loop_enabled_external", False):
+        log0("[carryover_eval] depth recurrence active — temporarily disabled for this eval")
+        prev_loop = True
+        core.loop_enabled_external = False
+    else:
+        prev_loop = False
+
+    total_tokens = val_tokens.size - 1  # x/y consume span-1 tokens
+
+    # Stateful-overlap config (PR #1644 / reviewer guidance):
+    #   - block has length `block_len` total tokens
+    #   - first `overlap` tokens are "context" — Mamba state has carried
+    #     them via initial_states; attention re-sees them inside the block;
+    #     they are NOT scored (already counted as score_region in prior block)
+    #   - remaining `score_region = block_len - overlap` tokens are scored
+    #   - block stride = score_region (not block_len), so consecutive blocks
+    #     overlap by exactly `overlap` tokens
+    #
+    # When overlap=0, this collapses to non-overlap (legacy) behavior.
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), block_len - 1))
+    score_region = block_len - overlap
+
+    # Exact block sharding. Global block index g starts at g * score_region.
+    # Only full block_len windows are used here to keep the direct Mamba kernel
+    # shape stable. No block index is dropped across ranks.
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - block_len) // score_region + 1)
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    n_scored_blocks = max(0, n_blocks - warmup_blocks)
+
+    # State containers
+    if use_direct:
+        layer_states = None  # filled on first block by forward_with_state
+        seq_idx_base = 0     # monotonic doc-id counter across blocks
+    else:
+        inference_params = InferenceParams(max_seqlen=block_len, max_batch_size=1)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    path_label = "direct_kernel" if use_direct else "inference_params"
+    log0(
+        f"  carryover_eval: path={path_label}, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        # Block starts at global_b_idx * score_region (so consecutive blocks
+        # overlap by `overlap` tokens). We need block_len + 1 tokens total:
+        # block_len input tokens plus the next-token target.
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + block_len + 1]
+        if chunk.size < block_len + 1:
+            break
+        xn = chunk[:-1].reshape(1, block_len)
+        yn = chunk[1:].reshape(1, block_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            if use_direct:
+                hidden, layer_states, seq_idx_base = core.forward_with_state(
+                    x, layer_states, seq_idx_base=seq_idx_base
+                )
+            else:
+                hidden = core(x, inference_params=inference_params)
+            logits = core.output_logits_from_hidden(hidden)
+            logits = core.add_copy_logits(logits, hidden, hidden, x, query_start=0)
+
+            # Score only new positions. The first GLOBAL block must score from
+            # position 0 so official cold-start tokens are counted; every later
+            # block skips the overlap because those tokens were already scored.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            score_logits = logits[:, score_start:, :]
+            score_y = y[:, score_start:]
+            loss = F.cross_entropy(
+                score_logits.float().reshape(-1, score_logits.shape[-1]),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            # Bytes accounting also restricted to the positions actually scored.
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / n_blocks
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(
+        f"  carryover_eval: rank={RANK} scored={n_scored_blocks} blocks "
+        f"(warmup={warmup_blocks}), block_len={block_len}, path={path_label}, {elapsed:.1f}s"
+    )
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# LoRA infrastructure for legal score-first TTT
+# -----------------------------------------------------------------------------
+class LoRALinear(nn.Module):
+    """
+    LoRA adapter wrapping an existing nn.Linear without changing its semantics
+    at init. Output is `linear(x) + alpha/r * (x @ A^T @ B^T)`. At init B=0
+    so the wrapped output exactly matches the base linear.
+
+    The base linear's weight is held *frozen* via a registered buffer ref;
+    only the LoRA A, B matrices have requires_grad=True (per LORA_FROZEN_BASE
+    convention).
+    """
+    def __init__(self, base_linear: nn.Linear, rank: int, alpha: float):
+        super().__init__()
+        if not isinstance(base_linear, nn.Linear):
+            raise TypeError(f"LoRALinear expects nn.Linear, got {type(base_linear)}")
+        self.base = base_linear  # not registered as submodule param-wise — we freeze it externally
+        self.in_features = base_linear.in_features
+        self.out_features = base_linear.out_features
+        self.rank = int(rank)
+        self.alpha = float(alpha)
+        self.scaling = self.alpha / max(1, self.rank)
+        # A: (rank, in_features) — initialized small random
+        # B: (out_features, rank) — initialized zero so initial output unchanged
+        self.lora_A = nn.Parameter(torch.zeros(self.rank, self.in_features))
+        self.lora_B = nn.Parameter(torch.zeros(self.out_features, self.rank))
+        nn.init.kaiming_uniform_(self.lora_A, a=math.sqrt(5))
+        # B stays zero
+
+    @property
+    def weight(self):
+        # Expose an effective weight so modules that read `.weight` directly
+        # do not crash if accidentally wrapped. Gradients still flow to LoRA.
+        return self.base.weight + self.scaling * (self.lora_B @ self.lora_A).to(self.base.weight.dtype)
+
+    @property
+    def bias(self):
+        return self.base.bias
+
+    def forward(self, x):
+        # Use the effective weight path. This is slightly more expensive than
+        # two matmuls but is robust for modules that expect .weight/.bias.
+        return F.linear(x, self.weight, self.bias)
+
+    def reset_lora(self):
+        """Zero out B to restore base-only behavior. A is left as-is."""
+        with torch.no_grad():
+            self.lora_B.zero_()
+
+
+def install_lora_adapters(core: nn.Module, rank: int, alpha: float,
+                           target_substrings=("qkv", "out_proj", "gate_up", "down", "in_proj")):
+    """
+    Walk the model and replace selected nn.Linear modules with LoRALinear
+    wrappers. Returns (lora_params, n_replaced). Base weights are frozen
+    (requires_grad=False) — only LoRA A,B have grads.
+
+    target_substrings: any module name *segment* matching one of these gets
+      LoRA wrapped. Defaults match attention qkv/out_proj, FFN gate_up/down,
+      Mamba internals are skipped by default; enable SCORE_FIRST_TTT_WRAP_MAMBA=1
+      only for a smoke-tested ablation.
+    """
+    # Snapshot the modules to replace (don't mutate during iteration)
+    to_replace = []  # list of (parent_module, attr_name, base_linear)
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if not isinstance(child, nn.Linear):
+                continue
+            full_name = f"{module_name}.{child_name}" if module_name else child_name
+            # Match if any target substring appears as a segment (last component)
+            # AND the linear is not the lm_head/tok_emb/embed projections.
+            if "lm_head" in full_name or "tok_emb" in full_name or "embed_proj" in full_name:
+                continue
+            # Critical crash fix: mamba_ssm.Mamba2.forward reads in_proj/out_proj.weight
+            # directly in its fused path. The LoRALinear properties above make accidental
+            # wrapping survivable, but by default we keep Mamba internals unwrapped because
+            # it is slower and was the source of the previous run's AttributeError.
+            if (not SCORE_FIRST_TTT_WRAP_MAMBA) and (".mamba." in full_name or full_name.startswith("mamba.")):
+                continue
+            if any(t == child_name for t in target_substrings):
+                to_replace.append((module, child_name, child, full_name))
+
+    n_replaced = 0
+    lora_params = []
+    for parent, child_name, base_linear, full_name in to_replace:
+        wrapper = LoRALinear(base_linear, rank=rank, alpha=alpha)
+        # Move adapter to the same device, but keep LoRA A/B in fp32 for
+        # AdamW stability. The forward path casts the effective delta to the
+        # base weight dtype.
+        wrapper = wrapper.to(device=base_linear.weight.device)
+        setattr(parent, child_name, wrapper)
+        n_replaced += 1
+        lora_params.append(wrapper.lora_A)
+        lora_params.append(wrapper.lora_B)
+
+    # Freeze all non-LoRA params
+    for p in core.parameters():
+        p.requires_grad_(False)
+    # Re-enable grads on LoRA params
+    for p in lora_params:
+        p.requires_grad_(True)
+
+    return lora_params, n_replaced
+
+
+def uninstall_lora_adapters(core: nn.Module):
+    """
+    Restore base nn.Linear modules in place of LoRALinear wrappers and
+    re-enable grads on all params. Called after TTT eval to leave the
+    model in its pre-eval state for any subsequent operations (compression,
+    further evals, etc.).
+    """
+    to_restore = []
+    for module_name, module in core.named_modules():
+        for child_name, child in module.named_children():
+            if isinstance(child, LoRALinear):
+                to_restore.append((module, child_name, child))
+    for parent, child_name, wrapper in to_restore:
+        setattr(parent, child_name, wrapper.base)
+    for p in core.parameters():
+        p.requires_grad_(True)
+    return len(to_restore)
+
+
+def reset_all_lora(core: nn.Module):
+    """Zero out all lora_B in the model (resets to base-only behavior).
+    Used between eval phases or to clear adapter state."""
+    n = 0
+    for m in core.modules():
+        if isinstance(m, LoRALinear):
+            m.reset_lora()
+            n += 1
+    return n
+
+
+# -----------------------------------------------------------------------------
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Legal score-first TTT with LoRA/adapters.
+
+    For each rank-local validation chunk:
+      1. Score each target token exactly once under no_grad.
+      2. Train adapters only on those already-scored tail tokens.
+      3. Carry adapter weights forward to the next chunk.
+
+    This fixes the previous overweighting bug where TTT trained on the full
+    overlapping windows even though only the scored tail tokens should adapt.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    if SCORE_FIRST_TTT_USE_LORA:
+        lora_params, n_replaced = install_lora_adapters(
+            core,
+            rank=SCORE_FIRST_TTT_LORA_RANK,
+            alpha=SCORE_FIRST_TTT_LORA_ALPHA,
+            target_substrings=SCORE_FIRST_TTT_TARGETS,
+        )
+        adapt_params = lora_params
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (LoRA): rank={SCORE_FIRST_TTT_LORA_RANK} "
+            f"alpha={SCORE_FIRST_TTT_LORA_ALPHA} replaced={n_replaced} linears, "
+            f"adapting {n_adapt:,} LoRA params, targets={SCORE_FIRST_TTT_TARGETS}, "
+            f"opt={SCORE_FIRST_TTT_OPT}, lr={SCORE_FIRST_TTT_LR}, "
+            f"wd={SCORE_FIRST_TTT_WD}, all_reduce={'NO' if SCORE_FIRST_TTT_NO_ALLREDUCE else 'YES'}"
+        )
+        base_state = None
+    else:
+        adapt_params = list(core.parameters())
+        n_adapt = sum(p.numel() for p in adapt_params)
+        log0(
+            f"Score-First TTT (FULL): chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, "
+            f"lr={SCORE_FIRST_TTT_LR}, momentum={SCORE_FIRST_TTT_MOMENTUM}, "
+            f"epochs={SCORE_FIRST_TTT_EPOCHS}, adapting {n_adapt:,} params"
+        )
+        base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    if SCORE_FIRST_TTT_OPT == "adamw":
+        ttt_opt = torch.optim.AdamW(
+            adapt_params,
+            lr=SCORE_FIRST_TTT_LR,
+            betas=(0.9, SCORE_FIRST_TTT_BETA2),
+            weight_decay=SCORE_FIRST_TTT_WD,
+        )
+    else:
+        ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                                  momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens + chunk_tokens - 1) // chunk_tokens
+    chunk_start_idx, chunk_end_idx = _rank_bounds(n_chunks)
+    local_chunks = chunk_end_idx - chunk_start_idx
+    batch_windows = max(1, 131072 // seq_len)
+    train_batch_windows = max(1, batch_windows // 2)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, local_chunks // 10)
+
+    try:
+        for chunk_idx_local, ci in enumerate(range(chunk_start_idx, chunk_end_idx)):
+            score_start = ci * chunk_tokens
+            score_end = min(score_start + chunk_tokens, total_tokens)
+            if score_end <= score_start:
+                continue
+
+            records = list(_sliding_score_records(total_tokens, seq_len, stride, score_start, score_end))
+            train_batches = []
+
+            core.eval()
+            with torch.no_grad():
+                for xn, yn, tail_start, tail_len in _iter_sliding_score_batches(
+                        val_tokens, records, seq_len, batch_windows):
+                    x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                    y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        hidden = core(x, state=None, return_state=False)
+                        hidden_tail = hidden[:, tail_start : tail_start + tail_len, :]
+                        y_tail = y[:, tail_start : tail_start + tail_len]
+                        logits = core.output_logits_from_hidden(hidden_tail)
+                        logits = core.add_copy_logits(logits, hidden_tail, hidden, x, query_start=tail_start)
+                        loss = F.cross_entropy(logits.float(), y_tail.reshape(-1), reduction="sum")
+
+                    cnt = float(y_tail.numel())
+                    loss_sum += float(loss.detach().float().item())
+                    p_tail = xn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    t_tail = yn[:, tail_start : tail_start + tail_len].reshape(-1)
+                    b = bb[t_tail].astype(np.int16, copy=True)
+                    b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                    tok_sum += cnt
+                    byt_sum += float(b.astype(np.float64).sum())
+                    train_batches.append((xn, yn, int(tail_start), int(tail_len)))
+
+            if train_batches:
+                core.train()
+                chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, local_chunks)))
+                for g in ttt_opt.param_groups:
+                    g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+                for _epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                    order = np.random.permutation(len(train_batches))
+                    for batch_i in order:
+                        bx, by, tail_start, tail_len = train_batches[int(batch_i)]
+                        for bi in range(0, bx.shape[0], train_batch_windows):
+                            be = min(bi + train_batch_windows, bx.shape[0])
+                            ax = torch.from_numpy(bx[bi:be]).long().to(DEVICE, non_blocking=True)
+                            ay = torch.from_numpy(by[bi:be]).long().to(DEVICE, non_blocking=True)
+
+                            ttt_opt.zero_grad(set_to_none=True)
+                            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                                adapt_loss = lm_loss_tail(core, ax, ay, tail_start, tail_len)
+                            adapt_loss.backward()
+
+                            if not SCORE_FIRST_TTT_NO_ALLREDUCE:
+                                for p in adapt_params:
+                                    if p.grad is not None:
+                                        dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                            if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                                nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                            ttt_opt.step()
+
+            if (chunk_idx_local + 1) % log_every_chunks == 0:
+                elapsed_e = time.perf_counter() - t0_eval
+                running_loss = loss_sum / max(tok_sum, 1.0)
+                running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+                eta = elapsed_e / (chunk_idx_local + 1) * max(0, local_chunks - chunk_idx_local - 1)
+                log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{local_chunks} "
+                     f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+        elapsed = time.perf_counter() - t0_eval
+        log0(f"  score_first_ttt: {local_chunks} chunks/rank, "
+             f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+        stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+        dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+        loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+        val_loss = loss_sum / max(tok_sum, 1.0)
+        bpt = val_loss / math.log(2.0)
+        return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+    finally:
+        if SCORE_FIRST_TTT_USE_LORA:
+            n_uninstalled = uninstall_lora_adapters(core)
+            log0(f"  score_first_ttt: uninstalled {n_uninstalled} LoRA adapters, base weights restored")
+        else:
+            with torch.no_grad():
+                for name, p in core.named_parameters():
+                    if name in base_state:
+                        p.data.copy_(base_state[name])
+        core.train()
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes an exact contiguous shard of val sequences.
+    seq_start, seq_end = _rank_bounds(total_seqs)
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = max(1, min(TTT_GLOBAL_BATCH_SEQS, max(local_seqs, 1)))
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks with exact remainder handling.
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start, seq_end = _rank_bounds(total_seqs)
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seq_end - seq_start
+    local_total_seqs = n_local_seqs
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {local_total_seqs})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Compression / quantization (int6 packed + Brotli-11)
+# -----------------------------------------------------------------------------
+def _quantize_row_sdclip(t: torch.Tensor, k: float, half_levels: int):
+    """Per-row symmetric quantization with std-based clipping.
+
+    t: (rows, cols) float
+    k: clipping coefficient (clip = k * std(row))
+    half_levels: max abs value (e.g., 31 for int6, 127 for int8)
+    Returns: (q int8 tensor, scale fp16 tensor)
+    """
+    t32 = t.float()
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    clip = (k * row_std).clamp_min(1e-8)  # (rows,)
+    scale = (clip / half_levels).clamp_min(1e-8)
+    clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+    q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels).to(torch.int8)
+    return q.contiguous(), scale.to(torch.float16).contiguous()
+
+
+def _quantize_row_optclip(t: torch.Tensor, half_levels: int,
+                           k_grid=(2.5, 3.0, 3.5, 4.0, 5.0, 6.0, 8.0, 10.0, 12.0, 16.0, 20.0, 24.0, 32.0, 48.0)):
+    """Per-row optimal-clip quantization (lite-GPTQ for embeddings).
+
+    For each row, sweep k_grid and pick the k that minimizes L2 reconstruction
+    error. The dominant quant-error driver for embedding tensors is rare-token
+    rows whose magnitude distribution differs from common-token rows; a single
+    global clip hurts them disproportionately. This captures most of GPTQ's
+    benefit for embeddings without needing calibration data.
+
+    NOT full GPTQ (no Hessian, no per-column error compensation). For
+    embeddings specifically the dominant error term is per-row magnitude
+    calibration, which this captures.
+    """
+    t32 = t.float()
+    rows, cols = t32.shape
+    row_std = t32.std(dim=1).clamp_min(1e-8)
+    row_abs_max = t32.abs().max(dim=1).values.clamp_min(1e-8)
+
+    best_err = torch.full((rows,), float("inf"), device=t32.device)
+    best_scale = torch.zeros((rows,), device=t32.device)
+    best_q = torch.zeros_like(t32, dtype=torch.int8)
+
+    for k in k_grid:
+        clip = (k * row_std).clamp_min(1e-8)
+        # Cap clip at row_abs_max so we don't waste levels on impossible values
+        clip = torch.minimum(clip, row_abs_max)
+        scale = (clip / half_levels).clamp_min(1e-8)
+        clipped = torch.clamp(t32, -clip[:, None], clip[:, None])
+        q = torch.round(clipped / scale[:, None]).clamp(-half_levels, half_levels)
+        recon = q * scale[:, None]
+        err = ((recon - t32) ** 2).sum(dim=1)
+        improved = err < best_err
+        best_err = torch.where(improved, err, best_err)
+        best_scale = torch.where(improved, scale, best_scale)
+        improved_mask = improved[:, None].expand_as(t32)
+        best_q = torch.where(improved_mask, q.to(torch.int8), best_q)
+
+    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+
+
+def _pack_int6(q_int8: torch.Tensor):
+    """Pack int8-stored int6 values (range [-31, 31]) into uint8.
+    4 values × 6 bits = 24 bits = 3 bytes."""
+    flat = q_int8.flatten().to(torch.int32) + 32  # shift to [0, 63]
+    n = flat.numel()
+    pad = (-n) % 4
+    if pad:
+        flat = torch.cat([flat, torch.zeros(pad, dtype=torch.int32, device=flat.device)])
+    g = flat.view(-1, 4)
+    a, b, c, d = g[:, 0], g[:, 1], g[:, 2], g[:, 3]
+    byte0 = ((a << 2) | (b >> 4)) & 0xFF
+    byte1 = (((b & 0xF) << 4) | (c >> 2)) & 0xFF
+    byte2 = (((c & 0x3) << 6) | d) & 0xFF
+    packed = torch.stack([byte0, byte1, byte2], dim=1).flatten().to(torch.uint8)
+    return packed.contiguous(), n
+
+
+def _unpack_int6(packed_u8: torch.Tensor, n_orig: int, shape):
+    """Inverse of _pack_int6."""
+    arr = packed_u8.to(torch.int32)
+    g = arr.view(-1, 3)
+    byte0, byte1, byte2 = g[:, 0], g[:, 1], g[:, 2]
+    a = byte0 >> 2
+    b = ((byte0 & 0x3) << 4) | (byte1 >> 4)
+    c = ((byte1 & 0xF) << 2) | (byte2 >> 6)
+    d = byte2 & 0x3F
+    unpacked = torch.stack([a, b, c, d], dim=1).flatten()[:n_orig]
+    signed = unpacked.to(torch.int32) - 32
+    return signed.view(shape).to(torch.int8)
+
+
+def _is_embedding_tensor(name: str) -> bool:
+    """Embedding-like tensors get int8 (more sensitive to quantization);
+    everything else gets int6."""
+    n = name
+    return (
+        "tok_emb" in n
+        or "lm_head" in n
+        or "embed_proj" in n
+        or ("bigram" in n and "embed" in n)
+    )
+
+
+def _compress_best(raw: bytes):
+    """Try Brotli-11 (best); fall back to zstd-22; final fallback zlib-9."""
+    if _HAS_BROTLI:
+        try:
+            return brotli.compress(raw, quality=11), "brotli11"
+        except Exception:
+            pass
+    if "zstandard" in sys.modules:
+        try:
+            cctx = sys.modules["zstandard"].ZstdCompressor(level=22)
+            return cctx.compress(raw), "zstd22"
+        except Exception:
+            pass
+    return zlib.compress(raw, 9), "zlib9"
+
+
+def _decompress(blob: bytes, scheme: str) -> bytes:
+    if scheme == "brotli11":
+        return brotli.decompress(blob)
+    if scheme == "zstd22":
+        return sys.modules["zstandard"].ZstdDecompressor().decompress(blob)
+    return zlib.decompress(blob)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Data loaders. If LENGTH_CURRICULUM_ENABLED, we create both a short
+    # 2048 loader and the final SEQ_LEN loader, preserving the same token budget.
+    # -----------------------------------------------------------------------
+    def _make_loader(seq_len_value, prefetch_depth=3):
+        if USE_ASYNC_LOADER:
+            return AsyncDistributedTokenLoader(
+                pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+                rank=RANK,
+                world_size=WORLD_SIZE,
+                global_tokens=TRAIN_BATCH_TOK,
+                seq_len=seq_len_value,
+                grad_accum_steps=GRAD_ACCUM,
+                device=DEVICE,
+                prefetch_depth=prefetch_depth,
+            )
+        return DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=seq_len_value,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    loader_long = _make_loader(SEQ_LEN, prefetch_depth=3)
+    loader_short = None
+    if LENGTH_CURRICULUM_ENABLED:
+        if SEQ_LEN <= CURRICULUM_SHORT_SEQ_LEN:
+            raise ValueError("LENGTH_CURRICULUM_ENABLED requires SEQ_LEN > CURRICULUM_SHORT_SEQ_LEN")
+        if CURRICULUM_SHORT_SEQ_LEN % STREAM_CHUNKS != 0:
+            raise ValueError("CURRICULUM_SHORT_SEQ_LEN must be divisible by STREAM_CHUNKS")
+        loader_short = _make_loader(CURRICULUM_SHORT_SEQ_LEN, prefetch_depth=2)
+        log0(f"Length curriculum loaders ready: short={CURRICULUM_SHORT_SEQ_LEN}, long={SEQ_LEN}")
+    loader = loader_long
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS  # final/eval chunk length; train chunk len can change with curriculum
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "10"))  # keep training inside 600s; 100-step checks overshot by ~8s
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+
+        current_loader = loader_long
+        if LENGTH_CURRICULUM_ENABLED and loader_short is not None and MAX_WALLCLOCK_SECONDS > 0:
+            frac_len = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac_len < CURRICULUM_SWITCH_FRAC:
+                current_loader = loader_short
+                if step == 0:
+                    log0(f"LENGTH_CURRICULUM: using short seq_len={CURRICULUM_SHORT_SEQ_LEN} until {CURRICULUM_SWITCH_FRAC*100:.0f}% wall")
+            elif loader is not loader_long:
+                log0(f"LENGTH_CURRICULUM: switched to long seq_len={SEQ_LEN} at step {step} ({frac_len*100:.0f}% wall)")
+        loader = current_loader
+
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            current_seq_len = x.shape[1]
+            _cur_chunk_len = current_seq_len // STREAM_CHUNKS
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_cur_chunk_len]
+                        ys = y[:, :_cur_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        ys = y[:, c * _cur_chunk_len : (c + 1) * _cur_chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    # --- State-carryover eval (SSM-native) ---
+    # Threads Mamba2 hidden state across non-overlapping val blocks via the
+    # direct mamba_chunk_scan_combined kernel (with initial_states /
+    # return_final_states). Falls back to InferenceParams path for diagnosis
+    # if direct kernel unavailable. Compare against the sliding-window
+    # number above to see whether long-prefix recurrent state actually helps.
+    pre_ttt_co_vb = None
+    have_carry_path = (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None) \
+                       or (InferenceParams is not None)
+    if CARRYOVER_EVAL_ENABLED and have_carry_path:
+        dist.barrier()
+        log0("=" * 60)
+        log0(f"Running state-carryover eval (block_len={CARRYOVER_BLOCK_LEN}, warmup={CARRYOVER_WARMUP_TOKENS} tokens)...")
+        try:
+            co_vl, co_vb = eval_val_carryover(
+                model, val_tokens, bb, hs, ib,
+                block_len=CARRYOVER_BLOCK_LEN,
+                warmup_tokens=CARRYOVER_WARMUP_TOKENS,
+            )
+            log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+            log0(f"Carryover vs standard:    bpb={best_vb - co_vb:+.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"Carryover vs sliding:     bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+            pre_ttt_co_vb = co_vb
+        except Exception as e:
+            log0(f"[carryover_eval] FAILED: {type(e).__name__}: {e}")
+            import traceback
+            log0(traceback.format_exc())
+            log0("[carryover_eval] continuing — sliding-window number above is unaffected")
+        log0("=" * 60)
+    elif CARRYOVER_EVAL_ENABLED:
+        log0("[carryover_eval] skipped: no carryover path available (need either mamba_chunk_scan_combined or InferenceParams)")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if RUN_PREQUANT_SCORE_FIRST_TTT and SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    # -----------------------------------------------------------------------
+    # Quantization + compression + roundtrip validation
+    # int6 GPTQ-lite (per-row SDClip) for matrices, int8 for embeddings,
+    # fp16 passthrough for small/sensitive. Brotli-11 with zstd fallback.
+    # -----------------------------------------------------------------------
+    # Load best weights for quantization
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+        for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+            try:
+                if _ldr is not None:
+                    _ldr.shutdown()
+            except Exception:
+                pass
+        return
+
+    log0(f"Quantizing model (mode={QUANT_MODE}, k_mat={QUANT_K_MATRIX}, k_emb={QUANT_K_EMBED})...")
+    state_dict = base_model.state_dict()
+
+    # Dynamics-protected quantization (PR #1890 / Q-Mamba ICLR 2025).
+    # Mamba2.in_proj output is split into [z, x, B, C, dt]; the last `nheads`
+    # rows of in_proj.weight produce dt (the SSM time-step generator).
+    # Q-Mamba shows that uniform 6-bit PTQ destabilizes the SSM recurrence
+    # because errors in dt (and consequently A_bar = exp(dt*A)) compound over
+    # many tokens. Promoting just these dt rows to INT8 costs ~16 extra bytes
+    # per packed row (about 0.01 MB total at our scale) and recovers most of
+    # the post-quant BPB regression.
+    #
+    # We derive the row range from the live module's .nheads attribute rather
+    # than hardcoding indices, so this works across configs with different
+    # ngroups, d_state, headdim, etc. The map is keyed by the parameter name
+    # we'd see in state_dict (e.g. "blocks.0.mamba.in_proj.weight").
+    dt_row_map = {}  # name -> (dt_start, dt_end) in row indexing
+    if QUANT_PROTECT_DYNAMICS:
+        for mod_name, mod in base_model.named_modules():
+            # mamba_ssm Mamba2 modules expose .nheads, .in_proj
+            if hasattr(mod, "in_proj") and hasattr(mod, "nheads"):
+                w = getattr(mod.in_proj, "weight", None)
+                if w is None or w.ndim != 2:
+                    continue
+                total_rows = w.shape[0]
+                nheads = int(mod.nheads)
+                if nheads <= 0 or nheads >= total_rows:
+                    continue
+                weight_name = f"{mod_name}.in_proj.weight"
+                dt_row_map[weight_name] = (total_rows - nheads, total_rows)
+        log0(
+            f"  dynamics-protected rows: {len(dt_row_map)} in_proj tensors flagged "
+            f"({sum(end-start for start,end in dt_row_map.values())} total dt rows -> int8)"
+        )
+
+    # Stats counters
+    n_int6 = n_int8 = n_passthrough = n_alias = 0
+    bytes_int6 = bytes_int8 = bytes_passthrough = 0
+
+    quant_entries = {}    # name -> {"mode", ...} or {"mode": "alias", "target": canonical_name}
+    # Tied-weight dedup keyed by the ORIGINAL tensor's data_ptr/storage. We
+    # must NOT key on the CPU copy's data_ptr — CPU buffers get freed and
+    # reused across iterations, causing false-positive aliases between
+    # unrelated tensors. Original state_dict tensors share storage with
+    # live model parameters, so their data_ptrs are stable for the duration
+    # of this loop.
+    seen_ptrs = {}
+
+    for name, t_orig in state_dict.items():
+        # Check aliasing on the original tensor BEFORE making any copies.
+        # Combine data_ptr with shape to be doubly safe — two tensors that
+        # share storage AND have the same shape are genuine aliases (e.g.
+        # tied lm_head.weight ↔ tok_emb.weight). Different shapes at the
+        # same ptr would indicate a view, not a tied weight.
+        ptr_key = (t_orig.data_ptr(), tuple(t_orig.shape))
+        if ptr_key in seen_ptrs:
+            quant_entries[name] = {"mode": "alias", "target": seen_ptrs[ptr_key]}
+            n_alias += 1
+            continue
+        seen_ptrs[ptr_key] = name
+
+        t = t_orig.detach().cpu().contiguous()
+
+        # Non-float or small/sensitive: keep as fp16 (or original int)
+        if not t.is_floating_point():
+            quant_entries[name] = {"mode": "raw", "tensor": t}
+            n_passthrough += 1
+            bytes_passthrough += t.numel() * t.element_size()
+            continue
+
+        if t.numel() <= QUANT_PASSTHROUGH_NUMEL or t.ndim != 2:
+            t16 = t.to(torch.float16).contiguous()
+            quant_entries[name] = {"mode": "fp16", "tensor": t16}
+            n_passthrough += 1
+            bytes_passthrough += t16.numel() * 2
+            continue
+
+        # 2D float, large: quantize
+        is_embed = _is_embedding_tensor(name)
+        if QUANT_MODE == "int8" or is_embed:
+            # int8 with SDClip — embedding-like tensors get optimal-clip
+            # search (GPTQ-lite) when enabled, otherwise the single global k.
+            if is_embed and QUANT_OPTCLIP_EMBED:
+                q, scale = _quantize_row_optclip(t, half_levels=127)
+            else:
+                q, scale = _quantize_row_sdclip(t, k=QUANT_K_EMBED if is_embed else QUANT_K_MATRIX, half_levels=127)
+            # Store as raw int8 bytes (no need to pack — one byte per value)
+            quant_entries[name] = {
+                "mode": "int8",
+                "packed": q.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(t.numel()),
+            }
+            n_int8 += 1
+            bytes_int8 += q.numel()
+        elif name in dt_row_map:
+            # Dynamics-protected int6+int8 split: low rows int6, dt rows int8.
+            dt_start, dt_end = dt_row_map[name]
+            t_low = t[:dt_start].contiguous()        # z, x, B, C rows -> int6
+            t_dt = t[dt_start:dt_end].contiguous()   # dt rows -> int8
+
+            q_low, scale_low = _quantize_row_sdclip(t_low, k=QUANT_K_MATRIX, half_levels=31)
+            packed_low, n_orig_low = _pack_int6(q_low)
+
+            q_dt, scale_dt = _quantize_row_sdclip(t_dt, k=QUANT_K_MATRIX, half_levels=127)
+
+            quant_entries[name] = {
+                "mode": "mixed_int6_int8",
+                "packed_low": packed_low.numpy().tobytes(),
+                "scale_low": scale_low,
+                "shape_low": tuple(t_low.shape),
+                "numel_low": int(n_orig_low),
+                "packed_dt": q_dt.numpy().tobytes(),
+                "scale_dt": scale_dt,
+                "shape_dt": tuple(t_dt.shape),
+                "shape_full": tuple(t.shape),
+            }
+            n_int6 += 1  # count under int6 since the bulk is int6
+            bytes_int6 += packed_low.numel()
+            bytes_int8 += q_dt.numel()
+        else:
+            # int6 packed (4 vals per 3 bytes) with SDClip
+            q, scale = _quantize_row_sdclip(t, k=QUANT_K_MATRIX, half_levels=31)
+            packed, n_orig = _pack_int6(q)
+            quant_entries[name] = {
+                "mode": "int6",
+                "packed": packed.numpy().tobytes(),
+                "scale": scale,
+                "shape": tuple(t.shape),
+                "numel": int(n_orig),
+            }
+            n_int6 += 1
+            bytes_int6 += packed.numel()
+
+    log0(
+        f"  quant tensors: int6={n_int6} ({bytes_int6/1e6:.2f}MB) "
+        f"int8={n_int8} ({bytes_int8/1e6:.2f}MB) "
+        f"fp16/raw={n_passthrough} ({bytes_passthrough/1e6:.2f}MB) "
+        f"alias={n_alias}"
+    )
+    raw_total = bytes_int6 + bytes_int8 + bytes_passthrough
+    log0(f"  raw quantized total before compression: {raw_total/1e6:.2f}MB")
+
+    # Serialize and compress
+    import io
+    quant_buf = io.BytesIO()
+    torch.save(quant_entries, quant_buf)
+    quant_raw = quant_buf.getvalue()
+
+    quant_blob, scheme = _compress_best(quant_raw)
+    compressed_bytes = len(quant_blob)
+    log0(
+        f"Compressed model ({scheme}): {compressed_bytes:,} bytes "
+        f"({compressed_bytes / 1024 / 1024:.2f} MB) — "
+        f"{'UNDER' if compressed_bytes <= 16_000_000 else 'OVER'} 16MB cap"
+    )
+
+    # Roundtrip: decompress, dequantize, reload, and re-evaluate
+    quant_raw_rt = _decompress(quant_blob, scheme)
+    quant_entries_rt = torch.load(io.BytesIO(quant_raw_rt), map_location="cpu")
+
+    dequant_state = {}
+    # First pass: dequantize non-alias entries
+    for name, entry in quant_entries_rt.items():
+        mode = entry["mode"]
+        if mode == "alias":
+            continue  # second pass
+        if mode == "raw":
+            dequant_state[name] = entry["tensor"]
+        elif mode == "fp16":
+            dequant_state[name] = entry["tensor"].to(torch.bfloat16)
+        elif mode == "int8":
+            shape = entry["shape"]
+            packed = np.frombuffer(entry["packed"], dtype=np.int8)
+            q = torch.from_numpy(packed.copy()).view(shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "int6":
+            shape = entry["shape"]
+            n_orig = entry["numel"]
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed"], dtype=np.uint8).copy())
+            q = _unpack_int6(packed_u8, n_orig, shape)
+            scale = entry["scale"].float()
+            dq = q.float() * scale.view(shape[0], 1)
+            dequant_state[name] = dq.to(torch.bfloat16)
+        elif mode == "mixed_int6_int8":
+            # Dynamics-protected: low rows from int6, dt rows from int8.
+            shape_low = entry["shape_low"]
+            shape_dt = entry["shape_dt"]
+            shape_full = entry["shape_full"]
+            n_orig_low = entry["numel_low"]
+
+            # Decode int6 part
+            packed_u8 = torch.from_numpy(np.frombuffer(entry["packed_low"], dtype=np.uint8).copy())
+            q_low = _unpack_int6(packed_u8, n_orig_low, shape_low)
+            scale_low = entry["scale_low"].float()
+            dq_low = q_low.float() * scale_low.view(shape_low[0], 1)
+
+            # Decode int8 part
+            packed_dt = np.frombuffer(entry["packed_dt"], dtype=np.int8)
+            q_dt = torch.from_numpy(packed_dt.copy()).view(shape_dt)
+            scale_dt = entry["scale_dt"].float()
+            dq_dt = q_dt.float() * scale_dt.view(shape_dt[0], 1)
+
+            # Stitch back to full shape
+            dq = torch.cat([dq_low, dq_dt], dim=0)
+            assert dq.shape == shape_full, f"mixed dequant shape mismatch: got {dq.shape}, expected {shape_full}"
+            dequant_state[name] = dq.to(torch.bfloat16)
+        else:
+            raise RuntimeError(f"unknown quant mode: {mode}")
+    # Second pass: resolve aliases
+    for name, entry in quant_entries_rt.items():
+        if entry["mode"] == "alias":
+            dequant_state[name] = dequant_state[entry["target"]]
+
+    base_model.load_state_dict(dequant_state, strict=True)
+    q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+    q_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+    # Final leaderboard-relevant diagnostic: dequantized artifact path +
+    # legal score-first LoRA TTT. Reload dequant weights first so any earlier
+    # eval state is clean; eval_score_first_ttt restores base weights after it.
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        base_model.load_state_dict(dequant_state, strict=True)
+        log0("=" * 60)
+        log0(f"Running POST-QUANT Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        q_sft_vl, q_sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Post-quant Score-First TTT val_loss:{q_sft_vl:.4f} val_bpb:{q_sft_vb:.4f}")
+        if q_sw_vb is not None:
+            log0(f"Post-quant Score-First TTT vs sliding: bpb={q_sw_vb - q_sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # Save compressed artifact
+    if MASTER_PROCESS:
+        ext = scheme  # brotli11 / zstd22 / zlib9
+        run_tag = os.environ.get("RUN_TAG", "").strip()
+        artifact_dir = os.environ.get("ARTIFACT_DIR", ".").strip() or "."
+        os.makedirs(artifact_dir, exist_ok=True)
+        prefix = f"final_model.{run_tag}." if run_tag else "final_model."
+        artifact_path = os.path.join(artifact_dir, f"{prefix}{QUANT_MODE}.{ext}.bin")
+        with open(artifact_path, "wb") as f:
+            f.write(quant_blob)
+        log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loaders
+    for _ldr in (locals().get("loader_short", None), locals().get("loader_long", None)):
+        try:
+            if _ldr is not None:
+                _ldr.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/requirements.txt
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/requirements.txt
@@ -1,0 +1,14 @@
+# Do NOT pin torch — use whatever is pre-installed on the pod.
+# mamba-ssm and causal-conv1d must be built against the existing torch/CUDA.
+# Install with (H100 only, fastest):
+#   TORCH_CUDA_ARCH_LIST="9.0" MAX_JOBS=16 pip install -r requirements.txt --no-build-isolation
+numpy
+sentencepiece
+huggingface-hub
+datasets
+tiktoken
+mamba-ssm
+causal-conv1d
+einops
+tqdm
+zstandard

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/submission.json
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/submission.json
@@ -1,0 +1,11 @@
+{
+  "track": "non_record_16mb",
+  "date": "2026-04-30",
+  "name": "Mamba2 SSM + Attention Hybrid (SP8192, Single-Attention, QK-Gain 5.25, Aggressive LZMA Quant)",
+  "author": "Saroosh Khan",
+  "github_id": "SarooshKhan897",
+  "val_bpb": 1.2938,
+  "val_loss": 3.3421,
+  "bytes_total": 16094692,
+  "_notes": "Single-run, post-quantization sliding val_bpb=1.2938 from the moderate quant run (int4 FFN gate, int4 FFN down, int5 Mamba/attn, int6 embed). Pre-quant sliding val_bpb=1.1005, demonstrating architectural potential. Artifact size 16,094,692 bytes is ~95KB over the 16,000,000 byte cap before code bytes - submitted as a non-record research contribution documenting SSM/Mamba2 + attention hybrid behavior under the parameter golf constraints. A more aggressive quant (run #1 in train.log) fit at 10.9 MB but quality collapsed to 2.12 BPB."
+}

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/train.log
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/train.log
@@ -1,0 +1,362 @@
+root@e24cbb578f3c:/workspace/parameter-golf# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+SEQ_LEN=8192 \
+N_UNIQUE_BLOCKS=10 \
+ATTN_LAYER_IDXS=6 \
+FFN_MULT=3 \
+FFN_ACTIVE_POLICY=all \
+EMBED_DIM=512 \
+BIGRAM_ENABLED=1 \
+HEADDIM=64 \
+DT_MIN=0.0005 \
+DT_MAX=0.05 \
+SEQ_IDX_ENABLED=1 \
+DOC_BOUNDARY_TOKEN=1 \
+CARRYOVER_EVAL_ENABLED=0 \
+SCORE_FIRST_TTT_ENABLED=0 \
+TTT_ENABLED=0 \
+RUN_POSTQUANT=1 \
+QUANT_FORMAT=fullmuon_aggressive_lzma \
+QUANT_BITS_FFN_GATE=3 \
+QUANT_BITS_FFN_DOWN=4 \
+QUANT_BITS_MAMBA=4 \
+QUANT_BITS_ATTN=5 \
+QUANT_BITS_EMBED=6 \
+QUANT_BITS_MATRIX=5 \
+QUANT_PACK_ALL=1 \
+QUANT_PASSTHROUGH_NUMEL=65536 \
+QUANT_K_FFN_GATE=12.85 \
+QUANT_K_FFN_DOWN=12.85 \
+QUANT_K_MAMBA=12.85 \
+QUANT_K_ATTN=12.85 \
+QUANT_K_EMBED=20.0 \
+QUANT_SCALE_FLOOR_MULT=1.0 \
+QUANT_PROTECT_DYNAMICS=1 \
+QUANT_OPTCLIP_EMBED=1 \
+QUANT_OPTCLIP_STEPS=8 \
+QUANT_AUTO_PRUNE_TO_BYTES=1 \
+QUANT_TARGET_BYTES=15850000 \
+QUANT_AUTO_PRUNE_FRACS=0,0.25,0.40,0.55,0.70,0.85 \
+QUANT_LZMA_PRESET=9 \
+QUANT_LZMA_EXTREME=1 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 \
+ssm_recall_sota_sp8192_fullmuon_final_compress.py \
+| tee /workspace/fullmuon_final_compress.log
+W0430 23:48:48.496000 199510 torch/distributed/run.py:803] 
+W0430 23:48:48.496000 199510 torch/distributed/run.py:803] *****************************************
+W0430 23:48:48.496000 199510 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0430 23:48:48.496000 199510 torch/distributed/run.py:803] *****************************************
+Project root: /workspace/parameter-golf-repo
+GPU inventory:
+{'rank': 0, 'local_rank': 0, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 1, 'local_rank': 1, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 2, 'local_rank': 2, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 3, 'local_rank': 3, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 4, 'local_rank': 4, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 5, 'local_rank': 5, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 6, 'local_rank': 6, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 7, 'local_rank': 7, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+AMP dtype: torch.bfloat16
+Config: 10 unique x 1 unrolls = 10 effective layers
+d_model=512, d_state=64, ffn_mult=3, memory_dim=256
+mamba2: headdim=64, nheads=16, dt_min=0.0005, dt_max=0.05
+seq_idx: enabled=True, doc_boundary_token=1 (-1 to disable)
+carryover_eval: enabled=False, block_len=8192, overlap=1024, warmup_tokens=0, direct_kernel=True
+ffn_every=1, ffn_freq_mode=layer
+ffn_active_policy=all, ffn_active_idxs=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+train_batch_tok(global)=524288, local_batch_tok=65536, grad_accum=1
+effective_batch_tok/step=524288, micro_batch_tok/rank=65536
+warmup_steps=20, iterations=20000, max_wallclock_seconds=600.0
+lr_schedule=cosine_late, lr_min_scale=0.0, enable_s4d_init=True
+stream_chunks=1, bptt_chunks=1
+mixed_length_curriculum=0, curriculum_steps=1500
+use_async_loader=True
+use_memory=False, use_torch_compile=True
+vocab=8192, factored_embed_dim=512 (enabled)
+hybrid_attn: layer_idxs=[6], n_heads=8, qk_gain_init=5.25
+compression_defaults: Option-A full-Muon baseline + aggressive role-bit packed LZMA artifact
+activation: swiglu
+depth_recur: loop=[-1..-1] activate@0.35
+score_first_ttt: enabled=False, chunk=32768, lr=0.005, epochs=3
+bigram: enabled=True, buckets=10240, dim=128
+swa: enabled=False, start_frac=0.15, every=50
+eval_stride=64
+postquant: run_postquant=True
+compression_quant: format=fullmuon_aggressive_lzma, pack_all=True, bits(ffn_gate/down=3/4, mamba=4, attn=5, embed=6, other=5), passthrough_numel<=65536, k(ffn_gate/down=12.85/12.85, mamba=12.85, attn=12.85, embed=20.0, other=12.85), scale_floor_mult=1.0, protect_dynamics=True, optclip_embed=True, prune_ones_frac=0.0, auto_prune=True, target_bytes=15850000, lzma_preset=9, extreme=True
+ema: enabled=False, decay=0.9965
+optimizer: matrix_lr=0.022, scalar_lr=0.02, embed_lr=0.03, wd=0.095, grad_clip=0.3
+batch_warmup: steps=0, start_frac=0.25
+ttt: enabled=False, per_seq_steps=5, per_seq_lr=0.001, params=in_proj, max_seqs=256
+ttt_global: steps=10, lr=0.0002, batch_seqs=16, passes=1, grad_clip=1.0
+hybrid_optimizer: muon_momentum=0.99, muon_momentum_warmup=0.85->0.99 over 500 steps, muon_backend_steps=5, muon_nesterov=True
+Val tokens: 40,534,016 (full: 40,534,016)
+FFN instantiated on layers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] / 10
+Model parameters: 45,651,000
+S4D init applied to 9 module(s), skipped 0
+Pre-cast 53 parameters to torch.bfloat16
+torch_compile: enabled
+Optimizer split: matrix=45 (Muon), scalar/control=106 (AdamW), embed=1 (AdamW)
+Muon config: muon_only_2d=1 eligible_2d=45 eligible_nd=9
+Training for up to 20000 steps (cap=600.0s)
+Replay: will reset data stream at 0% wall time
+step:1/20000 loss:9.0139 lr:0.000 tok/s_inst:22565 tok/s_avg:22565
+step:2/20000 loss:9.0143 lr:0.050 tok/s_inst:3656286 tok/s_avg:44853
+step:3/20000 loss:8.9337 lr:0.100 tok/s_inst:3811936 tok/s_avg:66886
+step:4/20000 loss:8.6914 lr:0.150 tok/s_inst:4181807 tok/s_avg:88708
+step:5/20000 loss:8.2148 lr:0.200 tok/s_inst:4197139 tok/s_avg:110302
+step:500/20000 loss:3.5009 lr:1.000 tok/s_inst:3833257 tok/s_avg:2865939
+step:1000/20000 loss:3.3001 lr:1.000 tok/s_inst:3669007 tok/s_avg:3218129
+step:1500/20000 loss:3.0895 lr:0.969 tok/s_inst:4039367 tok/s_avg:3452074
+step:2000/20000 loss:3.1251 lr:0.836 tok/s_inst:3934410 tok/s_avg:3561220
+step:2500/20000 loss:3.0474 lr:0.626 tok/s_inst:3760014 tok/s_avg:3599279
+step:3000/20000 loss:3.0310 lr:0.380 tok/s_inst:4050200 tok/s_avg:3667329
+step:3500/20000 loss:2.9403 lr:0.172 tok/s_inst:3847724 tok/s_avg:3692057
+step:4000/20000 loss:2.5302 lr:0.031 tok/s_inst:3718526 tok/s_avg:3695345
+Training complete: 4300 steps in 605.7s
+stopping_early: wallclock_cap at step 4300/20000
+All ranks synced. Starting evaluation...
+Final val_loss:2.8533 val_bpb:1.1046
+Best (standard): live val_loss:2.8533 val_bpb:1.1046
+Running sliding window eval (stride=64)...
+  sliding_eval: 10% (494/4947 batches, eta:216s)
+  sliding_eval: 20% (988/4947 batches, eta:192s)
+  sliding_eval: 30% (1482/4947 batches, eta:168s)
+  sliding_eval: 40% (1976/4947 batches, eta:144s)
+  sliding_eval: 50% (2470/4947 batches, eta:120s)
+  sliding_eval: 60% (2964/4947 batches, eta:96s)
+  sliding_eval: 70% (3458/4947 batches, eta:72s)
+  sliding_eval: 80% (3952/4947 batches, eta:48s)
+  sliding_eval: 90% (4446/4947 batches, eta:24s)
+  sliding_eval: 100% (4940/4947 batches, eta:0s)
+  sliding_eval: 79152 windows/rank, stride=64, 5065728 scored tokens, 240.3s
+Sliding val_loss:2.8410 val_bpb:1.0998
+Sliding vs standard: bpb=+0.0048
+Quantizing model with aggressive role-bit packing + LZMA...
+Quant candidate prune=0.000: compressed=10,910,872 bytes, raw=23,043,073, packed_bytes=22,417,408, byte_q=0, ones=0, pruned=0
+Selected quant prune=0.000: byte_q_tensors=0, packed_q_tensors=44, passthrough=108, alias=1, packed_bytes=22,417,408, byte_q_numel=0, approx_payload=21.91 MiB
+Role quantized numel: {'embedding': 6029312, 'mamba': 14819328, 'ffn_gate': 15728640, 'ffn_down': 7864320, 'attention': 1048576}
+Role packed/byte payload bytes: {'embedding': 4521984, 'mamba': 7409664, 'ffn_gate': 5898240, 'ffn_down': 3932160, 'attention': 655360}
+Serialized raw torch.save: 23,043,073 bytes (21.98 MiB)
+Compressed model (lzma9+extreme): 10,910,872 bytes (10.41 MiB)
+Artifact size check: UNDER 16,000,000-byte cap before code bytes
+Post-quant val_loss:5.4479 val_bpb:2.1090
+  sliding_eval: 10% (494/4947 batches, eta:211s)
+  sliding_eval: 20% (988/4947 batches, eta:188s)
+  sliding_eval: 30% (1482/4947 batches, eta:165s)
+  sliding_eval: 40% (1976/4947 batches, eta:141s)
+  sliding_eval: 50% (2470/4947 batches, eta:118s)
+  sliding_eval: 60% (2964/4947 batches, eta:94s)
+  sliding_eval: 70% (3458/4947 batches, eta:71s)
+  sliding_eval: 80% (3952/4947 batches, eta:47s)
+  sliding_eval: 90% (4446/4947 batches, eta:24s)
+  sliding_eval: 100% (4940/4947 batches, eta:0s)
+  sliding_eval: 79152 windows/rank, stride=64, 5065728 scored tokens, 235.2s
+Post-quant sliding val_loss:5.4887 val_bpb:2.1248
+Saved artifact: final_model.fullmuon_aggressive_lzma.lzma (10,910,872 bytes)
+[W501 00:07:48.717815758 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.737562968 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.933850414 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.041481717 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.089871022 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.164046829 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.207233744 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:07:48.211073294 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+root@e24cbb578f3c:/workspace/parameter-golf# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+SEQ_LEN=8192 \
+N_UNIQUE_BLOCKS=10 \
+ATTN_LAYER_IDXS=6 \
+FFN_MULT=3 \
+FFN_ACTIVE_POLICY=all \
+EMBED_DIM=512 \
+BIGRAM_ENABLED=1 \
+HEADDIM=64 \
+DT_MIN=0.0005 \
+DT_MAX=0.05 \
+SEQ_IDX_ENABLED=1 \
+DOC_BOUNDARY_TOKEN=1 \
+CARRYOVER_EVAL_ENABLED=0 \
+SCORE_FIRST_TTT_ENABLED=0 \
+TTT_ENABLED=0 \
+RUN_POSTQUANT=1 \
+QUANT_FORMAT=fullmuon_aggressive_lzma \
+QUANT_BITS_FFN_GATE=4 \
+QUANT_BITS_FFN_DOWN=4 \
+QUANT_BITS_MAMBA=5 \
+QUANT_BITS_ATTN=5 \
+QUANT_BITS_EMBED=6 \
+QUANT_BITS_MATRIX=5 \
+QUANT_PACK_ALL=1 \
+QUANT_PASSTHROUGH_NUMEL=65536 \
+QUANT_K_FFN_GATE=12.85 \
+QUANT_K_FFN_DOWN=12.85 \
+QUANT_K_MAMBA=12.85 \
+QUANT_K_ATTN=12.85 \
+QUANT_K_EMBED=20.0 \
+QUANT_SCALE_FLOOR_MULT=1.0 \
+QUANT_PROTECT_DYNAMICS=1 \
+QUANT_OPTCLIP_EMBED=1 \
+QUANT_OPTCLIP_STEPS=8 \
+QUANT_AUTO_PRUNE_TO_BYTES=0 \
+QUANT_TARGET_BYTES=15850000 \
+QUANT_AUTO_PRUNE_FRACS=0.25 \
+QUANT_LZMA_PRESET=9 \
+QUANT_LZMA_EXTREME=1 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 \
+ssm_recall_sota_sp8192_fullmuon_final_compress.py \
+| tee /workspace/fullmuon_final_compress.log
+W0501 00:08:26.513000 201125 torch/distributed/run.py:803] 
+W0501 00:08:26.513000 201125 torch/distributed/run.py:803] *****************************************
+W0501 00:08:26.513000 201125 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0501 00:08:26.513000 201125 torch/distributed/run.py:803] *****************************************
+Project root: /workspace/parameter-golf-repo
+GPU inventory:
+{'rank': 0, 'local_rank': 0, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 1, 'local_rank': 1, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 2, 'local_rank': 2, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 3, 'local_rank': 3, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 4, 'local_rank': 4, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 5, 'local_rank': 5, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 6, 'local_rank': 6, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+{'rank': 7, 'local_rank': 7, 'name': 'NVIDIA H100 80GB HBM3', 'total_mem_gb': 79.19}
+AMP dtype: torch.bfloat16
+Config: 10 unique x 1 unrolls = 10 effective layers
+d_model=512, d_state=64, ffn_mult=3, memory_dim=256
+mamba2: headdim=64, nheads=16, dt_min=0.0005, dt_max=0.05
+seq_idx: enabled=True, doc_boundary_token=1 (-1 to disable)
+carryover_eval: enabled=False, block_len=8192, overlap=1024, warmup_tokens=0, direct_kernel=True
+ffn_every=1, ffn_freq_mode=layer
+ffn_active_policy=all, ffn_active_idxs=[0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+train_batch_tok(global)=524288, local_batch_tok=65536, grad_accum=1
+effective_batch_tok/step=524288, micro_batch_tok/rank=65536
+warmup_steps=20, iterations=20000, max_wallclock_seconds=600.0
+lr_schedule=cosine_late, lr_min_scale=0.0, enable_s4d_init=True
+stream_chunks=1, bptt_chunks=1
+mixed_length_curriculum=0, curriculum_steps=1500
+use_async_loader=True
+use_memory=False, use_torch_compile=True
+vocab=8192, factored_embed_dim=512 (enabled)
+hybrid_attn: layer_idxs=[6], n_heads=8, qk_gain_init=5.25
+compression_defaults: Option-A full-Muon baseline + aggressive role-bit packed LZMA artifact
+activation: swiglu
+depth_recur: loop=[-1..-1] activate@0.35
+score_first_ttt: enabled=False, chunk=32768, lr=0.005, epochs=3
+bigram: enabled=True, buckets=10240, dim=128
+swa: enabled=False, start_frac=0.15, every=50
+eval_stride=64
+postquant: run_postquant=True
+compression_quant: format=fullmuon_aggressive_lzma, pack_all=True, bits(ffn_gate/down=4/4, mamba=5, attn=5, embed=6, other=5), passthrough_numel<=65536, k(ffn_gate/down=12.85/12.85, mamba=12.85, attn=12.85, embed=20.0, other=12.85), scale_floor_mult=1.0, protect_dynamics=True, optclip_embed=True, prune_ones_frac=0.0, auto_prune=False, target_bytes=15850000, lzma_preset=9, extreme=True
+ema: enabled=False, decay=0.9965
+optimizer: matrix_lr=0.022, scalar_lr=0.02, embed_lr=0.03, wd=0.095, grad_clip=0.3
+batch_warmup: steps=0, start_frac=0.25
+ttt: enabled=False, per_seq_steps=5, per_seq_lr=0.001, params=in_proj, max_seqs=256
+ttt_global: steps=10, lr=0.0002, batch_seqs=16, passes=1, grad_clip=1.0
+hybrid_optimizer: muon_momentum=0.99, muon_momentum_warmup=0.85->0.99 over 500 steps, muon_backend_steps=5, muon_nesterov=True
+Val tokens: 40,534,016 (full: 40,534,016)
+FFN instantiated on layers: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9] / 10
+Model parameters: 45,651,000
+S4D init applied to 9 module(s), skipped 0
+Pre-cast 53 parameters to torch.bfloat16
+torch_compile: enabled
+Optimizer split: matrix=45 (Muon), scalar/control=106 (AdamW), embed=1 (AdamW)
+Muon config: muon_only_2d=1 eligible_2d=45 eligible_nd=9
+Training for up to 20000 steps (cap=600.0s)
+Replay: will reset data stream at 0% wall time
+step:1/20000 loss:9.0139 lr:0.000 tok/s_inst:23203 tok/s_avg:23203
+step:2/20000 loss:9.0143 lr:0.050 tok/s_inst:3423961 tok/s_avg:46093
+step:3/20000 loss:8.9337 lr:0.100 tok/s_inst:4177439 tok/s_avg:68760
+step:4/20000 loss:8.6914 lr:0.150 tok/s_inst:4204589 tok/s_avg:91183
+step:5/20000 loss:8.2330 lr:0.200 tok/s_inst:4218543 tok/s_avg:113366
+step:500/20000 loss:3.3658 lr:1.000 tok/s_inst:3831194 tok/s_avg:2885047
+step:1000/20000 loss:3.2679 lr:1.000 tok/s_inst:3795676 tok/s_avg:3278299
+step:1500/20000 loss:3.1632 lr:0.972 tok/s_inst:3952296 tok/s_avg:3475883
+step:2000/20000 loss:3.1221 lr:0.838 tok/s_inst:3909348 tok/s_avg:3574981
+step:2500/20000 loss:3.0176 lr:0.633 tok/s_inst:3773212 tok/s_avg:3612943
+step:3000/20000 loss:2.8015 lr:0.382 tok/s_inst:3974155 tok/s_avg:3668515
+step:3500/20000 loss:3.0344 lr:0.164 tok/s_inst:3631369 tok/s_avg:3663162
+step:4000/20000 loss:2.8274 lr:0.025 tok/s_inst:3657947 tok/s_avg:3662509
+Training complete: 4300 steps in 611.0s
+stopping_early: wallclock_cap at step 4300/20000
+All ranks synced. Starting evaluation...
+Final val_loss:2.8551 val_bpb:1.1053
+Best (standard): live val_loss:2.8551 val_bpb:1.1053
+Running sliding window eval (stride=64)...
+  sliding_eval: 10% (494/4947 batches, eta:217s)
+  sliding_eval: 20% (988/4947 batches, eta:193s)
+  sliding_eval: 30% (1482/4947 batches, eta:169s)
+  sliding_eval: 40% (1976/4947 batches, eta:144s)
+  sliding_eval: 50% (2470/4947 batches, eta:120s)
+  sliding_eval: 60% (2964/4947 batches, eta:96s)
+  sliding_eval: 70% (3458/4947 batches, eta:72s)
+  sliding_eval: 80% (3952/4947 batches, eta:48s)
+  sliding_eval: 90% (4446/4947 batches, eta:24s)
+  sliding_eval: 100% (4940/4947 batches, eta:0s)
+  sliding_eval: 79152 windows/rank, stride=64, 5065728 scored tokens, 240.4s
+Sliding val_loss:2.8426 val_bpb:1.1005
+Sliding vs standard: bpb=+0.0048
+Quantizing model with aggressive role-bit packing + LZMA...
+Quant candidate prune=0.000: compressed=16,094,692 bytes, raw=26,861,569, packed_bytes=26,235,904, byte_q=0, ones=0, pruned=0
+Selected quant prune=0.000: byte_q_tensors=0, packed_q_tensors=44, passthrough=108, alias=1, packed_bytes=26,235,904, byte_q_numel=0, approx_payload=25.55 MiB
+Role quantized numel: {'embedding': 6029312, 'mamba': 14819328, 'ffn_gate': 15728640, 'ffn_down': 7864320, 'attention': 1048576}
+Role packed/byte payload bytes: {'embedding': 4521984, 'mamba': 9262080, 'ffn_gate': 7864320, 'ffn_down': 3932160, 'attention': 655360}
+Serialized raw torch.save: 26,861,569 bytes (25.62 MiB)
+Compressed model (lzma9+extreme): 16,094,692 bytes (15.35 MiB)
+Artifact size check: OVER 16,000,000-byte cap before code bytes
+Post-quant val_loss:3.3542 val_bpb:1.2985
+  sliding_eval: 10% (494/4947 batches, eta:213s)
+  sliding_eval: 20% (988/4947 batches, eta:190s)
+  sliding_eval: 30% (1482/4947 batches, eta:166s)
+  sliding_eval: 40% (1976/4947 batches, eta:142s)
+  sliding_eval: 50% (2470/4947 batches, eta:119s)
+  sliding_eval: 60% (2964/4947 batches, eta:95s)
+  sliding_eval: 70% (3458/4947 batches, eta:71s)
+  sliding_eval: 80% (3952/4947 batches, eta:48s)
+  sliding_eval: 90% (4446/4947 batches, eta:24s)
+  sliding_eval: 100% (4940/4947 batches, eta:0s)
+  sliding_eval: 79152 windows/rank, stride=64, 5065728 scored tokens, 237.2s
+Post-quant sliding val_loss:3.3421 val_bpb:1.2938
+Saved artifact: final_model.fullmuon_aggressive_lzma.lzma (16,094,692 bytes)
+[W501 00:27:31.032137418 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.079432880 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.271485906 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.282026257 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.287913253 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.354487033 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.355751523 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+[W501 00:27:31.545105876 AllocatorConfig.cpp:28] Warning: PYTORCH_CUDA_ALLOC_CONF is deprecated, use PYTORCH_ALLOC_CONF instead (function operator())
+root@e24cbb578f3c:/workspace/parameter-golf# CUDA_VISIBLE_DEVICES=0,1,2,3,4,5,6,7 \
+SEQ_LEN=8192 \
+N_UNIQUE_BLOCKS=10 \
+ATTN_LAYER_IDXS=6 \
+FFN_MULT=3 \
+FFN_ACTIVE_POLICY=all \
+EMBED_DIM=512 \
+BIGRAM_ENABLED=1 \
+HEADDIM=64 \
+DT_MIN=0.0005 \
+DT_MAX=0.05 \
+SEQ_IDX_ENABLED=1 \
+DOC_BOUNDARY_TOKEN=1 \
+CARRYOVER_EVAL_ENABLED=0 \
+SCORE_FIRST_TTT_ENABLED=0 \
+TTT_ENABLED=0 \
+RUN_POSTQUANT=1 \
+MUON_TRUST_CLIP_ENABLED=1 \
+MUON_TRUST_FFN=0.020 \
+MUON_TRUST_ATTN=0.015 \
+MUON_TRUST_MAMBA_IN=0.008 \
+MUON_TRUST_MAMBA_OUT=0.008 \
+MUON_TRUST_EMBED_PROJ=0.010 \
+MUON_TRUST_BIGRAM=0.010 \
+MUON_TRUST_GENERIC=0.010 \
+QUANT_FORMAT=fullmuon_aggressive_lzma \
+QUANT_TARGET_BYTES=15850000 \
+MAX_WALLCLOCK_SECONDS=600 \
+torchrun --standalone --nproc_per_node=8 \
+ssm_recall_sota_sp8192_fullmuon_final_compress_trustclip.py \
+| tee /workspace/fullmuon_final_compress_trustclip.log
+W0501 00:27:42.509000 202732 torch/distributed/run.py:803] 
+W0501 00:27:42.509000 202732 torch/distributed/run.py:803] *****************************************
+W0501 00:27:42.509000 202732 torch/distributed/run.py:803] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0501 00:27:42.509000 202732 torch/distributed/run.py:803] *****************************************
+Project root: /workspace/parameter-golf-repo

--- a/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-30_SP8192_Mamba2_HybridSSM_TiedEmbed/train_gpt.py
@@ -1,0 +1,3114 @@
+import copy
+from contextlib import nullcontext
+import glob
+import math
+import os
+import pickle
+import random
+import subprocess
+import sys
+import time
+import threading
+import queue
+import zlib
+import lzma
+import io
+try:
+    import zstandard
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn as nn
+import torch.nn.functional as F
+from torch.nn.parallel import DistributedDataParallel as DDP
+from mamba_ssm.modules.mamba2 import Mamba2
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except Exception:
+    InferenceParams = None
+# Direct-kernel state carryover path. Mamba2.forward's inference cache path can
+# fall back to token-wise step() or fail to thread chunk-scan initial_states;
+# mamba_chunk_scan_combined exposes initial_states / return_final_states directly.
+try:
+    from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
+    _HAS_CHUNK_SCAN = True
+except Exception:
+    mamba_chunk_scan_combined = None
+    _HAS_CHUNK_SCAN = False
+try:
+    from einops import rearrange
+except Exception:
+    rearrange = None
+
+# Strictly require fused CUDA kernels from mamba_ssm.
+try:
+    import selective_scan_cuda  # type: ignore  # noqa: F401
+    import causal_conv1d_cuda  # type: ignore  # noqa: F401
+except Exception as e:
+    raise RuntimeError(
+        "mamba_ssm CUDA kernels are unavailable. Install matching CUDA build of "
+        "`mamba-ssm` and `causal-conv1d` for this PyTorch/CUDA environment."
+    ) from e
+
+# Memory allocator config — set before any CUDA allocation
+os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
+
+try:
+    import torch._dynamo
+    torch._dynamo.config.cache_size_limit = max(getattr(torch._dynamo.config, "cache_size_limit", 8), 64)
+    torch._dynamo.config.accumulated_cache_size_limit = max(getattr(torch._dynamo.config, "accumulated_cache_size_limit", 64), 256)
+except Exception:
+    pass
+
+# -----------------------------------------------------------------------------
+# Config
+# -----------------------------------------------------------------------------
+# Clean ablation: uploaded best architecture with only SSM correctness fixes.
+# Default keeps the original FFN-everywhere model; set FFN_ACTIVE_POLICY for sparse FFN experiments.
+DATA_PATH = "./data/datasets/fineweb10B_sp8192"
+TOK_PATH = "./data/tokenizers/fineweb_8192_bpe.model"
+VOCAB_SIZE = 8192
+SEQ_LEN = int(os.environ.get("SEQ_LEN", "2048"))
+TRAIN_SHARDS = int(os.environ.get("TRAIN_SHARDS", "80"))
+DOWNLOAD_DATA = os.environ.get("DOWNLOAD_DATA", "0") == "1"
+USE_ASYNC_LOADER = os.environ.get("USE_ASYNC_LOADER", "1") == "1"
+# sp8192 lives in a fork — set MATCHED_FINEWEB_REPO_ID=kevclark/parameter-golf
+os.environ.setdefault("MATCHED_FINEWEB_REPO_ID", "kevclark/parameter-golf")
+
+# SSM architecture
+D_MODEL = 512
+D_STATE = int(os.environ.get("D_STATE", "64"))
+N_UNIQUE_BLOCKS = int(os.environ.get("N_UNIQUE_BLOCKS", "10"))
+N_UNROLLS = int(os.environ.get("N_UNROLLS", "1"))
+CONV_KERNEL = 4
+# Explicit Mamba2 knobs. These match the newer runs and avoid relying on Mamba2 defaults.
+HEADDIM = int(os.environ.get("HEADDIM", "64"))
+DT_MIN = float(os.environ.get("DT_MIN", "0.0005"))
+DT_MAX = float(os.environ.get("DT_MAX", "0.05"))
+FFN_MULT = int(os.environ.get("FFN_MULT", "3"))
+FFN_EVERY = int(os.environ.get("FFN_EVERY", "1"))  # Run FFN every Nth layer/unroll
+FFN_FREQ_MODE = os.environ.get("FFN_FREQ_MODE", "layer").lower()  # "layer" or "unroll"
+# Parameter-saving FFN placement policy.
+# Default: original uploaded-best behavior, independent FFN in every block.
+# Options: attn_final, attention, final, all, none, or custom via FFN_ACTIVE_IDXS.
+FFN_ACTIVE_POLICY = os.environ.get("FFN_ACTIVE_POLICY", "all").lower()
+FFN_ACTIVE_IDXS_RAW = os.environ.get("FFN_ACTIVE_IDXS", "")
+MEMORY_DIM = 256
+LOGIT_SOFTCAP = 30.0
+EMBED_INIT_STD = 0.005
+USE_MEMORY = os.environ.get("USE_MEMORY", "0") == "1"
+USE_TORCH_COMPILE = os.environ.get("USE_TORCH_COMPILE", "1") == "1"
+
+# Document-boundary reset for Mamba2 chunk scan. The SP8192 tokenizer uses <s>
+# as token 1. Packed rows contain many document starts; seq_idx bounds SSM state
+# contamination instead of letting one document's state flow through the whole row.
+SEQ_IDX_ENABLED = os.environ.get("SEQ_IDX_ENABLED", "1") == "1"
+DOC_BOUNDARY_TOKEN = int(os.environ.get("DOC_BOUNDARY_TOKEN", "1"))
+
+# Optional direct-kernel carryover helpers. The method is implemented even if
+# carryover eval is not enabled in this file.
+CARRYOVER_EVAL_ENABLED = os.environ.get("CARRYOVER_EVAL_ENABLED", "0") == "1"
+CARRYOVER_BLOCK_LEN = int(os.environ.get("CARRYOVER_BLOCK_LEN", str(SEQ_LEN)))
+CARRYOVER_OVERLAP = int(os.environ.get("CARRYOVER_OVERLAP", "1024"))
+CARRYOVER_WARMUP_TOKENS = int(os.environ.get("CARRYOVER_WARMUP_TOKENS", "0"))
+CARRYOVER_DIRECT_KERNEL = os.environ.get("CARRYOVER_DIRECT_KERNEL", "1") == "1"
+
+# Factored embedding: tok_emb at EMBED_DIM, project to D_MODEL.
+# Saves params at vocab=8192. SOTA uses similar factoring (kev's 8192 setup).
+EMBED_DIM = int(os.environ.get("EMBED_DIM", "512"))  # best current: factored 512
+
+# Hybrid attention config
+ATTN_LAYER_IDXS = [int(x) for x in os.environ.get("ATTN_LAYER_IDXS", "6").split(",") if x.strip()]
+
+def _resolve_ffn_active_idxs():
+    if FFN_ACTIVE_IDXS_RAW.strip():
+        return sorted({int(x) for x in FFN_ACTIVE_IDXS_RAW.split(",") if x.strip()})
+    policy = FFN_ACTIVE_POLICY
+    if policy in ("attn_final", "attention_final", "attn+final"):
+        return sorted(set(ATTN_LAYER_IDXS) | {N_UNIQUE_BLOCKS - 1})
+    if policy in ("attention", "attn"):
+        return sorted(set(ATTN_LAYER_IDXS))
+    if policy == "final":
+        return [N_UNIQUE_BLOCKS - 1]
+    if policy == "all":
+        return list(range(N_UNIQUE_BLOCKS))
+    if policy in ("none", "off"):
+        return []
+    raise ValueError(f"Unknown FFN_ACTIVE_POLICY={FFN_ACTIVE_POLICY!r}")
+
+FFN_ACTIVE_IDXS = _resolve_ffn_active_idxs()
+ATTN_N_HEADS = int(os.environ.get("ATTN_N_HEADS", "8"))
+QK_GAIN_INIT = float(os.environ.get("QK_GAIN_INIT", "5.25"))  # best current: learnable per-head query scaling
+
+# Activation choice
+ACTIVATION = os.environ.get("ACTIVATION", "swiglu").lower()  # "swiglu" or "leaky_relu2"
+
+# Depth recurrence — loop layers [LOOP_START..LOOP_END] inclusive twice during decoder phase
+LOOP_START = int(os.environ.get("LOOP_START", "-1"))  # -1 = disabled
+LOOP_END = int(os.environ.get("LOOP_END", "-1"))      # inclusive
+LOOP_ACTIVATE_FRAC = float(os.environ.get("LOOP_ACTIVATE_FRAC", "0.35"))
+
+# Training
+ITERATIONS = int(os.environ.get("ITERATIONS", "20000"))
+VAL_EVERY = int(os.environ.get("VAL_EVERY", "0"))  # 0=final only (each val costs ~100 steps)
+LOG_EVERY = int(os.environ.get("LOG_EVERY", "500"))
+GRAD_CLIP = float(os.environ.get("GRAD_CLIP", "0.3"))
+STREAM_CHUNKS = int(os.environ.get("STREAM_CHUNKS", "1"))
+BPTT_CHUNKS = int(os.environ.get("BPTT_CHUNKS", "1"))
+MIXED_LENGTH_CURRICULUM = os.environ.get("MIXED_LENGTH_CURRICULUM", "0") == "1"
+CURRICULUM_STEPS = int(os.environ.get("CURRICULUM_STEPS", "1500"))
+SEED = int(os.environ.get("SEED", "7"))
+MAX_WALLCLOCK_SECONDS = float(os.environ.get("MAX_WALLCLOCK_SECONDS", "600"))
+
+# LR schedule: short warmup, then long warmdown (matching competitive GPT config)
+WARMUP_STEPS = int(os.environ.get("WARMUP_STEPS", "20"))
+LR_MIN_SCALE = float(os.environ.get("LR_MIN_SCALE", "0.0"))
+LR_SCHEDULE = os.environ.get("LR_SCHEDULE", "cosine_late")
+LR_WARMDOWN_START_FRAC = float(os.environ.get("LR_WARMDOWN_START_FRAC", "0.28"))  # SOTA: 0.72 of training is warmdown
+
+# SWA (Stochastic Weight Averaging) — collect checkpoints from late warmdown
+SWA_ENABLED = os.environ.get("SWA_ENABLED", "0") == "1"
+SWA_START_FRAC = float(os.environ.get("SWA_START_FRAC", "0.15"))  # collect from last 15%
+SWA_EVERY = int(os.environ.get("SWA_EVERY", "50"))  # checkpoint every N steps
+
+# EMA — SOTA submission uses EMA with decay 0.9965 successfully
+EMA_ENABLED = os.environ.get("EMA_ENABLED", "0") == "1"
+EMA_DECAY = float(os.environ.get("EMA_DECAY", "0.9965"))
+
+# Batch size warmup
+BATCH_WARMUP_STEPS = int(os.environ.get("BATCH_WARMUP_STEPS", "0"))
+BATCH_WARMUP_FRAC = float(os.environ.get("BATCH_WARMUP_FRAC", "0.25"))
+
+# BigramHash embedding
+BIGRAM_ENABLED = os.environ.get("BIGRAM_ENABLED", "1") == "1"
+BIGRAM_BUCKETS = int(os.environ.get("BIGRAM_BUCKETS", "10240"))
+BIGRAM_DIM = int(os.environ.get("BIGRAM_DIM", "128"))
+
+# Sliding window eval — stride < SEQ_LEN gives each token more context
+EVAL_STRIDE = int(os.environ.get("EVAL_STRIDE", "64"))  # 64 matches SOTA
+
+# Post-training quant/artifact path.
+# Final compression attempt for the proven Option-A full-Muon baseline:
+#   - Full-FFN clean architecture and optimizer are unchanged.
+#   - FFN gate_up is aggressively packed INT3.
+#   - FFN down is packed INT4.
+#   - Mamba matrices are packed INT4 with Mamba2 dt rows stored as protected INT8 sidecars.
+#   - Attention qkv/out are packed INT5.
+#   - Embeddings/bigram/embed projections are packed INT6 with optional opt-clip.
+#   - Small/control tensors stay fp16.
+#   - Container compression: LZMA-9 extreme.
+RUN_POSTQUANT = os.environ.get("RUN_POSTQUANT", "1") == "1"
+QUANT_FORMAT = os.environ.get("QUANT_FORMAT", "fullmuon_aggressive_lzma").lower()
+QUANT_BITS_MATRIX = int(os.environ.get("QUANT_BITS_MATRIX", "5"))
+QUANT_BITS_FFN_GATE = int(os.environ.get("QUANT_BITS_FFN_GATE", "3"))
+QUANT_BITS_FFN_DOWN = int(os.environ.get("QUANT_BITS_FFN_DOWN", "4"))
+QUANT_BITS_MAMBA = int(os.environ.get("QUANT_BITS_MAMBA", "4"))
+QUANT_BITS_ATTN = int(os.environ.get("QUANT_BITS_ATTN", "5"))
+QUANT_BITS_EMBED = int(os.environ.get("QUANT_BITS_EMBED", "6"))
+QUANT_PACK_ALL = os.environ.get("QUANT_PACK_ALL", "1") == "1"
+QUANT_PASSTHROUGH_NUMEL = int(os.environ.get("QUANT_PASSTHROUGH_NUMEL", "65536"))
+QUANT_K_MATRIX = float(os.environ.get("QUANT_K_MATRIX", "12.85"))
+QUANT_K_FFN_GATE = float(os.environ.get("QUANT_K_FFN_GATE", str(QUANT_K_MATRIX)))
+QUANT_K_FFN_DOWN = float(os.environ.get("QUANT_K_FFN_DOWN", str(QUANT_K_MATRIX)))
+QUANT_K_MAMBA = float(os.environ.get("QUANT_K_MAMBA", str(QUANT_K_MATRIX)))
+QUANT_K_ATTN = float(os.environ.get("QUANT_K_ATTN", str(QUANT_K_MATRIX)))
+QUANT_K_EMBED = float(os.environ.get("QUANT_K_EMBED", "20.0"))
+QUANT_SCALE_FLOOR_MULT = float(os.environ.get("QUANT_SCALE_FLOOR_MULT", "1.0"))
+QUANT_PROTECT_DYNAMICS = os.environ.get("QUANT_PROTECT_DYNAMICS", "1") == "1"
+QUANT_OPTCLIP_EMBED = os.environ.get("QUANT_OPTCLIP_EMBED", "1") == "1"
+QUANT_OPTCLIP_STEPS = int(os.environ.get("QUANT_OPTCLIP_STEPS", "8"))
+QUANT_OPTCLIP_MIN_FRAC = float(os.environ.get("QUANT_OPTCLIP_MIN_FRAC", "0.55"))
+QUANT_OPTCLIP_MAX_FRAC = float(os.environ.get("QUANT_OPTCLIP_MAX_FRAC", "1.00"))
+QUANT_PRUNE_ONES_FRAC = float(os.environ.get("QUANT_PRUNE_ONES_FRAC", "0.0"))
+QUANT_AUTO_PRUNE_TO_BYTES = os.environ.get("QUANT_AUTO_PRUNE_TO_BYTES", "1") == "1"
+QUANT_TARGET_BYTES = int(os.environ.get("QUANT_TARGET_BYTES", "15850000"))
+QUANT_AUTO_PRUNE_FRACS = [float(x) for x in os.environ.get("QUANT_AUTO_PRUNE_FRACS", "0,0.25,0.40,0.55,0.70,0.85").split(",") if x.strip()]
+QUANT_LZMA_PRESET = int(os.environ.get("QUANT_LZMA_PRESET", "9"))
+QUANT_LZMA_EXTREME = os.environ.get("QUANT_LZMA_EXTREME", "1") == "1"
+
+# Profiling
+PROFILE_ENABLED = os.environ.get("PROFILE", "0") == "1"
+PROFILE_START = int(os.environ.get("PROFILE_START", "3"))
+PROFILE_END = int(os.environ.get("PROFILE_END", "8"))
+PROFILE_DIR = os.environ.get("PROFILE_DIR", "./profile_traces")
+
+# Optimizer — higher LRs for 42M model, matching SOTA WD
+MATRIX_LR = float(os.environ.get("MATRIX_LR", "0.022"))  # SOTA: 0.022
+SCALAR_LR = float(os.environ.get("SCALAR_LR", "0.02"))   # SOTA: 0.02
+EMBED_LR = float(os.environ.get("EMBED_LR", "0.03"))     # SOTA: tied_embed_lr=0.03
+BETA1, BETA2 = 0.9, 0.95
+ADAM_EPS = 1e-8
+WEIGHT_DECAY = float(os.environ.get("WEIGHT_DECAY", "0.095"))  # SOTA: muon_wd=0.095
+ENABLE_S4D_INIT = os.environ.get("ENABLE_S4D_INIT", "1") == "1"
+
+# Test-Time Training (TTT) — global adaptation on val distribution
+TTT_ENABLED = os.environ.get("TTT_ENABLED", "0") == "1"
+TTT_STEPS = int(os.environ.get("TTT_STEPS", "5"))
+TTT_LR = float(os.environ.get("TTT_LR", "1e-3"))
+TTT_PREFIX_FRAC = float(os.environ.get("TTT_PREFIX_FRAC", "0.5"))
+# Which params to adapt: "norms", "in_proj", "all_linear", "all"
+TTT_PARAMS = os.environ.get("TTT_PARAMS", "in_proj")
+TTT_MAX_SEQS = int(os.environ.get("TTT_MAX_SEQS", "256"))  # max seqs per rank (0=all)
+# Global TTT: adapt on entire val set as LM training, then re-evaluate
+TTT_GLOBAL_STEPS = int(os.environ.get("TTT_GLOBAL_STEPS", "10"))
+TTT_GLOBAL_LR = float(os.environ.get("TTT_GLOBAL_LR", "2e-4"))
+TTT_GLOBAL_BATCH_SEQS = int(os.environ.get("TTT_GLOBAL_BATCH_SEQS", "16"))
+TTT_GLOBAL_GRAD_CLIP = float(os.environ.get("TTT_GLOBAL_GRAD_CLIP", "1.0"))
+TTT_GLOBAL_PASSES = int(os.environ.get("TTT_GLOBAL_PASSES", "1"))  # passes over val set
+
+# Score-First TTT (SOTA-style legal eval-time adaptation)
+SCORE_FIRST_TTT_ENABLED = os.environ.get("SCORE_FIRST_TTT_ENABLED", "0") == "1"
+SCORE_FIRST_TTT_CHUNK_TOKENS = int(os.environ.get("SCORE_FIRST_TTT_CHUNK_TOKENS", "32768"))
+SCORE_FIRST_TTT_LR = float(os.environ.get("SCORE_FIRST_TTT_LR", "0.005"))
+SCORE_FIRST_TTT_MOMENTUM = float(os.environ.get("SCORE_FIRST_TTT_MOMENTUM", "0.9"))
+SCORE_FIRST_TTT_EPOCHS = int(os.environ.get("SCORE_FIRST_TTT_EPOCHS", "3"))
+SCORE_FIRST_TTT_GRAD_CLIP = float(os.environ.get("SCORE_FIRST_TTT_GRAD_CLIP", "1.0"))
+MUON_MOMENTUM = float(os.environ.get("MUON_MOMENTUM", "0.99"))
+MUON_MOMENTUM_WARMUP_START = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", "0.85"))
+MUON_MOMENTUM_WARMUP_STEPS = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", "500"))
+MUON_BACKEND_STEPS = int(os.environ.get("MUON_BACKEND_STEPS", "5"))
+MUON_NESTEROV = os.environ.get("MUON_NESTEROV", "1") == "1"
+MUON_ONLY_2D = os.environ.get("MUON_ONLY_2D", "1") == "1"
+
+if D_STATE > 256:
+    raise RuntimeError(
+        f"D_STATE={D_STATE} is unsupported by the fused mamba_ssm kernel in this build. "
+        "Please set D_STATE <= 256 (e.g., D_STATE=256)."
+    )
+
+CTRL_PATTERNS = (
+    "ssm_scale",
+    "mlp_scale",
+    "attn_scale",
+    "resid_mix",
+    "mem_to_model",
+    "mem_in_gate",
+    "memory_proj",
+    "memory_gate",
+    "q_gain",
+)
+
+# -----------------------------------------------------------------------------
+# Distributed setup (strict 6xGPU)
+# -----------------------------------------------------------------------------
+assert torch.cuda.is_available(), "CUDA is required."
+DISTRIBUTED = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+RANK = int(os.environ.get("RANK", "0"))
+WORLD_SIZE = int(os.environ.get("WORLD_SIZE", "8"))
+LOCAL_RANK = int(os.environ.get("LOCAL_RANK", "0"))
+
+if not DISTRIBUTED:
+    raise RuntimeError(
+        "This script requires torchrun distributed launch. "
+        "Example: torchrun --standalone --nproc_per_node=8 ssm_recall_tied64.py"
+    )
+if WORLD_SIZE != 8:
+    raise RuntimeError(f"Expected WORLD_SIZE=8, got WORLD_SIZE={WORLD_SIZE}")
+
+torch.cuda.set_device(LOCAL_RANK)
+if not dist.is_initialized():
+    dist.init_process_group(backend="nccl", device_id=torch.device("cuda", LOCAL_RANK))
+DEVICE = torch.device("cuda", LOCAL_RANK)
+MASTER_PROCESS = RANK == 0
+AMP_DTYPE = torch.bfloat16 if torch.cuda.is_bf16_supported() else torch.float16
+
+torch.backends.cuda.matmul.allow_tf32 = True
+torch.backends.cudnn.allow_tf32 = True
+torch.set_float32_matmul_precision("high")
+
+
+def log0(msg: str):
+    if MASTER_PROCESS:
+        print(msg, flush=True)
+
+
+def ensure_repo_root() -> Path:
+    repo_url = os.environ.get("REPO_URL", "https://github.com/openai/parameter-golf.git")
+    clone_dir = Path(os.environ.get("REPO_CLONE_DIR", "/workspace/parameter-golf-repo")).resolve()
+    candidates = [Path.cwd().resolve(), Path(__file__).resolve().parent, clone_dir]
+    for c in candidates:
+        if (c / "data" / "cached_challenge_fineweb.py").exists():
+            return c
+    if MASTER_PROCESS:
+        log0(f"Repo not found locally, cloning from {repo_url} -> {clone_dir}")
+        if not clone_dir.exists():
+            subprocess.run(["git", "clone", repo_url, str(clone_dir)], check=True)
+        elif not (clone_dir / ".git").exists():
+            raise RuntimeError(f"REPO_CLONE_DIR exists but is not a git repo: {clone_dir}")
+    dist.barrier()
+    if not (clone_dir / "data" / "cached_challenge_fineweb.py").exists():
+        raise RuntimeError(
+            "Could not locate data/cached_challenge_fineweb.py. "
+            "Set REPO_CLONE_DIR to a valid parameter-golf checkout."
+        )
+    return clone_dir
+
+
+PROJECT_ROOT = ensure_repo_root()
+os.chdir(PROJECT_ROOT)
+log0(f"Project root: {PROJECT_ROOT}")
+
+
+def gather_gpu_inventory():
+    props = torch.cuda.get_device_properties(DEVICE)
+    local = {
+        "rank": RANK,
+        "local_rank": LOCAL_RANK,
+        "name": props.name,
+        "total_mem_gb": round(props.total_memory / (1024**3), 2),
+    }
+    all_inv = [None for _ in range(WORLD_SIZE)]
+    dist.all_gather_object(all_inv, local)
+    if MASTER_PROCESS:
+        print("GPU inventory:")
+        for row in all_inv:
+            print(row)
+        bad = [row for row in all_inv if "H100" not in row["name"]]
+        if bad:
+            raise RuntimeError(f"Non-H100 devices detected: {bad}")
+
+
+gather_gpu_inventory()
+
+# ---------------------------------------------------------------------------
+# Batch config
+# ---------------------------------------------------------------------------
+TOK_PER_RANK_TARGET = int(os.environ.get("TOK_PER_RANK", "65536"))
+GRAD_ACCUM = int(os.environ.get("GRAD_ACCUM", "1"))
+TRAIN_BATCH_TOK = TOK_PER_RANK_TARGET * WORLD_SIZE
+LOCAL_BATCH_TOK = TOK_PER_RANK_TARGET
+
+seed_offset = SEED + RANK
+random.seed(seed_offset)
+np.random.seed(seed_offset)
+torch.manual_seed(seed_offset)
+torch.cuda.manual_seed_all(seed_offset)
+
+EFF_LAYERS = N_UNIQUE_BLOCKS * N_UNROLLS
+log0(f"AMP dtype: {AMP_DTYPE}")
+log0(f"Config: {N_UNIQUE_BLOCKS} unique x {N_UNROLLS} unrolls = {EFF_LAYERS} effective layers")
+log0(f"d_model={D_MODEL}, d_state={D_STATE}, ffn_mult={FFN_MULT}, memory_dim={MEMORY_DIM}")
+log0(f"mamba2: headdim={HEADDIM}, nheads={(2*D_MODEL)//HEADDIM}, dt_min={DT_MIN}, dt_max={DT_MAX}")
+log0(f"seq_idx: enabled={SEQ_IDX_ENABLED}, doc_boundary_token={DOC_BOUNDARY_TOKEN} (-1 to disable)")
+log0(f"carryover_eval: enabled={CARRYOVER_EVAL_ENABLED}, block_len={CARRYOVER_BLOCK_LEN}, overlap={CARRYOVER_OVERLAP}, warmup_tokens={CARRYOVER_WARMUP_TOKENS}, direct_kernel={CARRYOVER_DIRECT_KERNEL}")
+log0(f"ffn_every={FFN_EVERY}, ffn_freq_mode={FFN_FREQ_MODE}")
+log0(f"ffn_active_policy={FFN_ACTIVE_POLICY}, ffn_active_idxs={FFN_ACTIVE_IDXS}")
+log0(f"train_batch_tok(global)={TRAIN_BATCH_TOK}, local_batch_tok={LOCAL_BATCH_TOK}, grad_accum={GRAD_ACCUM}")
+log0(f"effective_batch_tok/step={TRAIN_BATCH_TOK}, micro_batch_tok/rank={LOCAL_BATCH_TOK // max(GRAD_ACCUM, 1)}")
+log0(f"warmup_steps={WARMUP_STEPS}, iterations={ITERATIONS}, max_wallclock_seconds={MAX_WALLCLOCK_SECONDS}")
+log0(
+    f"lr_schedule={LR_SCHEDULE}, lr_min_scale={LR_MIN_SCALE}, "
+    f"enable_s4d_init={ENABLE_S4D_INIT}"
+)
+log0(f"stream_chunks={STREAM_CHUNKS}, bptt_chunks={BPTT_CHUNKS}")
+log0(
+    f"mixed_length_curriculum={int(MIXED_LENGTH_CURRICULUM)}, "
+    f"curriculum_steps={CURRICULUM_STEPS}"
+)
+log0(f"use_async_loader={USE_ASYNC_LOADER}")
+log0(f"use_memory={USE_MEMORY}, use_torch_compile={USE_TORCH_COMPILE}")
+log0(f"vocab={VOCAB_SIZE}, factored_embed_dim={EMBED_DIM} ({'enabled' if EMBED_DIM > 0 else 'disabled'})")
+log0(f"hybrid_attn: layer_idxs={ATTN_LAYER_IDXS}, n_heads={ATTN_N_HEADS}, qk_gain_init={QK_GAIN_INIT}")
+log0("compression_defaults: Option-A full-Muon baseline + aggressive role-bit packed LZMA artifact")
+log0(f"activation: {ACTIVATION}")
+log0(f"depth_recur: loop=[{LOOP_START}..{LOOP_END}] activate@{LOOP_ACTIVATE_FRAC}")
+log0(f"score_first_ttt: enabled={SCORE_FIRST_TTT_ENABLED}, chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, epochs={SCORE_FIRST_TTT_EPOCHS}")
+log0(f"bigram: enabled={BIGRAM_ENABLED}, buckets={BIGRAM_BUCKETS}, dim={BIGRAM_DIM}")
+log0(f"swa: enabled={SWA_ENABLED}, start_frac={SWA_START_FRAC}, every={SWA_EVERY}")
+log0(f"eval_stride={EVAL_STRIDE}")
+log0(f"postquant: run_postquant={RUN_POSTQUANT}")
+log0(
+    f"compression_quant: format={QUANT_FORMAT}, pack_all={QUANT_PACK_ALL}, "
+    f"bits(ffn_gate/down={QUANT_BITS_FFN_GATE}/{QUANT_BITS_FFN_DOWN}, "
+    f"mamba={QUANT_BITS_MAMBA}, attn={QUANT_BITS_ATTN}, embed={QUANT_BITS_EMBED}, other={QUANT_BITS_MATRIX}), "
+    f"passthrough_numel<={QUANT_PASSTHROUGH_NUMEL}, "
+    f"k(ffn_gate/down={QUANT_K_FFN_GATE}/{QUANT_K_FFN_DOWN}, mamba={QUANT_K_MAMBA}, "
+    f"attn={QUANT_K_ATTN}, embed={QUANT_K_EMBED}, other={QUANT_K_MATRIX}), "
+    f"scale_floor_mult={QUANT_SCALE_FLOOR_MULT}, protect_dynamics={QUANT_PROTECT_DYNAMICS}, "
+    f"optclip_embed={QUANT_OPTCLIP_EMBED}, prune_ones_frac={QUANT_PRUNE_ONES_FRAC}, "
+    f"auto_prune={QUANT_AUTO_PRUNE_TO_BYTES}, target_bytes={QUANT_TARGET_BYTES}, "
+    f"lzma_preset={QUANT_LZMA_PRESET}, extreme={QUANT_LZMA_EXTREME}"
+)
+log0(f"ema: enabled={EMA_ENABLED}, decay={EMA_DECAY}")
+log0(f"optimizer: matrix_lr={MATRIX_LR}, scalar_lr={SCALAR_LR}, embed_lr={EMBED_LR}, wd={WEIGHT_DECAY}, grad_clip={GRAD_CLIP}")
+log0(f"batch_warmup: steps={BATCH_WARMUP_STEPS}, start_frac={BATCH_WARMUP_FRAC}")
+log0(
+    f"ttt: enabled={TTT_ENABLED}, per_seq_steps={TTT_STEPS}, per_seq_lr={TTT_LR}, "
+    f"params={TTT_PARAMS}, max_seqs={TTT_MAX_SEQS}"
+)
+log0(
+    f"ttt_global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+    f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+    f"grad_clip={TTT_GLOBAL_GRAD_CLIP}"
+)
+log0(
+    f"hybrid_optimizer: muon_momentum={MUON_MOMENTUM}, "
+    f"muon_momentum_warmup={MUON_MOMENTUM_WARMUP_START}->{MUON_MOMENTUM} over {MUON_MOMENTUM_WARMUP_STEPS} steps, "
+    f"muon_backend_steps={MUON_BACKEND_STEPS}, muon_nesterov={MUON_NESTEROV}"
+)
+
+if GRAD_ACCUM < 1:
+    raise ValueError(f"GRAD_ACCUM must be >= 1, got {GRAD_ACCUM}")
+if STREAM_CHUNKS < 1:
+    raise ValueError(f"STREAM_CHUNKS must be >= 1, got {STREAM_CHUNKS}")
+if BPTT_CHUNKS < 1:
+    raise ValueError(f"BPTT_CHUNKS must be >= 1, got {BPTT_CHUNKS}")
+if SEQ_LEN % STREAM_CHUNKS != 0:
+    raise ValueError(f"SEQ_LEN ({SEQ_LEN}) must be divisible by STREAM_CHUNKS ({STREAM_CHUNKS})")
+
+
+# -----------------------------------------------------------------------------
+# Data — threaded async loader with pinned memory
+# -----------------------------------------------------------------------------
+def maybe_download_data():
+    if not DOWNLOAD_DATA:
+        dist.barrier()
+        return
+    if MASTER_PROCESS:
+        subprocess.run(
+            [sys.executable, "data/cached_challenge_fineweb.py",
+             "--variant", "sp8192", "--train-shards", str(TRAIN_SHARDS)],
+            check=True,
+        )
+        log0("Data download complete.")
+    dist.barrier()
+
+
+def load_data_shard(path):
+    header = np.fromfile(path, dtype="<i4", count=256)
+    assert header.size == 256 and int(header[0]) == 20240520 and int(header[1]) == 1
+    n = int(header[2])
+    offset = 256 * np.dtype("<i4").itemsize
+    return np.fromfile(path, dtype="<u2", count=n, offset=offset).astype(np.int32, copy=False)
+
+
+class TokenStream:
+    def __init__(self, pattern):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        assert self.files, f"No files for {pattern}"
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def reset(self):
+        """Reset to beginning of first shard — replays all previously seen tokens."""
+        self.idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance(self):
+        self.idx = (self.idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.idx])
+        self.pos = 0
+
+    def take(self, n, return_boundaries=False):
+        parts, left = [], n
+        boundaries = np.zeros(n, dtype=np.bool_) if return_boundaries else None
+        out_pos = 0
+        while left > 0:
+            if self.pos >= self.tokens.size:
+                self._advance()
+                if return_boundaries and out_pos < n:
+                    boundaries[out_pos] = True
+            k = min(left, self.tokens.size - self.pos)
+            parts.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            left -= k
+            out_pos += k
+        chunk = parts[0] if len(parts) == 1 else np.concatenate(parts)
+        if return_boundaries:
+            return chunk, boundaries
+        return chunk
+
+
+def build_chunk_reset_mask(boundaries, seq_len, stream_chunks):
+    """
+    Build per-sequence reset flags for each streamed chunk.
+    boundaries marks token positions in local stream where a new shard begins.
+    """
+    if stream_chunks <= 1:
+        return None
+    if seq_len % stream_chunks != 0:
+        raise ValueError(f"SEQ_LEN ({seq_len}) must be divisible by STREAM_CHUNKS ({stream_chunks})")
+    n_tokens = boundaries.size - 1  # x/y consume span-1 tokens
+    n_seqs = n_tokens // seq_len
+    chunk_len = seq_len // stream_chunks
+    reset = np.zeros((n_seqs, stream_chunks), dtype=np.bool_)
+    for s in range(n_seqs):
+        base = s * seq_len
+        for c in range(1, stream_chunks):
+            prev_end = base + (c * chunk_len)
+            prev_start = base + ((c - 1) * chunk_len)
+            if np.any(boundaries[prev_start + 1 : prev_end + 1]):
+                reset[s, c] = True
+    return reset
+
+
+class AsyncDistributedTokenLoader:
+    """
+    Background-threaded data loader:
+    - Worker thread reads from disk + slices numpy on CPU
+    - Pins tensors to page-locked memory
+    - Transfers to GPU on a dedicated CUDA stream
+    - Main thread picks up ready batches with zero wait
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len,
+                 grad_accum_steps, device, prefetch_depth=3):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+        self.cuda_stream = torch.cuda.Stream(device=device)
+
+        # Queue of ready (x_gpu, y_gpu) batches
+        self.ready_queue = queue.Queue(maxsize=prefetch_depth)
+        self.stop_event = threading.Event()
+
+        # Start background worker
+        self.worker = threading.Thread(target=self._worker_loop, daemon=True)
+        self.worker.start()
+
+    def _produce_one_batch(self):
+        """Read from disk, slice, pin, transfer to GPU."""
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+
+        # Create pinned tensors on CPU
+        x_cpu = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().pin_memory()
+        y_cpu = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().pin_memory()
+
+        # Async transfer on dedicated stream
+        with torch.cuda.stream(self.cuda_stream):
+            x_gpu = x_cpu.to(self.device, non_blocking=True)
+            y_gpu = y_cpu.to(self.device, non_blocking=True)
+            reset_gpu = (
+                torch.from_numpy(reset_np).to(self.device, non_blocking=True)
+                if reset_np is not None else None
+            )
+
+        # Record event so consumer knows when transfer is done
+        event = self.cuda_stream.record_event()
+        return x_gpu, y_gpu, reset_gpu, event
+
+    def _worker_loop(self):
+        """Continuously prefetch batches in background thread."""
+        while not self.stop_event.is_set():
+            try:
+                batch = self._produce_one_batch()
+                self.ready_queue.put(batch, timeout=1.0)
+            except queue.Full:
+                continue
+            except Exception:
+                if self.stop_event.is_set():
+                    break
+                raise
+
+    def next_batch(self):
+        """Get the next ready batch. Waits for GPU transfer to complete."""
+        x_gpu, y_gpu, reset_gpu, event = self.ready_queue.get()
+        event.wait()  # ensure H2D transfer finished
+        return x_gpu, y_gpu, reset_gpu
+
+    def reset_stream(self):
+        """Drain prefetch queue and reset token stream to replay from start."""
+        while not self.ready_queue.empty():
+            try:
+                self.ready_queue.get_nowait()
+            except queue.Empty:
+                break
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        self.stop_event.set()
+        self.worker.join(timeout=5)
+
+
+class DistributedTokenLoader:
+    """
+    Synchronous loader: deterministic and simpler collective behavior.
+    """
+    def __init__(self, pattern, rank, world_size, global_tokens, seq_len, grad_accum_steps, device):
+        self.stream_obj = TokenStream(pattern)
+        self.rank = rank
+        self.world_size = world_size
+        self.global_tokens = global_tokens
+        self.seq_len = seq_len
+        self.grad_accum_steps = grad_accum_steps
+        self.device = device
+
+    def next_batch(self):
+        local_tokens = self.global_tokens // (self.world_size * self.grad_accum_steps)
+        local_tokens = (local_tokens // self.seq_len) * self.seq_len
+        span = local_tokens + 1
+        chunk, boundaries = self.stream_obj.take(span * self.world_size, return_boundaries=True)
+        local = chunk[self.rank * span : (self.rank + 1) * span]
+        local_boundaries = boundaries[self.rank * span : (self.rank + 1) * span]
+        reset_np = build_chunk_reset_mask(local_boundaries, self.seq_len, STREAM_CHUNKS)
+        x = torch.from_numpy(local[:-1].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        y = torch.from_numpy(local[1:].reshape(-1, self.seq_len)).long().to(self.device, non_blocking=True)
+        reset = torch.from_numpy(reset_np).to(self.device, non_blocking=True) if reset_np is not None else None
+        return x, y, reset
+
+    def reset_stream(self):
+        """Reset token stream to replay from start."""
+        self.stream_obj.reset()
+
+    def shutdown(self):
+        return
+
+
+def load_val_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    assert files, f"No val files for {pattern}"
+    tokens = np.concatenate([load_data_shard(f) for f in files])
+    usable = ((tokens.size - 1) // seq_len) * seq_len
+    return tokens[: usable + 1]
+
+
+def build_sp_luts(sp, vocab_size):
+    sz = max(int(sp.vocab_size()), vocab_size)
+    base_bytes = np.zeros(sz, dtype=np.int16)
+    has_space = np.zeros(sz, dtype=np.bool_)
+    is_bound = np.ones(sz, dtype=np.bool_)
+    for tid in range(int(sp.vocab_size())):
+        if sp.is_control(tid) or sp.is_unknown(tid) or sp.is_unused(tid):
+            continue
+        is_bound[tid] = False
+        if sp.is_byte(tid):
+            base_bytes[tid] = 1
+            continue
+        piece = sp.id_to_piece(tid)
+        if piece.startswith("\u2581"):
+            has_space[tid] = True
+            piece = piece[1:]
+        base_bytes[tid] = len(piece.encode("utf-8"))
+    return base_bytes, has_space, is_bound
+
+
+# -----------------------------------------------------------------------------
+# Model — Hybrid Mamba2 + Sliding Window Attention
+# -----------------------------------------------------------------------------
+def rms_norm(x, eps=1e-6):
+    if hasattr(F, "rms_norm"):
+        return F.rms_norm(x, (x.shape[-1],), eps=eps)
+    return x * torch.rsqrt(x.pow(2).mean(dim=-1, keepdim=True) + eps)
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, d_model, eps=1e-6):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(d_model))
+
+    def forward(self, x):
+        return rms_norm(x, self.eps) * self.weight
+
+
+class SwiGLU_FFN(nn.Module):
+    """SwiGLU: gate * swish(gate_proj) * up_proj. LeakyReLU² variant if ACTIVATION='leaky_relu2'."""
+    def __init__(self, d_model, ffn_mult=3):
+        super().__init__()
+        hidden = d_model * ffn_mult
+        if ACTIVATION == "leaky_relu2":
+            # SOTA-style: single up matrix, leaky_relu(0.5)² activation
+            self.gate_up = nn.Linear(d_model, hidden, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = False
+        else:
+            # SwiGLU: fused gate + up
+            self.gate_up = nn.Linear(d_model, hidden * 2, bias=False)
+            self.down = nn.Linear(hidden, d_model, bias=False)
+            self.is_swiglu = True
+        nn.init.zeros_(self.down.weight)
+
+    def forward(self, x):
+        if self.is_swiglu:
+            gu = self.gate_up(x)
+            gate, up = gu.chunk(2, dim=-1)
+            return self.down(F.silu(gate) * up)
+        else:
+            h = F.leaky_relu(self.gate_up(x), negative_slope=0.5)
+            return self.down(h * h)  # LeakyReLU(0.5)²
+
+
+class SelectiveSSMBlock(nn.Module):
+    def __init__(self, d_model, d_state, memory_dim, conv_kernel=4, ffn_mult=3,
+                 has_ffn=True, layer_idx=None):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.layer_idx = layer_idx
+        self.mamba = Mamba2(
+            d_model=d_model,
+            d_state=d_state,
+            d_conv=conv_kernel,
+            expand=2,
+            headdim=HEADDIM,
+            dt_min=DT_MIN,
+            dt_max=DT_MAX,
+            layer_idx=layer_idx,
+        )
+        self.ssm_norm = RMSNorm(d_model)
+        self.ssm_scale = nn.Parameter(torch.ones(d_model))
+        if self.has_ffn:
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.ffn_norm = RMSNorm(d_model)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            # Parameter-saving path: no FFN weights/norm/scale for this block.
+            self.ffn = None
+            self.ffn_norm = None
+            self.mlp_scale = None
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+        # Memory params (only used if USE_MEMORY)
+        if USE_MEMORY:
+            self.mem_to_model = nn.Linear(memory_dim, d_model, bias=False)
+            self.mem_in_gate = nn.Parameter(torch.tensor(0.0))
+            self.memory_proj = nn.Linear(d_model, memory_dim, bias=False)
+            self.memory_gate = nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x, x0, mem, run_ffn=True, inference_params=None, seq_idx=None):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x + mem_mix * mem_ctx
+        else:
+            x_in = x
+        kwargs = {}
+        if inference_params is not None:
+            kwargs["inference_params"] = inference_params
+        if seq_idx is not None:
+            kwargs["seq_idx"] = seq_idx
+        y = self.mamba(self.ssm_norm(x_in), **kwargs)
+        x = x + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x, mem
+
+    def _mamba_forward_with_state(self, u, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """
+        Manual Mamba2 forward with explicit SSM-state carryover via
+        mamba_chunk_scan_combined(initial_states=..., return_final_states=True).
+
+        Returns (out, final_ssm_state, last_conv_input).
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not available; direct-kernel "
+                "Mamba2 carryover cannot run."
+            )
+        m = self.mamba
+        _, L, _ = u.shape
+
+        zxbcdt = m.in_proj(u)
+        d_inner = getattr(m, "d_inner", getattr(m, "d_ssm", None))
+        if d_inner is None:
+            raise RuntimeError("Mamba2 module does not expose d_inner/d_ssm; cannot split in_proj")
+        nheads = m.nheads
+        ngroups = getattr(m, "ngroups", 1)
+        d_state = m.d_state
+        d_conv = m.d_conv
+        headdim = m.headdim
+        chunk_size = m.chunk_size
+        conv_channels = d_inner + 2 * ngroups * d_state
+        rmsnorm = getattr(m, "rmsnorm", False)
+
+        full = zxbcdt.shape[-1]
+        expected_no_mlp = d_inner + conv_channels + nheads
+        d_mlp = (full - expected_no_mlp) // 2
+        if d_mlp > 0:
+            z0, x0_mlp, z, xBC, dt = torch.split(
+                zxbcdt, [d_mlp, d_mlp, d_inner, conv_channels, nheads], dim=-1
+            )
+        else:
+            z, xBC, dt = torch.split(zxbcdt, [d_inner, conv_channels, nheads], dim=-1)
+            z0 = x0_mlp = None
+
+        # Carry causal depthwise-conv state by prepending prior block's last
+        # d_conv-1 pre-conv inputs. This produces exactly L outputs.
+        xBC_t = xBC.transpose(1, 2).contiguous()
+        if prev_conv_input is not None and d_conv > 1:
+            prev_t = prev_conv_input.transpose(1, 2).contiguous()
+            xBC_padded = torch.cat([prev_t, xBC_t], dim=-1)
+            xBC_conv = F.conv1d(
+                xBC_padded, m.conv1d.weight, m.conv1d.bias,
+                stride=1, padding=0, dilation=1, groups=conv_channels
+            )
+        else:
+            xBC_conv = m.conv1d(xBC_t)[..., :L]
+        new_conv_input = xBC[:, -(d_conv - 1):, :].contiguous() if d_conv > 1 else None
+
+        xBC_conv = F.silu(xBC_conv).transpose(1, 2)
+        x, Bm, Cm = torch.split(
+            xBC_conv, [d_inner, ngroups * d_state, ngroups * d_state], dim=-1
+        )
+
+        x_r = rearrange(x, "b l (h p) -> b l h p", p=headdim)
+        Bm_r = rearrange(Bm, "b l (g n) -> b l g n", g=ngroups)
+        Cm_r = rearrange(Cm, "b l (g n) -> b l g n", g=ngroups)
+        A = -torch.exp(m.A_log.float())
+        z_for_scan = rearrange(z, "b l (h p) -> b l h p", p=headdim) if not rmsnorm else None
+
+        y, final_ssm_state = mamba_chunk_scan_combined(
+            x_r, dt, A, Bm_r, Cm_r,
+            chunk_size=chunk_size, D=m.D, z=z_for_scan,
+            dt_bias=m.dt_bias, dt_softplus=True,
+            initial_states=initial_ssm_state, seq_idx=seq_idx,
+            return_final_states=True,
+        )
+        y = rearrange(y, "b l h p -> b l (h p)")
+        if rmsnorm:
+            y = m.norm(y, z)
+        if d_mlp > 0:
+            y = torch.cat([F.silu(z0) * x0_mlp, y], dim=-1)
+        out = m.out_proj(y)
+        return out, final_ssm_state, new_conv_input
+
+    def forward_with_state(self, x, x0, mem, run_ffn, initial_ssm_state, prev_conv_input, seq_idx=None):
+        """Thread Mamba2 SSM and conv state across eval blocks."""
+        mix = self.resid_mix
+        x_mixed = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        if USE_MEMORY and mem is not None:
+            mem_ctx = self.mem_to_model(mem)[:, None, :]
+            mem_mix = torch.sigmoid(self.mem_in_gate)
+            x_in = x_mixed + mem_mix * mem_ctx
+        else:
+            x_in = x_mixed
+
+        y, final_ssm_state, last_conv_input = self._mamba_forward_with_state(
+            self.ssm_norm(x_in), initial_ssm_state, prev_conv_input, seq_idx=seq_idx
+        )
+        x_out = x_mixed + self.ssm_scale[None, None, :] * y
+        if self.has_ffn and run_ffn:
+            x_out = x_out + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x_out))
+        if USE_MEMORY and mem is not None:
+            new_mem = torch.tanh(self.memory_proj(x_out[:, -1, :]))
+            g = torch.sigmoid(self.memory_gate)
+            mem = g * mem + (1.0 - g) * new_mem
+        return x_out, mem, final_ssm_state, last_conv_input
+
+
+class CausalAttentionBlock(nn.Module):
+    """Causal attention with learnable per-head QK gain (SOTA: QK_GAIN_INIT=5.25)."""
+    def __init__(self, d_model, n_heads=8, ffn_mult=3, has_ffn=True):
+        super().__init__()
+        self.has_ffn = bool(has_ffn)
+        self.n_heads = n_heads
+        self.head_dim = d_model // n_heads
+
+        self.attn_norm = RMSNorm(d_model)
+        self.qkv = nn.Linear(d_model, 3 * d_model, bias=False)
+        self.out_proj = nn.Linear(d_model, d_model, bias=False)
+        nn.init.zeros_(self.out_proj.weight)
+
+        # Learnable per-head query gain (SOTA technique)
+        self.q_gain = nn.Parameter(torch.full((n_heads,), QK_GAIN_INIT))
+
+        if self.has_ffn:
+            self.ffn_norm = RMSNorm(d_model)
+            self.ffn = SwiGLU_FFN(d_model, ffn_mult)
+            self.mlp_scale = nn.Parameter(torch.ones(d_model))
+        else:
+            self.ffn_norm = None
+            self.ffn = None
+            self.mlp_scale = None
+        self.attn_scale = nn.Parameter(torch.ones(d_model))
+        self.resid_mix = nn.Parameter(torch.stack([torch.ones(d_model), torch.zeros(d_model)]))
+
+    def forward(self, x, x0, mem, run_ffn=True):
+        mix = self.resid_mix
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+
+        B, T, D = x.shape
+        normed = self.attn_norm(x)
+        qkv = self.qkv(normed).reshape(B, T, 3, self.n_heads, self.head_dim)
+        q, k, v = qkv.permute(2, 0, 3, 1, 4)  # (3, B, H, T, D_h)
+
+        # QK RMSNorm + learnable per-head query gain (SOTA)
+        q = F.rms_norm(q, (self.head_dim,))
+        k = F.rms_norm(k, (self.head_dim,))
+        q = q * self.q_gain.to(q.dtype)[None, :, None, None]
+
+        attn_out = F.scaled_dot_product_attention(q, k, v, is_causal=True)
+        attn_out = attn_out.transpose(1, 2).reshape(B, T, D)
+        x = x + self.attn_scale[None, None, :] * self.out_proj(attn_out)
+
+        if self.has_ffn and run_ffn:
+            x = x + self.mlp_scale[None, None, :] * self.ffn(self.ffn_norm(x))
+        return x, mem  # pass mem through unchanged
+
+
+class BigramHash(nn.Module):
+    """Hash consecutive token pairs into a learned embedding table."""
+    def __init__(self, vocab_size, n_buckets, bigram_dim, d_model):
+        super().__init__()
+        self.n_buckets = n_buckets
+        self.embed = nn.Embedding(n_buckets, bigram_dim)
+        self.proj = nn.Linear(bigram_dim, d_model, bias=False)
+        nn.init.normal_(self.embed.weight, std=0.01)
+        nn.init.normal_(self.proj.weight, std=0.01)
+
+    def forward(self, ids):
+        # ids: (B, T) token ids
+        # Compute bigram hashes: hash(ids[t-1], ids[t]) for each position
+        # For position 0, use a zero bigram (no previous token)
+        prev = F.pad(ids[:, :-1], (1, 0), value=0)  # (B, T) — shifted right, pad with 0
+        bigram_hash = (prev * 1009 + ids) % self.n_buckets  # simple hash
+        bigram_emb = self.embed(bigram_hash)  # (B, T, bigram_dim)
+        return self.proj(bigram_emb)  # (B, T, d_model)
+
+
+class SSM_LM(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.softcap = LOGIT_SOFTCAP
+        self.n_unrolls = N_UNROLLS
+        self.memory_dim = MEMORY_DIM
+
+        # Factored embedding for vocab=8192: tok_emb at EMBED_DIM, project to D_MODEL.
+        # Without factoring, vocab*D_MODEL=8192*512=4.2M params just for embeddings.
+        # With EMBED_DIM=256: tok_emb=2.1M + projections=131K+131K = ~2.4M (saves ~1.8M).
+        self.use_factored = EMBED_DIM > 0
+        if self.use_factored:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, EMBED_DIM)
+            self.embed_proj = nn.Linear(EMBED_DIM, D_MODEL, bias=False)
+            self.embed_proj_rev = nn.Linear(D_MODEL, EMBED_DIM, bias=False)
+            self.lm_head = nn.Linear(EMBED_DIM, VOCAB_SIZE, bias=False)
+        else:
+            self.tok_emb = nn.Embedding(VOCAB_SIZE, D_MODEL)
+            self.embed_proj = None
+            self.embed_proj_rev = None
+            self.lm_head = nn.Linear(D_MODEL, VOCAB_SIZE, bias=False)
+        with torch.no_grad():
+            self.tok_emb.weight.normal_(mean=0.0, std=EMBED_INIT_STD)
+        # Tied embeddings
+        self.lm_head.weight = self.tok_emb.weight
+
+        # BigramHash embedding
+        self.bigram = BigramHash(VOCAB_SIZE, BIGRAM_BUCKETS, BIGRAM_DIM, D_MODEL) if BIGRAM_ENABLED else None
+
+        # Build layers: SSM blocks + attention layers at specified positions
+        eff = N_UNIQUE_BLOCKS * N_UNROLLS
+        attn_set = set(ATTN_LAYER_IDXS)
+        layers = []
+        ffn_active_set = set(FFN_ACTIVE_IDXS)
+        for i in range(N_UNIQUE_BLOCKS):
+            has_ffn = i in ffn_active_set
+            if i in attn_set:
+                blk = CausalAttentionBlock(
+                    D_MODEL, ATTN_N_HEADS, FFN_MULT, has_ffn=has_ffn)
+                blk._is_ssm = False
+            else:
+                blk = SelectiveSSMBlock(
+                    D_MODEL, D_STATE, MEMORY_DIM, CONV_KERNEL, FFN_MULT, has_ffn=has_ffn, layer_idx=i)
+                blk._is_ssm = True
+            blk._has_ffn = has_ffn
+            layers.append(blk)
+        self.blocks = nn.ModuleList(layers)
+        self.ffn_active_idxs = sorted(ffn_active_set)
+        log0(f"FFN instantiated on layers: {self.ffn_active_idxs} / {N_UNIQUE_BLOCKS}")
+
+        self.n_enc = eff // 2
+        self.n_skip = min(self.n_enc, eff - self.n_enc)
+        self.skip_weights = nn.Parameter(torch.ones(self.n_skip, D_MODEL))
+        self.final_norm = RMSNorm(D_MODEL)
+
+        # Depth recurrence (SOTA): re-run a window of layers to gain virtual depth
+        # for free. Built-in indices: encoder visits each layer once; decoder loops
+        # the [LOOP_START..LOOP_END] window if enabled.
+        self.loop_enabled_external = False  # toggled at runtime by training loop
+        if LOOP_START >= 0 and LOOP_END >= LOOP_START:
+            # Build encoder/decoder layer index sequences with loop inserted in encoder.
+            # Mirroring SOTA: encoder=[0..LE, LS..LE-1], decoder=[LE, LS..N-1]
+            enc_seq = list(range(0, LOOP_END + 1)) + list(range(LOOP_START, LOOP_END))
+            dec_seq = [LOOP_END] + list(range(LOOP_START, N_UNIQUE_BLOCKS))
+            self.loop_enc_seq = enc_seq
+            self.loop_dec_seq = dec_seq
+        else:
+            self.loop_enc_seq = None
+            self.loop_dec_seq = None
+
+    def output_logits_from_hidden(self, hidden):
+        if self.use_factored:
+            flat_h = hidden.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, self.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, self.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden.reshape(-1, self.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, self.lm_head.weight.to(flat_h.dtype))
+        return self.softcap * torch.tanh(logits / self.softcap)
+
+    def _should_run_ffn(self, layer_pos, block_idx):
+        if FFN_ACTIVE_POLICY == "all":
+            if FFN_FREQ_MODE == "unroll":
+                return True
+            return (layer_pos % max(FFN_EVERY, 1)) == 0
+        return block_idx in self.ffn_active_idxs
+
+    def _make_seq_idx(self, ids):
+        if not (SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0):
+            return None
+        with torch.no_grad():
+            is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+            return torch.cumsum(is_boundary, dim=-1).to(torch.int32).contiguous()
+
+    def forward(self, ids, state=None, return_state=False, inference_params=None, seq_idx=None):
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None
+        if USE_MEMORY:
+            mem = None if state is None else state.get("mem", None)
+            if mem is None:
+                mem = torch.zeros(bsz, self.memory_dim, device=ids.device, dtype=x.dtype)
+            else:
+                mem = mem.to(device=ids.device, dtype=x.dtype)
+
+        if seq_idx is None:
+            seq_idx = self._make_seq_idx(ids)
+
+        # Pick layer sequence: looped or default
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            enc_indices = self.loop_enc_seq
+            dec_indices = self.loop_dec_seq
+        else:
+            half = N_UNIQUE_BLOCKS // 2
+            enc_indices = list(range(0, half))
+            dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+
+        if inference_params is not None and use_loop:
+            raise RuntimeError(
+                "inference_params/direct state carryover is incompatible with depth recurrence "
+                "because it would update the same Mamba state multiple times per forward."
+            )
+
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+        skips = []
+        # Encoder
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        # Decoder with skip connections
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                x, mem = block(x, x0, mem, run_ffn=run_ffn,
+                               inference_params=inference_params, seq_idx=seq_idx)
+            else:
+                x, mem = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        if return_state:
+            return out, {"mem": mem} if USE_MEMORY else None
+        return out
+
+    def forward_with_state(self, ids, layer_states=None, seq_idx_base=0):
+        """
+        Stateful forward for cross-block carryover at eval time. Threads each
+        SSM block's Mamba2 scan state and causal-conv input history across calls
+        via the direct mamba_chunk_scan_combined kernel. Attention blocks see
+        only the current block.
+
+        Returns: (hidden_out, new_layer_states, next_seq_idx_base)
+        """
+        if not _HAS_CHUNK_SCAN or rearrange is None:
+            raise RuntimeError(
+                "mamba_chunk_scan_combined or einops not importable — direct-kernel "
+                "state carryover is unavailable."
+            )
+
+        bsz = ids.shape[0]
+        x = self.tok_emb(ids)
+        if self.use_factored:
+            x = self.embed_proj(x)
+        if self.bigram is not None:
+            x = x + self.bigram(ids)
+        x0 = x
+        mem = None  # USE_MEMORY interaction with direct SSM carryover is intentionally not mixed.
+
+        if SEQ_IDX_ENABLED and DOC_BOUNDARY_TOKEN >= 0:
+            with torch.no_grad():
+                is_boundary = (ids == DOC_BOUNDARY_TOKEN).int()
+                local_seq_idx = torch.cumsum(is_boundary, dim=-1).to(torch.int32)
+                seq_idx = (local_seq_idx + int(seq_idx_base)).contiguous()
+                next_seq_idx_base = int(seq_idx[:, -1].max().item())
+        else:
+            seq_idx = None
+            next_seq_idx_base = int(seq_idx_base)
+
+        use_loop = self.loop_enabled_external and self.loop_enc_seq is not None
+        if use_loop:
+            raise RuntimeError("forward_with_state is incompatible with depth recurrence.")
+
+        half = N_UNIQUE_BLOCKS // 2
+        enc_indices = list(range(0, half))
+        dec_indices = list(range(half, N_UNIQUE_BLOCKS))
+        n_skip_eff = min(len(enc_indices), len(dec_indices), self.n_skip)
+
+        if layer_states is None:
+            layer_states = {}
+        new_layer_states = {}
+
+        skips = []
+        for layer_pos, block_idx in enumerate(enc_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+            skips.append(x)
+
+        for layer_pos, block_idx in enumerate(dec_indices):
+            block = self.blocks[block_idx]
+            run_ffn = self._should_run_ffn(layer_pos, block_idx)
+            if layer_pos < n_skip_eff and skips:
+                x = x + self.skip_weights[layer_pos][None, None, :] * skips.pop()
+            if getattr(block, "_is_ssm", False):
+                init_ssm, init_conv = layer_states.get(block_idx, (None, None))
+                x, _, fin_ssm, fin_conv = block.forward_with_state(
+                    x, x0, mem, run_ffn, init_ssm, init_conv, seq_idx=seq_idx
+                )
+                new_layer_states[block_idx] = (fin_ssm, fin_conv)
+            else:
+                x, _ = block(x, x0, mem, run_ffn=run_ffn)
+
+        out = self.final_norm(x)
+        return out, new_layer_states, next_seq_idx_base
+
+
+def cast_params_to_dtype(model, dtype):
+    """
+    Pre-cast small non-matrix parameters (scales, gates, mix vectors) to compute
+    dtype so we don't launch hundreds of aten::copy_ kernels every forward pass.
+    Only casts 1D params and small 2D params that are control/scale params.
+    Leaves embedding, linear weights, and Mamba internals in their native dtype.
+    """
+    cast_count = 0
+    for name, p in model.named_parameters():
+        if "mamba" in name:
+            continue
+        # Cast 1D params (scales, gates, norms) and the 2D resid_mix (2, d_model)
+        is_ctrl = any(c in name for c in CTRL_PATTERNS) or "skip_weights" in name
+        is_norm = "final_norm" in name or (p.ndim == 1 and "weight" in name)
+        if (p.ndim <= 1 or (p.ndim == 2 and is_ctrl)) and p.dtype != dtype:
+            p.data = p.data.to(dtype)
+            cast_count += 1
+    return cast_count
+
+
+def apply_s4d_init_to_mamba(model: nn.Module):
+    """
+    Safely apply S4D-style diagonal initialization to Mamba modules that expose
+    A_log and D parameters. This is done pre-DDP and keeps fused kernel paths.
+    """
+    initialized = 0
+    skipped = 0
+    for mod_name, module in model.named_modules():
+        if not (hasattr(module, "A_log") and hasattr(module, "D")):
+            continue
+
+        A_log = getattr(module, "A_log")
+        D = getattr(module, "D")
+        if not (torch.is_tensor(A_log) and torch.is_tensor(D)):
+            skipped += 1
+            continue
+        if A_log.numel() == 0:
+            skipped += 1
+            continue
+
+        d_state = A_log.shape[-1]
+        if d_state <= 0:
+            skipped += 1
+            continue
+
+        # S4D-Real: A = - (1/2, 3/2, 5/2, ...), parameterized as log(-A).
+        a_init = torch.arange(1, 2 * d_state, 2, device=A_log.device, dtype=torch.float32) / 2.0
+        while a_init.ndim < A_log.ndim:
+            a_init = a_init.unsqueeze(0)
+        a_init = a_init.expand_as(A_log).to(dtype=A_log.dtype)
+
+        try:
+            with torch.no_grad():
+                A_log.copy_(torch.log(a_init))
+                D.fill_(1.0)
+            initialized += 1
+        except Exception as e:
+            skipped += 1
+            log0(f"[s4d_init] skip module '{mod_name}': {e}")
+
+    return initialized, skipped
+
+
+def lm_loss(model_or_ddp, ids, targets, state=None, return_state=False):
+    if return_state:
+        hidden, next_state = model_or_ddp(ids, state=state, return_state=True)
+    else:
+        hidden = model_or_ddp(ids, state=state, return_state=False)
+        next_state = None
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    y = targets.reshape(-1)
+    if core.use_factored:
+        flat_h = hidden.reshape(-1, D_MODEL)
+        h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+        logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+    else:
+        flat_h = hidden.reshape(-1, core.lm_head.weight.shape[1])
+        logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+    logits = core.softcap * torch.tanh(logits / core.softcap)
+    loss = F.cross_entropy(logits.float(), y, reduction="mean")
+    if return_state:
+        return loss, next_state
+    return loss
+
+
+def detach_state(state):
+    if state is None:
+        return None
+    out = {}
+    for k, v in state.items():
+        out[k] = v.detach() if torch.is_tensor(v) else v
+    return out
+
+
+def apply_state_reset_mask(state, reset_mask):
+    """
+    Zero state rows where a new shard/document boundary is crossed.
+    """
+    if state is None or reset_mask is None:
+        return state
+    if not torch.any(reset_mask):
+        return state
+    out = dict(state)
+    mem = out.get("mem", None)
+    if mem is None:
+        return out
+    out["mem"] = mem.masked_fill(reset_mask[:, None], 0.0)
+    return out
+
+
+def stream_chunks_for_step(step):
+    """
+    Optional mixed-length curriculum over streamed chunks.
+    Starts with shorter context and ramps to STREAM_CHUNKS by CURRICULUM_STEPS.
+    """
+    if STREAM_CHUNKS <= 1 or not MIXED_LENGTH_CURRICULUM:
+        return STREAM_CHUNKS
+    if CURRICULUM_STEPS <= 0:
+        return STREAM_CHUNKS
+    frac = max(0.0, min(1.0, step / float(CURRICULUM_STEPS)))
+    chunks = 1 + int(frac * (STREAM_CHUNKS - 1))
+    return max(1, min(STREAM_CHUNKS, chunks))
+
+
+# -----------------------------------------------------------------------------
+# Train / eval helpers
+# -----------------------------------------------------------------------------
+def _zeropower_via_newtonschulz5(G: torch.Tensor, steps: int = 5, eps: float = 1e-7) -> torch.Tensor:
+    """
+    Orthogonalize a 2D update matrix via a fast Newton-Schulz iteration.
+    Muon-style update preconditioner for matrix parameters.
+    """
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = X.size(0) > X.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+# Compile for fused CUDA kernels — significant speedup on the NS5 iterations
+zeropower_via_newtonschulz5 = torch.compile(_zeropower_via_newtonschulz5)
+
+
+class Muon(torch.optim.Optimizer):
+    """
+    Muon optimizer for matrix-shaped parameters.
+    Uses compiled NS5 for speed. DDP synchronizes gradients during backward.
+    """
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int,
+                 nesterov: bool = True, weight_decay: float = 0.0):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps,
+                 nesterov=nesterov, weight_decay=weight_decay, base_lr=lr),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group["weight_decay"]
+            for p in group["params"]:
+                if p.grad is None:
+                    continue
+                if wd > 0:
+                    p.mul_(1.0 - lr * wd)
+                g = p.grad
+                state = self.state[p]
+                if "momentum_buffer" not in state:
+                    state["momentum_buffer"] = torch.zeros_like(g)
+                buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                upd = g.add(buf, alpha=momentum) if nesterov else buf
+                upd_2d = upd.reshape(upd.shape[0], -1) if upd.ndim > 2 else upd
+                if upd_2d.ndim >= 2:
+                    upd_orth = zeropower_via_newtonschulz5(upd_2d, steps=backend_steps)
+                    upd_orth = upd_orth * (max(1, upd_orth.size(0) / upd_orth.size(1)) ** 0.5)
+                    upd = upd_orth.reshape(upd.shape)
+                p.add_(upd.to(dtype=p.dtype), alpha=-lr)
+        return loss
+
+
+def build_optimizers(model):
+    mat_params, scalar_params, embed_params = [], [], []
+    muon_eligible_2d = 0
+    muon_eligible_nd = 0
+    _seen_data_ptrs = set()  # handle tied params
+    for name, p in model.named_parameters():
+        dp = p.data_ptr()
+        if dp in _seen_data_ptrs:
+            continue  # skip tied duplicate (lm_head.weight = tok_emb.weight)
+        _seen_data_ptrs.add(dp)
+        if name in ("tok_emb.weight", "lm_head.weight"):
+            embed_params.append(p)
+        else:
+            is_control = any(c in name for c in CTRL_PATTERNS)
+            if p.ndim == 2 and not is_control:
+                muon_eligible_2d += 1
+            elif p.ndim > 2 and not is_control:
+                muon_eligible_nd += 1
+
+            if ((p.ndim == 2) if MUON_ONLY_2D else (p.ndim >= 2)) and not is_control:
+                mat_params.append(p)
+            else:
+                scalar_params.append(p)
+
+    optimizer_muon = Muon(
+        mat_params,
+        lr=MATRIX_LR,
+        momentum=MUON_MOMENTUM,
+        backend_steps=MUON_BACKEND_STEPS,
+        nesterov=MUON_NESTEROV,
+        weight_decay=WEIGHT_DECAY,
+    ) if len(mat_params) > 0 else None
+
+    optimizer_adamw = torch.optim.AdamW(
+        [
+            {"params": scalar_params, "lr": SCALAR_LR, "weight_decay": WEIGHT_DECAY, "base_lr": SCALAR_LR},
+            {"params": embed_params, "lr": EMBED_LR, "weight_decay": WEIGHT_DECAY, "base_lr": EMBED_LR},
+        ],
+        betas=(BETA1, BETA2),
+        eps=ADAM_EPS,
+        fused=True,
+    )
+    log0(
+        f"Optimizer split: matrix={len(mat_params)} (Muon), "
+        f"scalar/control={len(scalar_params)} (AdamW), embed={len(embed_params)} (AdamW)"
+    )
+    log0(
+        f"Muon config: muon_only_2d={int(MUON_ONLY_2D)} "
+        f"eligible_2d={muon_eligible_2d} eligible_nd={muon_eligible_nd}"
+    )
+    return optimizer_adamw, optimizer_muon, mat_params
+
+
+def lr_schedule(step, elapsed_sec):
+    """
+    LR schedule with two modes:
+    - cosine_full: warmup then cosine decay from peak to LR_MIN_SCALE over full training.
+    - cosine_late: warmup, hold at peak, then cosine decay in final phase (original behavior).
+    Both use wallclock progress as the time axis.
+    """
+    if step < WARMUP_STEPS:
+        return step / max(WARMUP_STEPS, 1)
+    if MAX_WALLCLOCK_SECONDS <= 0:
+        return 1.0
+
+    prog = max(0.0, min(1.0, elapsed_sec / MAX_WALLCLOCK_SECONDS))
+
+    if LR_SCHEDULE == "step":
+        # Manual step schedule: 1.0 → 0.8 → 0.5 → 0.3
+        if prog < 0.35:
+            return 1.0
+        elif prog < 0.65:
+            return 0.8
+        elif prog < 0.85:
+            return 0.5
+        else:
+            return 0.3
+    elif LR_SCHEDULE == "cosine_full":
+        t = prog
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+    else:
+        # Original: hold at peak, then cosine warmdown
+        if prog < LR_WARMDOWN_START_FRAC:
+            return 1.0
+        denom = max(1.0 - LR_WARMDOWN_START_FRAC, 1e-8)
+        t = (prog - LR_WARMDOWN_START_FRAC) / denom
+        cosine = 0.5 * (1.0 + math.cos(math.pi * t))
+        return LR_MIN_SCALE + (1.0 - LR_MIN_SCALE) * cosine
+
+
+
+def _rank_bounds(n_items: int):
+    """Exact contiguous sharding over WORLD_SIZE ranks; no dropped remainders."""
+    start = (int(n_items) * RANK) // WORLD_SIZE
+    end = (int(n_items) * (RANK + 1)) // WORLD_SIZE
+    return start, end
+
+
+@torch.no_grad()
+def eval_val(model_or_ddp, val_tokens, bb, hs, ib):
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+    vbs = 131072
+    batch_seqs = max(vbs // seq_len, 1)
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seq_start = (total_seqs * RANK) // WORLD_SIZE
+    seq_end = (total_seqs * (RANK + 1)) // WORLD_SIZE
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    for s in range(seq_start, seq_end, batch_seqs):
+        e = min(s + batch_seqs, seq_end)
+        chunk = val_tokens[s * seq_len : (e * seq_len) + 1]
+        xn = chunk[:-1].reshape(-1, seq_len)
+        yn = chunk[1:].reshape(-1, seq_len)
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            loss = lm_loss(core, x, y)
+        cnt = float(y.numel())
+        loss_sum += float(loss.detach().float().item()) * cnt
+        p, t = xn.reshape(-1), yn.reshape(-1)
+        b = bb[t].astype(np.int16, copy=True)
+        b += (hs[t] & ~ib[p]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+@torch.no_grad()
+def eval_val_sliding(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    Sliding window evaluation: each token gets near-full context.
+    Process windows of SEQ_LEN tokens with small stride, only score the last
+    `stride` tokens of each window. Much more accurate BPB than non-overlapping eval.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+    # Unwrap DDP — eval doesn't need gradient sync and DDP forward hooks
+    # can cause NCCL hangs if ranks have mismatched batch counts.
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    core.eval()
+    seq_len = SEQ_LEN
+
+    total_tokens = val_tokens.size - 1  # available for input-target pairs
+    # Number of windows: each window is seq_len tokens, stride forward by `stride`
+    n_windows = max(0, (total_tokens - seq_len) // stride + 1)
+
+    # Distribute windows across ranks
+    win_per_rank = n_windows // WORLD_SIZE
+    win_start = win_per_rank * RANK
+    win_end = win_start + win_per_rank
+
+    # Batch multiple windows together for efficiency
+    # Each window is (1, seq_len), we batch up to `batch_windows` at a time
+    batch_windows = max(1, 131072 // seq_len)  # ~32 at seq_len=4096
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    total_batches = (win_per_rank + batch_windows - 1) // batch_windows
+    log_every_batches = max(1, total_batches // 10)
+
+    batch_idx = 0
+    for wb in range(win_start, win_end, batch_windows):
+        we = min(wb + batch_windows, win_end)
+        bsz = we - wb
+
+        # Build batch of overlapping windows
+        x_list = []
+        y_list = []
+        for w in range(wb, we):
+            pos = w * stride
+            x_list.append(val_tokens[pos : pos + seq_len])
+            y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+
+        xn = np.stack(x_list)  # (bsz, seq_len)
+        yn = np.stack(y_list)  # (bsz, seq_len)
+
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden = core(x, state=None, return_state=False)
+
+        # Only score the last `stride` positions of each window
+        hidden_tail = hidden[:, -stride:, :]  # (bsz, stride, d_model)
+        y_tail = y[:, -stride:]  # (bsz, stride)
+
+        flat_y = y_tail.reshape(-1)
+        if core.use_factored:
+            flat_h = hidden_tail.reshape(-1, D_MODEL)
+            h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+            logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+        else:
+            flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+            logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+        logits = core.softcap * torch.tanh(logits / core.softcap)
+        loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+        cnt = float(flat_y.numel())
+        loss_sum += float(loss.detach().float().item())
+
+        # BPB: compute bytes only for scored tokens
+        p_tail = xn[:, -stride:].reshape(-1)  # input tokens at scored positions
+        t_tail = yn[:, -stride:].reshape(-1)  # target tokens at scored positions
+        b = bb[t_tail].astype(np.int16, copy=True)
+        b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        batch_idx += 1
+        if batch_idx % log_every_batches == 0:
+            pct = 100.0 * batch_idx / total_batches
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / batch_idx * (total_batches - batch_idx)
+            log0(f"  sliding_eval: {pct:.0f}% ({batch_idx}/{total_batches} batches, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  sliding_eval: {win_per_rank} windows/rank, stride={stride}, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+
+@torch.no_grad()
+def eval_val_carryover(model_or_ddp, val_tokens, bb, hs, ib, block_len=None, warmup_tokens=None):
+    """
+    Optional SSM-native stateful-overlap eval. It threads Mamba2 SSM + conv state
+    across overlapping blocks via core.forward_with_state(). Attention sees only
+    the current block, with CARRYOVER_OVERLAP restoring some local context.
+    """
+    if block_len is None:
+        block_len = CARRYOVER_BLOCK_LEN
+    if warmup_tokens is None:
+        warmup_tokens = CARRYOVER_WARMUP_TOKENS
+    if not (CARRYOVER_DIRECT_KERNEL and _HAS_CHUNK_SCAN and rearrange is not None):
+        raise RuntimeError("Direct-kernel carryover requested but chunk_scan/einops is unavailable.")
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    # If torch.compile wrapped the model, use the original module for the custom
+    # forward_with_state method and direct-kernel calls.
+    if hasattr(core, "_orig_mod"):
+        core = core._orig_mod
+    core.eval()
+
+    prev_loop = getattr(core, "loop_enabled_external", False)
+    if prev_loop:
+        log0("[carryover_eval] depth recurrence active — temporarily disabled")
+        core.loop_enabled_external = False
+
+    total_tokens = val_tokens.size - 1
+    overlap = max(0, min(int(CARRYOVER_OVERLAP), int(block_len) - 1))
+    score_region = int(block_len) - overlap
+    if score_region <= 0 or total_tokens < block_len:
+        n_blocks_total = 0
+    else:
+        n_blocks_total = max(0, (total_tokens - int(block_len)) // score_region + 1)
+
+    block_start_idx, block_end_idx = _rank_bounds(n_blocks_total)
+    n_blocks = block_end_idx - block_start_idx
+    rank_start = block_start_idx * score_region
+    warmup_blocks = int(warmup_tokens) // int(block_len)
+
+    layer_states = None
+    seq_idx_base = 0
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_blocks = max(1, n_blocks // 20) if n_blocks > 0 else 1
+
+    log0(
+        f"  carryover_eval: path=direct_kernel, block_len={block_len}, "
+        f"overlap={overlap}, score_region={score_region}, "
+        f"n_blocks/rank={n_blocks}, global_blocks={n_blocks_total}, warmup_blocks={warmup_blocks}"
+    )
+
+    for b_idx in range(n_blocks):
+        global_b_idx = block_start_idx + b_idx
+        pos = rank_start + b_idx * score_region
+        chunk = val_tokens[pos : pos + int(block_len) + 1]
+        if chunk.size < int(block_len) + 1:
+            break
+        xn = chunk[:-1].reshape(1, int(block_len))
+        yn = chunk[1:].reshape(1, int(block_len))
+        x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+        y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+            hidden, layer_states, seq_idx_base = core.forward_with_state(
+                x, layer_states, seq_idx_base=seq_idx_base
+            )
+            # First global block scores from 0; later blocks skip overlap
+            # because those tokens were scored by the previous block.
+            score_start = overlap if (overlap > 0 and global_b_idx > 0) else 0
+            hidden_tail = hidden[:, score_start:, :]
+            score_y = y[:, score_start:]
+            score_logits = core.output_logits_from_hidden(hidden_tail)
+            loss = F.cross_entropy(
+                score_logits.float(),
+                score_y.reshape(-1),
+                reduction="sum",
+            )
+
+        if b_idx >= warmup_blocks:
+            cnt = float(score_y.numel())
+            loss_sum += float(loss.detach().float().item())
+            p_flat = xn[:, score_start:].reshape(-1)
+            t_flat = yn[:, score_start:].reshape(-1)
+            b_arr = bb[t_flat].astype(np.int16, copy=True)
+            b_arr += (hs[t_flat] & ~ib[p_flat]).astype(np.int16)
+            tok_sum += cnt
+            byt_sum += float(b_arr.astype(np.float64).sum())
+
+        if (b_idx + 1) % log_every_blocks == 0:
+            pct = 100.0 * (b_idx + 1) / max(n_blocks, 1)
+            elapsed_e = time.perf_counter() - t0_eval
+            eta = elapsed_e / (b_idx + 1) * (n_blocks - (b_idx + 1))
+            log0(f"  carryover_eval: {pct:.0f}% ({b_idx + 1}/{n_blocks} blocks, eta:{eta:.0f}s)")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  carryover_eval: rank={RANK}, scored_tokens={tok_sum:.0f}, {elapsed:.1f}s")
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    if prev_loop:
+        core.loop_enabled_external = True
+    core.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def eval_score_first_ttt(model_or_ddp, val_tokens, bb, hs, ib, stride=None):
+    """
+    SOTA-style legal Score-First TTT eval.
+
+    For each chunk of val (~32K tokens):
+      1. Score ALL sliding windows in the chunk under torch.no_grad() (FINAL grades)
+      2. Train model with SGD on the scored chunk tokens (3 epochs, momentum=0.9)
+      3. Move to next chunk with adapted weights
+
+    Compliance:
+      - Causality preserved (sliding windows are causal)
+      - Each token scored exactly once, before any update that benefits from it
+      - No re-scoring, no rescoring, no n-gram cache
+    Weights are modified in-place; restored at end.
+    """
+    if stride is None:
+        stride = EVAL_STRIDE
+
+    core = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    seq_len = SEQ_LEN
+
+    # Save base weights for restoration after eval
+    base_state = {name: p.data.clone() for name, p in core.named_parameters()}
+
+    # Build SGD optimizer over ALL params
+    adapt_params = list(core.parameters())
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"Score-First TTT: chunk={SCORE_FIRST_TTT_CHUNK_TOKENS}, lr={SCORE_FIRST_TTT_LR}, "
+         f"momentum={SCORE_FIRST_TTT_MOMENTUM}, epochs={SCORE_FIRST_TTT_EPOCHS}, "
+         f"adapting {n_adapt:,} params")
+
+    ttt_opt = torch.optim.SGD(adapt_params, lr=SCORE_FIRST_TTT_LR,
+                              momentum=SCORE_FIRST_TTT_MOMENTUM)
+
+    total_tokens = val_tokens.size - 1
+    chunk_tokens = SCORE_FIRST_TTT_CHUNK_TOKENS
+    n_chunks = (total_tokens - seq_len) // chunk_tokens + 1
+
+    # Distribute chunks across ranks
+    chunks_per_rank = n_chunks // WORLD_SIZE
+    chunk_start = chunks_per_rank * RANK
+    chunk_end = chunk_start + chunks_per_rank
+
+    batch_windows = max(1, 131072 // seq_len)
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    t0_eval = time.perf_counter()
+    log_every_chunks = max(1, chunks_per_rank // 10)
+
+    for chunk_idx_local, ci in enumerate(range(chunk_start, chunk_end)):
+        chunk_tok_start = ci * chunk_tokens
+        chunk_tok_end = min(chunk_tok_start + chunk_tokens, total_tokens - seq_len)
+        if chunk_tok_end <= chunk_tok_start:
+            break
+
+        # === STEP 1: SCORE the chunk under torch.no_grad() (FINAL grades) ===
+        core.eval()
+        n_windows_in_chunk = max(1, (chunk_tok_end - chunk_tok_start) // stride)
+
+        chunk_tokens_for_train = []  # collect input tokens for training phase
+        chunk_targets_for_train = []
+
+        with torch.no_grad():
+            for wb in range(0, n_windows_in_chunk, batch_windows):
+                we = min(wb + batch_windows, n_windows_in_chunk)
+                x_list, y_list = [], []
+                for w in range(wb, we):
+                    pos = chunk_tok_start + w * stride
+                    if pos + seq_len + 1 > total_tokens + 1:
+                        break
+                    x_list.append(val_tokens[pos : pos + seq_len])
+                    y_list.append(val_tokens[pos + 1 : pos + seq_len + 1])
+                if not x_list:
+                    continue
+                xn = np.stack(x_list)
+                yn = np.stack(y_list)
+                x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+                y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+                with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                    hidden = core(x, state=None, return_state=False)
+
+                hidden_tail = hidden[:, -stride:, :]
+                y_tail = y[:, -stride:]
+                flat_y = y_tail.reshape(-1)
+                if core.use_factored:
+                    flat_h = hidden_tail.reshape(-1, D_MODEL)
+                    h_proj = F.linear(flat_h, core.embed_proj_rev.weight.to(flat_h.dtype))
+                    logits = F.linear(h_proj, core.lm_head.weight.to(h_proj.dtype))
+                else:
+                    flat_h = hidden_tail.reshape(-1, core.lm_head.weight.shape[1])
+                    logits = F.linear(flat_h, core.lm_head.weight.to(flat_h.dtype))
+                logits = core.softcap * torch.tanh(logits / core.softcap)
+                loss = F.cross_entropy(logits.float(), flat_y, reduction="sum")
+
+                cnt = float(flat_y.numel())
+                loss_sum += float(loss.detach().float().item())
+
+                p_tail = xn[:, -stride:].reshape(-1)
+                t_tail = yn[:, -stride:].reshape(-1)
+                b = bb[t_tail].astype(np.int16, copy=True)
+                b += (hs[t_tail] & ~ib[p_tail]).astype(np.int16)
+                tok_sum += cnt
+                byt_sum += float(b.astype(np.float64).sum())
+
+                # Save these (already-scored) tokens for the training phase
+                chunk_tokens_for_train.append(xn)
+                chunk_targets_for_train.append(yn)
+
+        # === STEP 2: SGD train on the scored chunk tokens ===
+        if chunk_tokens_for_train:
+            core.train()
+            all_x = np.concatenate(chunk_tokens_for_train, axis=0)
+            all_y = np.concatenate(chunk_targets_for_train, axis=0)
+            n_seqs_in_chunk = all_x.shape[0]
+
+            # Cosine LR decay across chunks
+            chunk_lr_scale = 0.5 * (1.0 + math.cos(math.pi * chunk_idx_local / max(1, chunks_per_rank)))
+            for g in ttt_opt.param_groups:
+                g["lr"] = SCORE_FIRST_TTT_LR * chunk_lr_scale
+
+            for epoch in range(SCORE_FIRST_TTT_EPOCHS):
+                # Shuffle each epoch
+                perm = np.random.permutation(n_seqs_in_chunk)
+                bs = max(1, batch_windows // 2)
+                for bi in range(0, n_seqs_in_chunk, bs):
+                    be = min(bi + bs, n_seqs_in_chunk)
+                    idx = perm[bi:be]
+                    ax = torch.from_numpy(all_x[idx]).long().to(DEVICE)
+                    ay = torch.from_numpy(all_y[idx]).long().to(DEVICE)
+
+                    ttt_opt.zero_grad(set_to_none=True)
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        adapt_loss = lm_loss(core, ax, ay)
+                    adapt_loss.backward()
+
+                    for p in adapt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+                    if SCORE_FIRST_TTT_GRAD_CLIP > 0:
+                        nn.utils.clip_grad_norm_(adapt_params, SCORE_FIRST_TTT_GRAD_CLIP)
+                    ttt_opt.step()
+
+        if (chunk_idx_local + 1) % log_every_chunks == 0:
+            elapsed_e = time.perf_counter() - t0_eval
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            eta = elapsed_e / (chunk_idx_local + 1) * (chunks_per_rank - chunk_idx_local - 1)
+            log0(f"  score_first_ttt: chunk {chunk_idx_local+1}/{chunks_per_rank} "
+                 f"running_bpb:{running_bpb:.4f} eta:{eta:.0f}s")
+
+    elapsed = time.perf_counter() - t0_eval
+    log0(f"  score_first_ttt: {chunks_per_rank} chunks/rank, "
+         f"{tok_sum:.0f} scored tokens, {elapsed:.1f}s")
+
+    # Aggregate across ranks
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in core.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+    core.train()
+
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+def _select_ttt_params(base_model, param_mode):
+    """Select which parameters to adapt during TTT based on mode string."""
+    adapt_names = set()
+    adapt_params = []
+    for name, p in base_model.named_parameters():
+        include = False
+        if param_mode == "norms":
+            include = ("norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "in_proj":
+            include = ("in_proj" in name or "out_proj" in name
+                       or "norm" in name or "scale" in name
+                       or "ssm_scale" in name or "mlp_scale" in name)
+        elif param_mode == "all_linear":
+            # All linear layers + norms/scales, but NOT embeddings
+            include = (name not in ("tok_emb.weight", "lm_head.weight"))
+        elif param_mode == "all":
+            include = True
+        if include:
+            adapt_names.add(name)
+            adapt_params.append(p)
+    return adapt_names, adapt_params
+
+
+def ttt_global_adapt(model_or_ddp, val_tokens):
+    """
+    Global Test-Time Training: treat the entire validation set as an LM
+    training corpus and run a few Adam steps to adapt model weights to the
+    val distribution. This is NOT per-sequence — it is a global domain
+    adaptation pass. Weights are modified IN-PLACE; caller must save/restore.
+
+    Returns the saved base state dict for later restoration.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+    # Save base weights for later restoration
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    n_adapt = sum(p.numel() for p in adapt_params)
+    log0(f"TTT global: adapting {len(adapt_params)} param tensors "
+         f"({n_adapt:,} params, mode={TTT_PARAMS})")
+    log0(f"TTT global: steps={TTT_GLOBAL_STEPS}, lr={TTT_GLOBAL_LR}, "
+         f"batch_seqs={TTT_GLOBAL_BATCH_SEQS}, passes={TTT_GLOBAL_PASSES}, "
+         f"grad_clip={TTT_GLOBAL_GRAD_CLIP}")
+
+    # Freeze non-adapted params to save memory on optimizer states
+    frozen = []
+    for name, p in base_model.named_parameters():
+        if name not in adapt_names:
+            p.requires_grad_(False)
+            frozen.append(name)
+
+    # Build Adam optimizer for adapted params only
+    ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_GLOBAL_LR, betas=(0.9, 0.95),
+                               weight_decay=0.0)
+
+    seq_len = SEQ_LEN
+    total_seqs = (val_tokens.size - 1) // seq_len
+    # Each rank processes its shard of val sequences
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+    local_seqs = seq_end - seq_start
+
+    batch_seqs = min(TTT_GLOBAL_BATCH_SEQS, local_seqs)
+    batches_per_pass = max(1, local_seqs // batch_seqs)
+
+    base_model.train()
+    ttt_t0 = time.perf_counter()
+    global_step = 0
+
+    for pass_idx in range(TTT_GLOBAL_PASSES):
+        # Shuffle sequence order each pass (deterministic per rank)
+        rng = np.random.RandomState(seed=42 + pass_idx + RANK)
+        perm = rng.permutation(local_seqs) + seq_start
+        batch_idx = 0
+
+        for bi in range(0, local_seqs, batch_seqs):
+            if global_step >= TTT_GLOBAL_STEPS:
+                break
+            be = min(bi + batch_seqs, local_seqs)
+            seq_ids = perm[bi:be]
+
+            # Build batch
+            x_list, y_list = [], []
+            for s in seq_ids:
+                chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+                x_list.append(chunk[:-1])
+                y_list.append(chunk[1:])
+            xn = np.stack(x_list)
+            yn = np.stack(y_list)
+            x = torch.from_numpy(xn).long().to(DEVICE, non_blocking=True)
+            y = torch.from_numpy(yn).long().to(DEVICE, non_blocking=True)
+
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss = lm_loss(base_model, x, y)
+            loss.backward()
+
+            # All-reduce gradients across ranks for consistent adaptation
+            for p in adapt_params:
+                if p.grad is not None:
+                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+
+            if TTT_GLOBAL_GRAD_CLIP > 0:
+                nn.utils.clip_grad_norm_(adapt_params, TTT_GLOBAL_GRAD_CLIP)
+            ttt_opt.step()
+            global_step += 1
+            batch_idx += 1
+
+            if MASTER_PROCESS and (global_step <= 3 or global_step % max(1, TTT_GLOBAL_STEPS // 10) == 0):
+                elapsed = time.perf_counter() - ttt_t0
+                log0(f"  TTT global step {global_step}/{TTT_GLOBAL_STEPS} "
+                     f"pass={pass_idx} loss={loss.item():.4f} "
+                     f"elapsed={elapsed:.1f}s")
+
+        if global_step >= TTT_GLOBAL_STEPS:
+            break
+
+    # Unfreeze all params
+    for name, p in base_model.named_parameters():
+        p.requires_grad_(True)
+
+    elapsed = time.perf_counter() - ttt_t0
+    log0(f"TTT global adapt done: {global_step} steps in {elapsed:.1f}s")
+
+    return base_state, adapt_names
+
+
+def ttt_restore_weights(base_model, base_state, adapt_names):
+    """Restore model weights from saved base state after TTT."""
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in adapt_names:
+                p.data.copy_(base_state[name])
+
+
+def ttt_evaluate(model_or_ddp, val_tokens, bb, hs, ib):
+    """
+    Per-sequence Test-Time Training evaluation: for each validation sequence,
+    adapt model weights on the full sequence using the causal LM objective
+    (no data leakage — each token only sees prior context), then re-evaluate
+    the same sequence with adapted weights. Weights restored between sequences.
+
+    Uses Adam instead of SGD for faster few-step convergence.
+    Returns (val_loss, val_bpb) on full sequences.
+    """
+    base_model = model_or_ddp.module if isinstance(model_or_ddp, DDP) else model_or_ddp
+    base_model.eval()
+
+    seq_len = SEQ_LEN
+    adapt_names, adapt_params = _select_ttt_params(base_model, TTT_PARAMS)
+
+    # Save base weights
+    base_state = {name: p.data.clone() for name, p in base_model.named_parameters()
+                  if name in adapt_names}
+
+    # Distribute val sequences across ranks
+    total_seqs = (val_tokens.size - 1) // seq_len
+    seqs_per_rank = total_seqs // WORLD_SIZE
+    seq_start = seqs_per_rank * RANK
+    seq_end = seq_start + seqs_per_rank
+
+    # Subsample if TTT_MAX_SEQS is set (0 = use all)
+    n_local_seqs = seqs_per_rank
+    if TTT_MAX_SEQS > 0 and n_local_seqs > TTT_MAX_SEQS:
+        stride = n_local_seqs // TTT_MAX_SEQS
+        seq_indices = list(range(seq_start, seq_end, stride))[:TTT_MAX_SEQS]
+        n_local_seqs = len(seq_indices)
+    else:
+        seq_indices = list(range(seq_start, seq_end))
+        n_local_seqs = len(seq_indices)
+
+    log0(f"TTT per-seq: adapting {len(adapt_params)} params ({TTT_PARAMS}), "
+         f"steps={TTT_STEPS}, lr={TTT_LR}, "
+         f"seqs/rank={n_local_seqs} (of {seqs_per_rank})")
+
+    loss_sum = 0.0
+    tok_sum = 0.0
+    byt_sum = 0.0
+    ttt_t0 = time.perf_counter()
+    ttt_log_every = max(1, n_local_seqs // 20)
+
+    for si, s in enumerate(seq_indices):
+        # Restore base weights before each sequence
+        with torch.no_grad():
+            for name, p in base_model.named_parameters():
+                if name in base_state:
+                    p.data.copy_(base_state[name])
+
+        chunk = val_tokens[s * seq_len : s * seq_len + seq_len + 1]
+        full_x = chunk[:-1]
+        full_y = chunk[1:]
+
+        x = torch.from_numpy(full_x.reshape(1, -1)).long().to(DEVICE)
+        y = torch.from_numpy(full_y.reshape(1, -1)).long().to(DEVICE)
+
+        # --- TTT: Adam gradient steps on full sequence (causal, no leakage) ---
+        base_model.train()
+        ttt_opt = torch.optim.Adam(adapt_params, lr=TTT_LR, betas=(0.9, 0.95),
+                                   weight_decay=0.0)
+        for _ttt_step in range(TTT_STEPS):
+            ttt_opt.zero_grad(set_to_none=True)
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_adapt = lm_loss(base_model, x, y)
+            loss_adapt.backward()
+            nn.utils.clip_grad_norm_(adapt_params, 1.0)
+            ttt_opt.step()
+
+        # --- Re-evaluate full sequence with adapted weights ---
+        base_model.eval()
+        with torch.no_grad():
+            with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                loss_eval = lm_loss(base_model, x, y)
+
+        cnt = float(seq_len)
+        loss_sum += float(loss_eval.detach().float().item()) * cnt
+
+        # BPB calculation on full sequence
+        b = bb[full_y].astype(np.int16, copy=True)
+        b += (hs[full_y] & ~ib[full_x]).astype(np.int16)
+        tok_sum += cnt
+        byt_sum += float(b.astype(np.float64).sum())
+
+        done = si + 1
+        if done == 1 or done == n_local_seqs or done % ttt_log_every == 0:
+            elapsed_ttt = time.perf_counter() - ttt_t0
+            running_loss = loss_sum / max(tok_sum, 1.0)
+            running_bpb = (running_loss / math.log(2.0)) * (tok_sum / max(byt_sum, 1.0))
+            seqs_per_sec = done / max(elapsed_ttt, 1e-9)
+            eta = (n_local_seqs - done) / max(seqs_per_sec, 1e-9)
+            log0(
+                f"  TTT eval: {done}/{n_local_seqs} seqs "
+                f"({100.0 * done / n_local_seqs:.0f}%) "
+                f"running_loss:{running_loss:.4f} running_bpb:{running_bpb:.4f} "
+                f"seq/s:{seqs_per_sec:.1f} eta:{eta:.0f}s"
+            )
+
+    # Restore base weights
+    with torch.no_grad():
+        for name, p in base_model.named_parameters():
+            if name in base_state:
+                p.data.copy_(base_state[name])
+
+    stats = torch.tensor([loss_sum, tok_sum, byt_sum], device=DEVICE, dtype=torch.float64)
+    dist.all_reduce(stats, op=dist.ReduceOp.SUM)
+    loss_sum, tok_sum, byt_sum = float(stats[0]), float(stats[1]), float(stats[2])
+    val_loss = loss_sum / max(tok_sum, 1.0)
+    bpt = val_loss / math.log(2.0)
+    ttt_total_time = time.perf_counter() - ttt_t0
+    log0(f"TTT per-seq eval done in {ttt_total_time:.1f}s ({n_local_seqs} seqs/rank)")
+    base_model.train()
+    return float(val_loss), float(bpt * (tok_sum / max(byt_sum, 1.0)))
+
+
+# -----------------------------------------------------------------------------
+# EMA (Exponential Moving Average) for eval
+# -----------------------------------------------------------------------------
+class ModelEMA:
+    """Maintains an exponential moving average of model parameters."""
+
+    def __init__(self, model, decay=0.999):
+        self.decay = decay
+        self.shadow = {}
+        self.backup = {}
+        with torch.no_grad():
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+
+    @torch.no_grad()
+    def update(self, model):
+        d = self.decay
+        for name, p in model.named_parameters():
+            self.shadow[name].lerp_(p.data, 1.0 - d)
+
+    def apply_shadow(self, model):
+        """Swap model weights with EMA weights. Call before eval."""
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name])
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+class ModelSWA:
+    """Stochastic Weight Averaging — collect and average checkpoints from late training."""
+
+    def __init__(self):
+        self.shadow = {}
+        self.n_checkpoints = 0
+        self.collecting = False
+
+    def maybe_start(self, elapsed_frac):
+        """Start collecting if we're in the SWA window."""
+        if not self.collecting and elapsed_frac >= (1.0 - SWA_START_FRAC):
+            self.collecting = True
+            return True
+        return False
+
+    @torch.no_grad()
+    def collect(self, model):
+        """Add current weights to the running average."""
+        self.n_checkpoints += 1
+        if self.n_checkpoints == 1:
+            for name, p in model.named_parameters():
+                self.shadow[name] = p.data.clone()
+        else:
+            for name, p in model.named_parameters():
+                self.shadow[name].add_(p.data)
+
+    def apply_average(self, model):
+        """Apply averaged weights to model. Call before eval."""
+        if self.n_checkpoints == 0:
+            return
+        self.backup = {}
+        for name, p in model.named_parameters():
+            self.backup[name] = p.data.clone()
+            p.data.copy_(self.shadow[name] / float(self.n_checkpoints))
+
+    def restore(self, model):
+        """Restore original weights after eval."""
+        if not hasattr(self, 'backup') or not self.backup:
+            return
+        for name, p in model.named_parameters():
+            if name in self.backup:
+                p.data.copy_(self.backup[name])
+        self.backup = {}
+
+
+def batch_warmup_seqs(step, full_batch_seqs):
+    """
+    Return the number of sequences to use from the batch at this step.
+    Ramps linearly from BATCH_WARMUP_FRAC * full_batch_seqs to full_batch_seqs
+    over BATCH_WARMUP_STEPS steps.
+    """
+    if BATCH_WARMUP_STEPS <= 0 or step >= BATCH_WARMUP_STEPS:
+        return full_batch_seqs
+    frac = BATCH_WARMUP_FRAC + (1.0 - BATCH_WARMUP_FRAC) * (step / BATCH_WARMUP_STEPS)
+    n = max(1, int(frac * full_batch_seqs))
+    return min(n, full_batch_seqs)
+
+
+# -----------------------------------------------------------------------------
+# Main
+# -----------------------------------------------------------------------------
+def main():
+    maybe_download_data()
+    sp = spm.SentencePieceProcessor(model_file=TOK_PATH)
+    assert int(sp.vocab_size()) == VOCAB_SIZE
+
+    val_tokens_full = load_val_tokens(f"{DATA_PATH}/fineweb_val_*.bin", SEQ_LEN)
+    if int(os.environ.get("SMOKE_VAL_TOK", "0")) > 0:
+        cap = ((int(os.environ["SMOKE_VAL_TOK"]) // SEQ_LEN) * SEQ_LEN) + 1
+        val_tokens = val_tokens_full[:cap]
+    else:
+        val_tokens = val_tokens_full
+    bb, hs, ib = build_sp_luts(sp, VOCAB_SIZE)
+    log0(f"Val tokens: {val_tokens.size - 1:,} (full: {val_tokens_full.size - 1:,})")
+
+    # -----------------------------------------------------------------------
+    # Async data loader — background thread reads disk, pins memory, H2D on
+    # a separate CUDA stream. Main thread never blocks on data.
+    # -----------------------------------------------------------------------
+    if USE_ASYNC_LOADER:
+        loader = AsyncDistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+            prefetch_depth=3,
+        )
+    else:
+        loader = DistributedTokenLoader(
+            pattern=f"{DATA_PATH}/fineweb_train_*.bin",
+            rank=RANK,
+            world_size=WORLD_SIZE,
+            global_tokens=TRAIN_BATCH_TOK,
+            seq_len=SEQ_LEN,
+            grad_accum_steps=GRAD_ACCUM,
+            device=DEVICE,
+        )
+
+    # -----------------------------------------------------------------------
+    # Build model
+    # -----------------------------------------------------------------------
+    base_model = SSM_LM().to(DEVICE)
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"Model parameters: {n_params:,}")
+
+    if ENABLE_S4D_INIT:
+        n_init, n_skip = apply_s4d_init_to_mamba(base_model)
+        log0(f"S4D init applied to {n_init} module(s), skipped {n_skip}")
+
+    # Pre-cast small params to bf16 to eliminate per-step .to(dtype) copies
+    n_cast = cast_params_to_dtype(base_model, AMP_DTYPE)
+    log0(f"Pre-cast {n_cast} parameters to {AMP_DTYPE}")
+
+    model_for_ddp = base_model
+    if USE_TORCH_COMPILE:
+        try:
+            # fullgraph=False required: mamba_ssm custom CUDA ops (causal_conv1d)
+            # use non-contiguous out= tensors which break dynamo's fullgraph mode.
+            model_for_ddp = torch.compile(base_model, dynamic=False)
+            log0("torch_compile: enabled")
+        except Exception as e:
+            log0(f"torch_compile: failed ({e}); falling back to eager")
+
+    model = DDP(model_for_ddp, device_ids=[LOCAL_RANK], output_device=LOCAL_RANK,
+                broadcast_buffers=False, gradient_as_bucket_view=True, static_graph=True)
+
+    optimizer_adamw, optimizer_muon, matrix_params = build_optimizers(base_model)
+    scaler = torch.amp.GradScaler("cuda", enabled=(AMP_DTYPE == torch.float16))
+
+    # EMA
+    ema = None
+    if EMA_ENABLED:
+        ema = ModelEMA(base_model, decay=EMA_DECAY)
+        log0(f"EMA initialized (decay={EMA_DECAY})")
+
+    # SWA
+    swa = None
+    if SWA_ENABLED:
+        swa = ModelSWA()
+        log0(f"SWA initialized (start_frac={SWA_START_FRAC}, every={SWA_EVERY})")
+
+    # -----------------------------------------------------------------------
+    # -----------------------------------------------------------------------
+    profiler = None
+    if PROFILE_ENABLED and MASTER_PROCESS:
+        os.makedirs(PROFILE_DIR, exist_ok=True)
+        profiler = torch.profiler.profile(
+            activities=[
+                torch.profiler.ProfilerActivity.CPU,
+                torch.profiler.ProfilerActivity.CUDA,
+            ],
+            schedule=torch.profiler.schedule(
+                wait=PROFILE_START - 1,
+                warmup=1,
+                active=PROFILE_END - PROFILE_START,
+                repeat=1,
+            ),
+            on_trace_ready=torch.profiler.tensorboard_trace_handler(PROFILE_DIR),
+            record_shapes=True,
+            profile_memory=True,
+            with_stack=True,
+        )
+        profiler.start()
+        log0(f"Profiler active: steps {PROFILE_START}-{PROFILE_END}, output to {PROFILE_DIR}/")
+
+    losses = []
+    t0 = time.perf_counter()
+    step = 0
+    stop_after = None
+    last_log_t = t0
+    last_log_step = 0
+    train_tok_processed = 0.0
+    last_log_tok_processed = 0.0
+    # Pre-compute constants outside the loop
+    _ga_inv = 1.0 / float(GRAD_ACCUM)
+    _sc_inv = 1.0 / float(STREAM_CHUNKS)
+    _chunk_len = SEQ_LEN // STREAM_CHUNKS
+    # Accumulator on GPU — avoids .item() CUDA sync every micro-batch
+    _loss_accum = torch.zeros((), device=DEVICE, dtype=torch.float32)
+    # Pre-allocated stop signal — reused every check to avoid tensor allocation
+    _stop_flag = torch.zeros(1, device=DEVICE, dtype=torch.float32)
+    _STOP_CHECK_EVERY = int(os.environ.get("STOP_CHECK_EVERY", "100"))  # fewer syncs; may overshoot slightly
+    _REPLAY_FRAC = float(os.environ.get("REPLAY_FRAC", "0.0"))  # race default: disabled
+    _replay_triggered = False
+    log0(f"Training for up to {ITERATIONS} steps (cap={MAX_WALLCLOCK_SECONDS}s)")
+    log0(f"Replay: will reset data stream at {_REPLAY_FRAC*100:.0f}% wall time")
+
+    while step < ITERATIONS:
+        # Wallclock stop: broadcast from rank 0 every N steps so all ranks
+        # exit on the exact same step. DDP requires all ranks to participate
+        # in every forward/backward, so even ±1 step desync causes a hang.
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+            _stop_flag.fill_(
+                1.0 if (MAX_WALLCLOCK_SECONDS > 0 and elapsed >= MAX_WALLCLOCK_SECONDS) else 0.0
+            )
+            dist.broadcast(_stop_flag, src=0)
+            if _stop_flag.item() > 0.5:
+                stop_after = step
+                break
+
+        if step % _STOP_CHECK_EVERY == 0:
+            elapsed = time.perf_counter() - t0
+        # Replay trigger: reset data stream to replay previously seen tokens
+        if not _replay_triggered and _REPLAY_FRAC > 0 and MAX_WALLCLOCK_SECONDS > 0:
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= _REPLAY_FRAC:
+                loader.reset_stream()
+                _replay_triggered = True
+                log0(f"REPLAY: data stream reset at step {step} ({frac*100:.0f}% wall time)")
+        # Depth recurrence activation: enable looping after warmup phase
+        if (LOOP_START >= 0 and not base_model.loop_enabled_external
+                and MAX_WALLCLOCK_SECONDS > 0):
+            frac = elapsed / MAX_WALLCLOCK_SECONDS
+            if frac >= LOOP_ACTIVATE_FRAC:
+                base_model.loop_enabled_external = True
+                log0(f"LOOP: depth recurrence activated at step {step} "
+                     f"({frac*100:.0f}% wall) enc={base_model.loop_enc_seq} "
+                     f"dec={base_model.loop_dec_seq}")
+        mul = lr_schedule(step, elapsed)
+        for group in optimizer_adamw.param_groups:
+            group["lr"] = group["base_lr"] * mul
+        if optimizer_muon is not None:
+            for group in optimizer_muon.param_groups:
+                group["lr"] = group["base_lr"] * mul
+            # Muon momentum warmup: ramp from MUON_MOMENTUM_WARMUP_START to MUON_MOMENTUM
+            if MUON_MOMENTUM_WARMUP_STEPS > 0:
+                frac = min(step / MUON_MOMENTUM_WARMUP_STEPS, 1.0)
+                cur_momentum = (1 - frac) * MUON_MOMENTUM_WARMUP_START + frac * MUON_MOMENTUM
+                for group in optimizer_muon.param_groups:
+                    group["momentum"] = cur_momentum
+
+        optimizer_adamw.zero_grad(set_to_none=True)
+        if optimizer_muon is not None:
+            optimizer_muon.zero_grad(set_to_none=True)
+
+        # --- Gradient accumulation inner loop ---
+        _loss_accum.zero_()
+        accum_tok = 0.0
+        for ga_step in range(GRAD_ACCUM):
+            x, y, reset_chunks = loader.next_batch()
+
+            # Batch warmup: use fewer sequences early for faster updates
+            full_seqs = x.shape[0]
+            use_seqs = batch_warmup_seqs(step, full_seqs)
+            if use_seqs < full_seqs:
+                x = x[:use_seqs]
+                y = y[:use_seqs]
+                if reset_chunks is not None:
+                    reset_chunks = reset_chunks[:use_seqs]
+
+            active_stream_chunks = stream_chunks_for_step(step)
+            # Disable DDP gradient sync on all but the last micro-batch
+            no_sync = (ga_step < GRAD_ACCUM - 1) and hasattr(model, 'no_sync')
+            ctx = model.no_sync() if no_sync else nullcontext()
+            with ctx:
+                if active_stream_chunks == 1:
+                    with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                        xs = x[:, :_chunk_len]
+                        ys = y[:, :_chunk_len]
+                        micro_loss = lm_loss(model, xs, ys)
+                else:
+                    state = None
+                    micro_loss = torch.zeros((), device=DEVICE, dtype=torch.float32)
+                    for c in range(active_stream_chunks):
+                        xs = x[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        ys = y[:, c * _chunk_len : (c + 1) * _chunk_len]
+                        if c > 0 and reset_chunks is not None:
+                            state = apply_state_reset_mask(state, reset_chunks[:, c])
+                        with torch.autocast(device_type="cuda", dtype=AMP_DTYPE, enabled=True):
+                            loss_c, state = lm_loss(model, xs, ys, state=state, return_state=True)
+                        micro_loss = micro_loss + (loss_c / float(active_stream_chunks))
+                        if ((c + 1) % BPTT_CHUNKS) == 0:
+                            state = detach_state(state)
+
+                # Scale loss by 1/GRAD_ACCUM so gradients average correctly
+                scaled_loss = micro_loss * _ga_inv
+                if scaler.is_enabled():
+                    scaler.scale(scaled_loss).backward()
+                else:
+                    scaled_loss.backward()
+
+            # Accumulate on GPU — no .item() CUDA sync
+            _loss_accum += micro_loss.detach()
+            micro_tok_ratio = (use_seqs / full_seqs) * (active_stream_chunks * _sc_inv)
+            accum_tok += TRAIN_BATCH_TOK * micro_tok_ratio * _ga_inv
+
+        # --- End accumulation loop, now step ---
+        train_tok_processed += accum_tok
+
+        if scaler.is_enabled():
+            scaler.unscale_(optimizer_adamw)
+            inv_scale = 1.0 / float(scaler.get_scale())
+            for p in matrix_params:
+                if p.grad is not None:
+                    p.grad.mul_(inv_scale)
+
+        if GRAD_CLIP > 0:
+            nn.utils.clip_grad_norm_(base_model.parameters(), GRAD_CLIP)
+
+        if scaler.is_enabled():
+            scaler.step(optimizer_adamw)
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+            scaler.update()
+        else:
+            optimizer_adamw.step()
+            if optimizer_muon is not None:
+                optimizer_muon.step()
+
+        step += 1
+
+        # EMA update
+        if ema is not None:
+            ema.update(base_model)
+
+        # SWA checkpoint collection
+        if swa is not None:
+            elapsed_frac = (time.perf_counter() - t0) / max(MAX_WALLCLOCK_SECONDS, 1.0)
+            if swa.maybe_start(elapsed_frac):
+                log0(f"SWA collection started at step {step} (elapsed {elapsed_frac:.2f})")
+            if swa.collecting and step % SWA_EVERY == 0:
+                swa.collect(base_model)
+
+        # Profiler step
+        if profiler is not None:
+            profiler.step()
+            if step > PROFILE_END:
+                profiler.stop()
+                log0(f"Profiler stopped. Traces saved to {PROFILE_DIR}/")
+                log0("\n=== PROFILE: sorted by cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="cuda_time_total", row_limit=30
+                ))
+                log0("\n=== PROFILE: sorted by self_cuda_time_total ===")
+                log0(profiler.key_averages().table(
+                    sort_by="self_cuda_time_total", row_limit=30
+                ))
+                profiler = None
+
+        # Logging — only .item() on log steps (forces one CUDA sync per log)
+        if step <= 5 or step % LOG_EVERY == 0:
+            lv = float((_loss_accum * _ga_inv).item())
+            now = time.perf_counter()
+            dt = max(now - last_log_t, 1e-9)
+            dtok = max(train_tok_processed - last_log_tok_processed, 0.0)
+            tok_s_inst = dtok / dt
+            tok_s_avg = train_tok_processed / max((now - t0), 1e-9)
+            log0(
+                f"step:{step}/{ITERATIONS} loss:{lv:.4f} lr:{mul:.3f} "
+                f"tok/s_inst:{tok_s_inst:.0f} tok/s_avg:{tok_s_avg:.0f}"
+            )
+            last_log_t = now
+            last_log_step = step
+            last_log_tok_processed = train_tok_processed
+            losses.append(lv)
+        else:
+            losses.append(None)  # placeholder — no sync on non-log steps
+
+        if VAL_EVERY > 0 and step % VAL_EVERY == 0:
+            vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+            log0(f"  -> val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+            if ema is not None:
+                ema.apply_shadow(base_model)
+                evl, evb = eval_val(model, val_tokens, bb, hs, ib)
+                ema.restore(base_model)
+                log0(f"  -> ema_val_loss:{evl:.4f} ema_val_bpb:{evb:.4f}")
+
+    # Clean up profiler
+    if profiler is not None:
+        profiler.stop()
+        log0(f"Profiler stopped early. Traces saved to {PROFILE_DIR}/")
+        log0(profiler.key_averages().table(sort_by="cuda_time_total", row_limit=30))
+        profiler = None
+
+    train_elapsed = time.perf_counter() - t0
+    log0(f"Training complete: {step} steps in {train_elapsed:.1f}s")
+    if stop_after is not None:
+        log0(f"stopping_early: wallclock_cap at step {stop_after}/{ITERATIONS}")
+
+    # Sync all ranks before eval to prevent NCCL desync
+    dist.barrier()
+    log0("All ranks synced. Starting evaluation...")
+
+    # Eval with live weights (standard, fast)
+    vl, vb = eval_val(model, val_tokens, bb, hs, ib)
+    log0(f"Final val_loss:{vl:.4f} val_bpb:{vb:.4f}")
+    best_vl, best_vb, best_source = vl, vb, "live"
+
+    # Eval with SWA weights (standard, fast)
+    if swa is not None and swa.n_checkpoints > 0:
+        log0(f"SWA: averaging {swa.n_checkpoints} checkpoints")
+        swa.apply_average(base_model)
+        swa_vl, swa_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"SWA   val_loss:{swa_vl:.4f} val_bpb:{swa_vb:.4f}")
+        log0(f"SWA delta vs live: loss={vl - swa_vl:+.4f} bpb={vb - swa_vb:+.4f}")
+        if swa_vb < best_vb:
+            best_vl, best_vb, best_source = swa_vl, swa_vb, "swa"
+        else:
+            swa.restore(base_model)
+
+    # Eval with EMA weights (standard, fast)
+    if ema is not None:
+        ema.apply_shadow(base_model)
+        ema_vl, ema_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"EMA   val_loss:{ema_vl:.4f} val_bpb:{ema_vb:.4f}")
+        if ema_vb < best_vb:
+            best_vl, best_vb, best_source = ema_vl, ema_vb, "ema"
+        ema.restore(base_model)
+
+    # Load best weights for sliding window eval
+    if best_source == "swa" and swa is not None:
+        swa.apply_average(base_model)
+    elif best_source == "ema" and ema is not None:
+        ema.apply_shadow(base_model)
+    log0(f"Best (standard): {best_source} val_loss:{best_vl:.4f} val_bpb:{best_vb:.4f}")
+
+    # Sliding window eval on best weights (pre-TTT baseline)
+    pre_ttt_sw_vb = None
+    if EVAL_STRIDE < SEQ_LEN:
+        log0(f"Running sliding window eval (stride={EVAL_STRIDE})...")
+        sw_vl, sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Sliding val_loss:{sw_vl:.4f} val_bpb:{sw_vb:.4f}")
+        log0(f"Sliding vs standard: bpb={best_vb - sw_vb:+.4f}")
+        pre_ttt_sw_vb = sw_vb
+
+    if CARRYOVER_EVAL_ENABLED:
+        dist.barrier()
+        log0("Running direct-kernel stateful-overlap carryover eval...")
+        co_vl, co_vb = eval_val_carryover(model, val_tokens, bb, hs, ib)
+        log0(f"Carryover val_loss:{co_vl:.4f} val_bpb:{co_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Carryover vs sliding: bpb={pre_ttt_sw_vb - co_vb:+.4f}")
+
+    # --- Score-First TTT (SOTA-style legal eval-time adaptation) ---
+    if SCORE_FIRST_TTT_ENABLED and EVAL_STRIDE < SEQ_LEN:
+        dist.barrier()
+        # Reload best weights before Score-First TTT (it modifies in-place then restores)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+        log0("=" * 60)
+        log0(f"Running Score-First TTT eval (chunk={SCORE_FIRST_TTT_CHUNK_TOKENS} tokens)...")
+        sft_vl, sft_vb = eval_score_first_ttt(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+        log0(f"Score-First TTT val_loss:{sft_vl:.4f} val_bpb:{sft_vb:.4f}")
+        if pre_ttt_sw_vb is not None:
+            log0(f"Score-First TTT vs sliding: bpb={pre_ttt_sw_vb - sft_vb:+.4f}")
+        log0("=" * 60)
+
+    # --- TTT Pipeline ---
+    # Phase 1: Global TTT — adapt weights on the val distribution
+    # Phase 2: Re-evaluate with adapted weights (standard + sliding)
+    if TTT_ENABLED:
+        dist.barrier()
+
+        # Ensure best weights are loaded before TTT
+        # (they should already be from the block above, but be explicit)
+        if best_source == "swa" and swa is not None:
+            if not hasattr(swa, 'backup') or not swa.backup:
+                swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            if not hasattr(ema, 'backup') or not ema.backup:
+                ema.apply_shadow(base_model)
+
+        # Phase 1: Global TTT adaptation
+        log0("=" * 60)
+        log0("Starting TTT global adaptation on val distribution...")
+        ttt_base_state, ttt_adapt_names = ttt_global_adapt(model, val_tokens)
+
+        # Phase 2a: Standard eval with TTT-adapted weights
+        ttt_vl, ttt_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"TTT global val_loss:{ttt_vl:.4f} val_bpb:{ttt_vb:.4f}")
+        log0(f"TTT global vs best standard: bpb={best_vb - ttt_vb:+.4f}")
+
+        # Phase 2b: Sliding window eval with TTT-adapted weights
+        if EVAL_STRIDE < SEQ_LEN:
+            log0(f"Running sliding window eval with TTT weights (stride={EVAL_STRIDE})...")
+            ttt_sw_vl, ttt_sw_vb = eval_val_sliding(
+                model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"TTT sliding val_loss:{ttt_sw_vl:.4f} val_bpb:{ttt_sw_vb:.4f}")
+            if pre_ttt_sw_vb is not None:
+                log0(f"TTT sliding vs pre-TTT sliding: bpb={pre_ttt_sw_vb - ttt_sw_vb:+.4f}")
+
+        # Restore weights after TTT eval
+        ttt_restore_weights(base_model, ttt_base_state, ttt_adapt_names)
+        log0("TTT weights restored.")
+        log0("=" * 60)
+    else:
+        # Restore live weights if no TTT
+        if best_source == "swa" and swa is not None:
+            swa.restore(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.restore(base_model)
+
+    if not RUN_POSTQUANT:
+        log0("Skipping quantization/post-quant eval/artifact because RUN_POSTQUANT=0")
+    else:
+        # -----------------------------------------------------------------------
+        # Aggressive role-bit packed + LZMA compression path.
+        # -----------------------------------------------------------------------
+        if best_source == "swa" and swa is not None:
+            swa.apply_average(base_model)
+        elif best_source == "ema" and ema is not None:
+            ema.apply_shadow(base_model)
+
+        if QUANT_FORMAT not in ("fullmuon_aggressive_lzma", "hybrid_aggressive_lzma"):
+            raise RuntimeError(
+                f"Unsupported QUANT_FORMAT={QUANT_FORMAT}; use fullmuon_aggressive_lzma"
+            )
+
+        def _is_embedding_like(n: str) -> bool:
+            return (
+                n == "tok_emb.weight" or n == "lm_head.weight" or
+                n.startswith("bigram.embed") or n.startswith("bigram.proj") or
+                "embed" in n
+            )
+
+        def _is_ffn_gate(n: str) -> bool:
+            return ".ffn.gate_up.weight" in n
+
+        def _is_ffn_down(n: str) -> bool:
+            return ".ffn.down.weight" in n
+
+        def _is_attn_weight(n: str) -> bool:
+            return (".qkv.weight" in n) or (".out_proj.weight" in n and ".mamba." not in n)
+
+        def _is_mamba_weight(n: str) -> bool:
+            return ".mamba." in n
+
+        def _qmax_for_bits(bits: int) -> int:
+            if bits < 2 or bits > 8:
+                raise ValueError(f"bits must be in [2,8], got {bits}")
+            return (1 << (bits - 1)) - 1
+
+        def _role_bits_k(name: str):
+            if _is_ffn_gate(name):
+                return QUANT_BITS_FFN_GATE, QUANT_K_FFN_GATE, "ffn_gate"
+            if _is_ffn_down(name):
+                return QUANT_BITS_FFN_DOWN, QUANT_K_FFN_DOWN, "ffn_down"
+            if _is_mamba_weight(name):
+                return QUANT_BITS_MAMBA, QUANT_K_MAMBA, "mamba"
+            if _is_attn_weight(name):
+                return QUANT_BITS_ATTN, QUANT_K_ATTN, "attention"
+            if _is_embedding_like(name):
+                return QUANT_BITS_EMBED, QUANT_K_EMBED, "embedding"
+            return QUANT_BITS_MATRIX, QUANT_K_MATRIX, "other_matrix"
+
+        def _pack_signed_q(q: torch.Tensor, bits: int):
+            """Pack signed symmetric q values [-qmax, qmax] into b bytes per 8 values."""
+            qmax = _qmax_for_bits(bits)
+            shape = tuple(q.shape)
+            flat = (q.to(torch.int16).reshape(-1).cpu() + qmax).clamp(0, (1 << bits) - 1).to(torch.uint8)
+            n = int(flat.numel())
+            if bits == 8:
+                return flat.contiguous(), shape, n, bits, qmax
+            pad = (-n) % 8
+            if pad:
+                flat = torch.cat([flat, torch.zeros(pad, dtype=torch.uint8)])
+            x = flat.view(-1, 8).to(torch.int64)
+            word = torch.zeros(x.shape[0], dtype=torch.int64)
+            for i in range(8):
+                word |= (x[:, i] << (bits * i))
+            out = torch.empty((x.shape[0], bits), dtype=torch.uint8)
+            for j in range(bits):
+                out[:, j] = ((word >> (8 * j)) & 0xFF).to(torch.uint8)
+            return out.contiguous().view(-1), shape, n, bits, qmax
+
+        def _unpack_signed_q(packed: torch.Tensor, shape, n: int, bits: int, qmax: int):
+            if bits == 8:
+                flat = packed.cpu().contiguous().view(-1)[:n].to(torch.int16)
+                return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+            b = packed.cpu().contiguous().view(-1, bits).to(torch.int64)
+            word = torch.zeros(b.shape[0], dtype=torch.int64)
+            for j in range(bits):
+                word |= (b[:, j] << (8 * j))
+            vals = []
+            mask = (1 << bits) - 1
+            for i in range(8):
+                vals.append(((word >> (bits * i)) & mask).to(torch.int16))
+            flat = torch.stack(vals, dim=1).reshape(-1)[:n]
+            return (flat - int(qmax)).to(torch.int8).view(*shape).contiguous()
+
+        def _mamba_dt_rows(name: str, rows: int):
+            if not (QUANT_PROTECT_DYNAMICS and name.endswith("mamba.in_proj.weight")):
+                return None
+            n_dt = max(1, (2 * D_MODEL) // max(1, HEADDIM))
+            n_dt = min(n_dt, rows)
+            return torch.arange(rows - n_dt, rows, dtype=torch.long)
+
+        def _quantize_rows(t32: torch.Tensor, bits: int, k: float, optclip: bool = False):
+            qmax = float(_qmax_for_bits(bits))
+            if t32.ndim == 2:
+                rows = t32.shape[0]
+                max_abs = t32.abs().amax(dim=1).clamp_min(1e-8)
+                std_abs = t32.float().std(dim=1).clamp_min(1e-8)
+                base_clip = torch.minimum(max_abs, std_abs * float(k)).clamp_min(1e-8)
+                if optclip and QUANT_OPTCLIP_STEPS > 1:
+                    best_err = torch.full((rows,), float("inf"), dtype=torch.float32)
+                    best_q = None
+                    best_scale = None
+                    fracs = torch.linspace(
+                        float(QUANT_OPTCLIP_MIN_FRAC),
+                        float(QUANT_OPTCLIP_MAX_FRAC),
+                        steps=int(QUANT_OPTCLIP_STEPS),
+                        dtype=torch.float32,
+                    )
+                    for frac in fracs:
+                        clip_abs = (base_clip * float(frac)).clamp_min(1e-8)
+                        scale_f = (clip_abs / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax)
+                        q_try = torch.round(torch.clamp(t32, -clip_abs[:, None], clip_abs[:, None]) / scale_f[:, None]).clamp(-qmax, qmax)
+                        err = (q_try * scale_f[:, None] - t32).pow(2).mean(dim=1)
+                        mask = err < best_err
+                        if best_q is None:
+                            best_q = q_try.to(torch.int8)
+                            best_scale = scale_f
+                            best_err = err
+                        else:
+                            best_q[mask] = q_try[mask].to(torch.int8)
+                            best_scale[mask] = scale_f[mask]
+                            best_err[mask] = err[mask]
+                    return best_q.contiguous(), best_scale.to(torch.float16).contiguous()
+                scale = (base_clip / qmax).clamp_min(float(QUANT_SCALE_FLOOR_MULT) / qmax).to(torch.float16).contiguous()
+                q = torch.round(torch.clamp(t32, -base_clip[:, None], base_clip[:, None]) / scale.float()[:, None]).clamp(-qmax, qmax).to(torch.int8).contiguous()
+                return q, scale
+            else:
+                max_abs = float(t32.abs().max().item()) if t32.numel() else 0.0
+                std_abs = float(t32.float().std().item()) if t32.numel() else 0.0
+                clip_abs = max(1e-8, min(max_abs, std_abs * float(k)) if std_abs > 0 else max_abs)
+                qmaxf = qmax
+                scale = max(clip_abs / qmaxf, float(QUANT_SCALE_FLOOR_MULT) / qmaxf)
+                q = torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale).clamp(-qmaxf, qmaxf).to(torch.int8).contiguous()
+                return q, torch.tensor(scale, dtype=torch.float16)
+
+        def _quantize_float_tensor(name: str, t: torch.Tensor):
+            t32 = t.float().cpu().contiguous()
+            bits, k, role = _role_bits_k(name)
+            q, scale = _quantize_rows(t32, bits, k, optclip=(_is_embedding_like(name) and QUANT_OPTCLIP_EMBED and t32.ndim == 2))
+            override = None
+            rows_to_override = _mamba_dt_rows(name, t32.shape[0] if t32.ndim == 2 else 0)
+            if rows_to_override is not None and rows_to_override.numel() > 0:
+                q8, s8 = _quantize_rows(t32[rows_to_override], 8, QUANT_K_MAMBA, optclip=False)
+                override = {
+                    "rows": rows_to_override.to(torch.int32),
+                    "q": q8.contiguous(),
+                    "scale": s8.contiguous(),
+                    "bits": 8,
+                    "qmax": 127,
+                }
+            return q, scale, bits, role, override
+
+        def _prune_low_error_ones(q_map, scale_map, prune_frac: float):
+            if prune_frac <= 0:
+                return 0, 0
+            errs = []
+            total_ones = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                counts = (q.abs() == 1).sum(dim=1).cpu()
+                if int(counts.sum().item()) == 0:
+                    continue
+                row_err = s.float().pow(2).cpu()
+                errs.append(torch.repeat_interleave(row_err, counts))
+                total_ones += int(counts.sum().item())
+            if total_ones == 0 or not errs:
+                return 0, 0
+            n_prune_target = int(max(0, min(total_ones, round(total_ones * float(prune_frac)))))
+            if n_prune_target <= 0:
+                return total_ones, 0
+            all_err = torch.cat(errs)
+            kth = max(1, min(n_prune_target, all_err.numel()))
+            threshold = float(torch.kthvalue(all_err, kth).values.item())
+            pruned = 0
+            for name, q in q_map.items():
+                s = scale_map[name]
+                if q.ndim != 2 or s.ndim != 1:
+                    continue
+                row_mask = (s.float().pow(2) <= threshold).view(-1, *([1] * (q.ndim - 1)))
+                mask = (q.abs() == 1) & row_mask
+                pruned += int(mask.sum().item())
+                q[mask] = 0
+            return total_ones, pruned
+
+        def _build_quant_blob(q_entries, scale_entries, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac: float):
+            q_map = {k: v.clone() for k, v in q_entries.items()}
+            total_ones, pruned = _prune_low_error_ones(q_map, scale_entries, prune_frac)
+            packed_quantized, byte_quantized = {}, {}
+            stats = {
+                "packed_tensors": 0, "byte_tensors": 0, "packed_bytes": 0, "byte_q_numel": 0,
+                "fp_numel": sum(v.numel() for v in passthrough.values()),
+                "role_numel": {}, "role_packed_bytes": {},
+                "total_ones": total_ones, "pruned": pruned,
+            }
+            for name, q in q_map.items():
+                bits = int(bits_entries[name])
+                role = role_entries[name]
+                stats["role_numel"][role] = stats["role_numel"].get(role, 0) + int(q.numel())
+                if QUANT_PACK_ALL and bits < 8:
+                    packed, shape, n, bits2, qmax = _pack_signed_q(q, bits)
+                    packed_quantized[name] = {"data": packed, "shape": shape, "numel": int(n), "bits": int(bits2), "qmax": int(qmax), "role": role}
+                    stats["packed_tensors"] += 1
+                    stats["packed_bytes"] += int(packed.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(packed.numel())
+                else:
+                    byte_quantized[name] = q.contiguous()
+                    stats["byte_tensors"] += 1
+                    stats["byte_q_numel"] += int(q.numel())
+                    stats["role_packed_bytes"][role] = stats["role_packed_bytes"].get(role, 0) + int(q.numel())
+            quant_obj = {
+                "format": QUANT_FORMAT,
+                "quantized": byte_quantized,
+                "packed_quantized": packed_quantized,
+                "scales": scale_entries,
+                "row_overrides": overrides,
+                "passthrough": passthrough,
+                "aliases": aliases,
+                "meta": {
+                    "bits": {
+                        "ffn_gate": QUANT_BITS_FFN_GATE,
+                        "ffn_down": QUANT_BITS_FFN_DOWN,
+                        "mamba": QUANT_BITS_MAMBA,
+                        "attention": QUANT_BITS_ATTN,
+                        "embed": QUANT_BITS_EMBED,
+                        "other": QUANT_BITS_MATRIX,
+                    },
+                    "pack_all": QUANT_PACK_ALL,
+                    "scale_floor_mult": QUANT_SCALE_FLOOR_MULT,
+                    "protect_dynamics": QUANT_PROTECT_DYNAMICS,
+                    "optclip_embed": QUANT_OPTCLIP_EMBED,
+                    "prune_ones_frac": prune_frac,
+                },
+            }
+            buf = io.BytesIO()
+            torch.save(quant_obj, buf)
+            raw = buf.getvalue()
+            lzma_preset = QUANT_LZMA_PRESET | (lzma.PRESET_EXTREME if QUANT_LZMA_EXTREME else 0)
+            blob = lzma.compress(raw, preset=lzma_preset)
+            return quant_obj, raw, blob, stats
+
+        log0("Quantizing model with aggressive role-bit packing + LZMA...")
+        state_dict = base_model.state_dict()
+        q_entries, scales, bits_entries, role_entries, passthrough, aliases, overrides = {}, {}, {}, {}, {}, {}, {}
+        base_stats = {"alias": 0, "passthrough": 0, "quantized": 0, "role_numel": {}}
+
+        tied_lm_weight = (
+            "tok_emb.weight" in state_dict and "lm_head.weight" in state_dict and
+            state_dict["tok_emb.weight"].shape == state_dict["lm_head.weight"].shape
+        )
+
+        for name, t in state_dict.items():
+            if tied_lm_weight and name == "lm_head.weight":
+                aliases[name] = "tok_emb.weight"
+                base_stats["alias"] += 1
+                continue
+            tcpu = t.detach().cpu().contiguous()
+            if (not tcpu.is_floating_point()) or tcpu.numel() <= QUANT_PASSTHROUGH_NUMEL:
+                if tcpu.is_floating_point() and tcpu.dtype in (torch.float32, torch.bfloat16):
+                    passthrough[name] = tcpu.to(torch.float16).contiguous()
+                else:
+                    passthrough[name] = tcpu
+                base_stats["passthrough"] += 1
+                continue
+            q, scale, bits, role, override = _quantize_float_tensor(name, tcpu)
+            q_entries[name] = q
+            scales[name] = scale
+            bits_entries[name] = int(bits)
+            role_entries[name] = role
+            if override is not None:
+                overrides[name] = override
+            base_stats["quantized"] += 1
+            base_stats["role_numel"][role] = base_stats["role_numel"].get(role, 0) + int(q.numel())
+
+        candidate_fracs = [QUANT_PRUNE_ONES_FRAC]
+        if QUANT_AUTO_PRUNE_TO_BYTES:
+            candidate_fracs = sorted(set(candidate_fracs + QUANT_AUTO_PRUNE_FRACS))
+        best_tuple = None
+        for frac in candidate_fracs:
+            quant_obj_c, raw_c, blob_c, stats_c = _build_quant_blob(
+                q_entries, scales, bits_entries, role_entries, overrides, passthrough, aliases, prune_frac=float(frac)
+            )
+            log0(
+                f"Quant candidate prune={float(frac):.3f}: compressed={len(blob_c):,} bytes, "
+                f"raw={len(raw_c):,}, packed_bytes={stats_c['packed_bytes']:,}, byte_q={stats_c['byte_q_numel']:,}, "
+                f"ones={stats_c['total_ones']:,}, pruned={stats_c['pruned']:,}"
+            )
+            if best_tuple is None:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+            if len(blob_c) <= QUANT_TARGET_BYTES:
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+                break
+            if len(blob_c) < len(best_tuple[2]):
+                best_tuple = (quant_obj_c, raw_c, blob_c, stats_c, float(frac))
+
+        quant_obj, quant_raw, quant_blob, q_stats, selected_prune = best_tuple
+        compressed_bytes = len(quant_blob)
+        raw_bytes = len(quant_raw)
+        q_raw_bytes = (
+            q_stats["byte_q_numel"] + q_stats["packed_bytes"] +
+            sum(v.numel() * v.element_size() for v in scales.values()) +
+            sum(v.numel() * v.element_size() for v in passthrough.values()) +
+            sum(ov["q"].numel() * ov["q"].element_size() + ov["scale"].numel() * ov["scale"].element_size() + ov["rows"].numel() * ov["rows"].element_size() for ov in overrides.values())
+        )
+        log0(
+            f"Selected quant prune={selected_prune:.3f}: byte_q_tensors={q_stats['byte_tensors']}, "
+            f"packed_q_tensors={q_stats['packed_tensors']}, passthrough={base_stats['passthrough']}, alias={base_stats['alias']}, "
+            f"packed_bytes={q_stats['packed_bytes']:,}, byte_q_numel={q_stats['byte_q_numel']:,}, "
+            f"approx_payload={q_raw_bytes/1024/1024:.2f} MiB"
+        )
+        log0(f"Role quantized numel: {base_stats['role_numel']}")
+        log0(f"Role packed/byte payload bytes: {q_stats['role_packed_bytes']}")
+        log0(f"Serialized raw torch.save: {raw_bytes:,} bytes ({raw_bytes/1024/1024:.2f} MiB)")
+        log0(f"Compressed model (lzma{QUANT_LZMA_PRESET}{'+extreme' if QUANT_LZMA_EXTREME else ''}): {compressed_bytes:,} bytes ({compressed_bytes / 1024 / 1024:.2f} MiB)")
+        if compressed_bytes <= 16_000_000:
+            log0("Artifact size check: UNDER 16,000,000-byte cap before code bytes")
+        else:
+            log0("Artifact size check: OVER 16,000,000-byte cap before code bytes")
+
+        # Roundtrip: decompress, dequantize, reload, and re-evaluate.
+        quant_obj_rt = torch.load(io.BytesIO(lzma.decompress(quant_blob)), map_location="cpu")
+        dequant_state = {}
+        for name, q in quant_obj_rt.get("quantized", {}).items():
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, pack_obj in quant_obj_rt.get("packed_quantized", {}).items():
+            q = _unpack_signed_q(
+                pack_obj["data"], tuple(pack_obj["shape"]), int(pack_obj["numel"]),
+                int(pack_obj["bits"]), int(pack_obj["qmax"])
+            )
+            s = quant_obj_rt["scales"][name]
+            if s.ndim > 0:
+                dequant_state[name] = (q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))).to(torch.bfloat16)
+            else:
+                dequant_state[name] = (q.float() * float(s.item())).to(torch.bfloat16)
+        for name, ov in quant_obj_rt.get("row_overrides", {}).items():
+            if name in dequant_state:
+                rows = ov["rows"].long()
+                q8 = ov["q"].float()
+                s8 = ov["scale"].float()
+                dequant_state[name][rows] = (q8 * s8.view(-1, *([1] * (q8.ndim - 1)))).to(torch.bfloat16)
+        for name, t in quant_obj_rt["passthrough"].items():
+            dequant_state[name] = t
+        for name, src_name in quant_obj_rt.get("aliases", {}).items():
+            dequant_state[name] = dequant_state[src_name]
+
+        base_model.load_state_dict(dequant_state, strict=True)
+        q_vl, q_vb = eval_val(model, val_tokens, bb, hs, ib)
+        log0(f"Post-quant val_loss:{q_vl:.4f} val_bpb:{q_vb:.4f}")
+        if EVAL_STRIDE < SEQ_LEN:
+            q_sw_vl, q_sw_vb = eval_val_sliding(model, val_tokens, bb, hs, ib, stride=EVAL_STRIDE)
+            log0(f"Post-quant sliding val_loss:{q_sw_vl:.4f} val_bpb:{q_sw_vb:.4f}")
+
+        if MASTER_PROCESS:
+            artifact_path = f"final_model.{QUANT_FORMAT}.lzma"
+            with open(artifact_path, "wb") as f:
+                f.write(quant_blob)
+            log0(f"Saved artifact: {artifact_path} ({compressed_bytes:,} bytes)")
+
+    # Shutdown async loader
+    try:
+        loader.shutdown()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    finally:
+        if dist.is_available() and dist.is_initialized():
+            dist.barrier()
+            dist.destroy_process_group()


### PR DESCRIPTION
## Summary

Adds a non-record submission documenting a Mamba2/SSM + single-attention hybrid trained at SP8192. Single-run, 600s on 8×H100.

**Submitted-run numbers** (Run #2 in `train.log`, moderate role-bit packed LZMA quant):
- Pre-quant sliding `val_bpb`: **1.1005**
- Post-quant sliding `val_bpb`: **1.2938**
- Compressed artifact: **16,094,692 bytes** (~95 KB over the 16 MB cap before code bytes)
- 45.65M params, 4,300 steps, SEQ_LEN=8,192

**Why non-record:** The architecture's pre-quant quality is competitive (sliding 1.10), but the compression cliff is real. A more aggressive variant (Run #1, also in `train.log`) does fit at 10.9 MB, but post-quant collapses to 2.12 BPB. We submit this as a research contribution documenting:
1. SSM-heavy hybrids work well at full precision
2. Compression — not architecture or optimizer — is the remaining bottleneck for SSM-hybrid submissions
3. Experiment chronicle in the README covers ~50+ related ablations (carrier-style SSMs, depth recurrence, AdamW vs Muon for Mamba, BF16 storage, byte-int6/LZMA, trust-clipped Muon)

The architecture matches the "State-space models" item in the "Requests for PRs" list.

## Files

- `README.md` — submission story + full ablation chronicle + reproduction commands
- `submission.json` — metadata (post-quant numbers)
- `train_gpt.py` — `ssm_recall_sota_sp8192_fullmuon_final_compress.py` (the actual file used)
- `train.log` — both completed runs end-to-end
- `requirements.txt` — Python deps

## Test plan

- [x] Reviewer can rerun on a fresh 8×H100 pod with the env command in the `Reproduction` section of the README
- [x] `train.log` shows the actual numbers reported in `submission.json`