### PR TITLE
Non-record: ACN Output Accumulator on the Naive Baseline

### DIFF
--- a/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/README.md
+++ b/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/README.md
@@ -1,0 +1,105 @@
+# ACN Output Accumulator on the Naive Baseline
+
+**Non-Record Submission (Idea Probe)**
+**Author:** Chris Coffee ([@chrico-bu-uab](https://github.com/chrico-bu-uab))
+**Base:** Official `train_gpt.py` baseline (1.2244 bpb)
+**Result:** 1.2265 bpb (ACN on) vs 1.2262 bpb (ACN off) — wallclock-tied
+**Idea:** Auto-Compressing Networks (Bose et al., 2025 — arxiv [2506.09714](https://arxiv.org/abs/2506.09714)) output accumulator, gated behind `ACN_OUTPUT=1`.
+
+## TL;DR
+
+I added one knob to the official baseline: each transformer block's hidden state is added (with a learnable per-layer scalar, init to zero) to the final pre-`final_norm` representation. With the cap on, the result is essentially tied with the unmodified baseline. With the cap conceptually removed and runs compared at equal step counts, ACN is ~0.006 bpb better. The naive accumulator costs ~2 % wallclock per step, which exactly eats the per-step gain in this 10-minute regime.
+
+That's the whole story: ACN gives a small but real signal on the baseline architecture, but the naive implementation is too expensive to convert into a record. This is a one-seed idea probe, not a tuned submission.
+
+## What ACN does (and what's actually in the diff)
+
+The Auto-Compressing Networks paper proposes letting every block contribute directly to the final representation, rather than having information flow only through the residual stream. With per-layer scales initialized to zero, the model starts identical to the baseline and only opts into auxiliary contributions where they pay for themselves.
+
+The full diff against the official `train_gpt.py` is 16 lines. In the `GPT.forward` loop:
+
+```python
+hidden_states.append(x)              # collected after each block
+...
+if self.output_scales is not None:
+    scales = self.output_scales.to(dtype=x.dtype)
+    for i, h in enumerate(hidden_states):
+        x = x + scales[i] * h
+x = self.final_norm(x)
+```
+
+`output_scales` is a single `nn.Parameter` of shape `[num_layers]` (9 floats — adds 9 params total, +36 bytes uncompressed). It's added to the scalar-LR optimizer group, picked up automatically by `CONTROL_TENSOR_NAME_PATTERNS` for fp32 retention. Everything else is unchanged from the baseline.
+
+Toggle: `ACN_OUTPUT=1` enables it. Default is off, so this is a strict superset of the official baseline.
+
+## Results (1 seed, 8xH100 SXM, 600s wallclock cap)
+
+Both runs use the official baseline config: 9 layers × 512d × vocab 1024, GQA 8/4, 2x MLP, tied embeddings, seed 1337, full 80 training shards.
+
+### At equal step counts (the per-step picture)
+
+| step | val_bpb (ACN off) | val_bpb (ACN on) | Δ |
+|----:|---:|---:|---:|
+| 1000  | 1.3834 | 1.3825 | −0.0009 |
+| 5000  | 1.2746 | 1.2747 | +0.0001 |
+| 9000  | 1.2536 | 1.2536 |  0.0000 |
+| 12000 | 1.2439 | 1.2437 | −0.0002 |
+| **13000** | **1.2326** | **1.2264** | **−0.0062** |
+
+The gap opens up late, in the warmdown phase. The output_scales drift away from zero gradually; once they're nonzero the ACN forward starts to actually do something different.
+
+### At equal wallclock (the headline picture)
+
+|                                  | ACN off    | ACN on     |
+|----------------------------------|-----------:|-----------:|
+| model_params                     | 17,059,912 | 17,059,921 |
+| step_avg                         | 43.92 ms   | 44.88 ms   |
+| steps reached in 600 s           | 13,662     | 13,370     |
+| pre-quant val_bpb (final step)   | 1.2191     | 1.2195     |
+| **post-quant val_bpb (final)**   | **1.2262** | **1.2265** |
+| compressed artifact (bytes)      | 15,864,344 | 15,875,628 |
+
+ACN is +2.2 % wallclock per step (the per-block accumulator is on the hot path), so it gets 292 fewer training steps in the 600 s budget. The per-step win and the per-step cost roughly cancel.
+
+## What this is and isn't
+
+**What it is.** A single-seed, single-config probe to see whether the ACN paper's idea has any signal on the official baseline. The question was whether routing each block's hidden state directly into the final representation gives the model useful auxiliary supervision at this scale. The answer appears to be "a little, on the per-step axis."
+
+**What it isn't.** A record submission. One seed, no hyperparameter tuning beyond the defaults, naive Python-loop accumulator with no kernel work. The 0.006-nat per-step gap is plausibly real (it is well above the ~0.001 jitter typically reported across seeds at this size in other PRs), but a single seed cannot statistically establish that on its own.
+
+## Why I'm submitting this anyway
+
+Three reasons, in order of honesty:
+
+1. The README explicitly invites "interesting negative results" and "in-progress or unoptimized solutions" in the non-record track. This fits.
+2. The diff is so small (16 lines, one env var) that anyone curious can run their own A/B in 20 minutes. Lowering the activation energy for someone with more compute to multi-seed this seems worth a few hundred lines of writeup.
+3. The wallclock tax is 100 % implementation cost: nine `x = x + s * h` calls in Python in the hot loop. A fused kernel, or even just collapsing the accumulator into a single `einsum`, plausibly recovers the per-step gain at zero wallclock cost. That's the natural follow-up I'd run if I had the budget.
+
+## Reproducing
+
+From the official repo, on the `acn-baseline` branch of [chrico-bu-uab/parameter-golf](https://github.com/chrico-bu-uab/parameter-golf/tree/acn-baseline) (or just take the `train_gpt.py` in this folder):
+
+```bash
+python3 data/cached_challenge_fineweb.py --variant sp1024
+
+# ACN off — should reproduce the baseline ~1.2244 bpb
+RUN_ID=baseline_off VOCAB_SIZE=1024 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+torchrun --standalone --nproc_per_node=8 train_gpt.py 2>&1 | tee baseline_off.log
+
+# ACN on
+RUN_ID=baseline_acn VOCAB_SIZE=1024 ACN_OUTPUT=1 \
+DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
+TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
+torchrun --standalone --nproc_per_node=8 train_gpt.py 2>&1 | tee baseline_acn.log
+```
+
+Seed 1337 (default), 80 shards, 600 s wallclock cap. Logs from this submission are in `baseline_off.log` and `baseline_acn.log`.
+
+## What would change my mind / suggested follow-ups
+
+- **More seeds.** 3-seed pairs at minimum. The 0.006-nat per-step gap is plausibly real but unproven at one seed.
+- **No-cap runs.** Run both to the full 20 k iterations to see whether the gap persists, grows, or collapses past where the 600 s cap currently cuts off.
+- **Kill the wallclock tax.** Replace the per-layer accumulator loop with a single fused operation (or skip layers whose `output_scale` is below some threshold). If the per-step win survives a near-zero-cost implementation, ACN becomes a free lunch on the baseline.
+- **Stack on top of a competitive run.** This was tested on the naive baseline only. Whether the auxiliary-supervision benefit holds on top of SP8192 + parallel residuals + TTT (where the model is already heavily over-supervised) is open.

--- a/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/baseline_acn.log
+++ b/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/baseline_acn.log
@@ -1,0 +1,131 @@
+logs/baseline_acn.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059921
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.02ms
+step:1/20000 train_loss:6.9370 train_time:29ms step_avg:29.07ms
+step:2/20000 train_loss:16.8810 train_time:80ms step_avg:40.02ms
+step:3/20000 train_loss:8.7671 train_time:122ms step_avg:40.70ms
+step:4/20000 train_loss:6.6385 train_time:168ms step_avg:41.90ms
+step:5/20000 train_loss:6.6133 train_time:213ms step_avg:42.55ms
+step:6/20000 train_loss:7.4241 train_time:258ms step_avg:43.02ms
+step:7/20000 train_loss:6.3556 train_time:301ms step_avg:42.96ms
+step:8/20000 train_loss:6.1627 train_time:349ms step_avg:43.59ms
+step:9/20000 train_loss:6.0704 train_time:388ms step_avg:43.08ms
+step:10/20000 train_loss:5.9741 train_time:432ms step_avg:43.16ms
+step:200/20000 train_loss:2.8407 train_time:8946ms step_avg:44.73ms
+step:400/20000 train_loss:2.3542 train_time:17899ms step_avg:44.75ms
+step:600/20000 train_loss:2.5440 train_time:26865ms step_avg:44.78ms
+step:800/20000 train_loss:2.2929 train_time:35839ms step_avg:44.80ms
+step:1000/20000 train_loss:2.3745 train_time:44839ms step_avg:44.84ms
+step:1000/20000 val_loss:2.3343 val_bpb:1.3825 train_time:44853ms step_avg:44.85ms
+step:1200/20000 train_loss:2.3861 train_time:53856ms step_avg:44.88ms
+step:1400/20000 train_loss:2.4301 train_time:62880ms step_avg:44.91ms
+step:1600/20000 train_loss:2.0984 train_time:71911ms step_avg:44.94ms
+step:1800/20000 train_loss:2.2013 train_time:80937ms step_avg:44.97ms
+step:2000/20000 train_loss:2.2535 train_time:89968ms step_avg:44.98ms
+step:2000/20000 val_loss:2.2354 val_bpb:1.3239 train_time:89984ms step_avg:44.99ms
+step:2200/20000 train_loss:2.0710 train_time:98975ms step_avg:44.99ms
+step:2400/20000 train_loss:2.2032 train_time:107998ms step_avg:45.00ms
+step:2600/20000 train_loss:2.4152 train_time:117004ms step_avg:45.00ms
+step:2800/20000 train_loss:2.2379 train_time:126014ms step_avg:45.00ms
+step:3000/20000 train_loss:2.2252 train_time:135021ms step_avg:45.01ms
+step:3000/20000 val_loss:2.1944 val_bpb:1.2996 train_time:135031ms step_avg:45.01ms
+step:3200/20000 train_loss:2.1884 train_time:144015ms step_avg:45.00ms
+step:3400/20000 train_loss:2.1577 train_time:153011ms step_avg:45.00ms
+step:3600/20000 train_loss:2.1151 train_time:162007ms step_avg:45.00ms
+step:3800/20000 train_loss:2.2222 train_time:170993ms step_avg:45.00ms
+step:4000/20000 train_loss:2.1625 train_time:179984ms step_avg:45.00ms
+step:4000/20000 val_loss:2.1695 val_bpb:1.2849 train_time:180000ms step_avg:45.00ms
+step:4200/20000 train_loss:2.1763 train_time:189033ms step_avg:45.01ms
+step:4400/20000 train_loss:2.1114 train_time:198006ms step_avg:45.00ms
+step:4600/20000 train_loss:1.9719 train_time:207072ms step_avg:45.02ms
+step:4800/20000 train_loss:2.2676 train_time:216037ms step_avg:45.01ms
+step:5000/20000 train_loss:2.0269 train_time:225002ms step_avg:45.00ms
+step:5000/20000 val_loss:2.1522 val_bpb:1.2747 train_time:225017ms step_avg:45.00ms
+step:5200/20000 train_loss:2.1776 train_time:233969ms step_avg:44.99ms
+step:5400/20000 train_loss:2.1854 train_time:242938ms step_avg:44.99ms
+step:5600/20000 train_loss:2.1832 train_time:251903ms step_avg:44.98ms
+step:5800/20000 train_loss:2.1426 train_time:260857ms step_avg:44.98ms
+step:6000/20000 train_loss:2.2217 train_time:269821ms step_avg:44.97ms
+step:6000/20000 val_loss:2.1419 val_bpb:1.2686 train_time:269836ms step_avg:44.97ms
+step:6200/20000 train_loss:2.0849 train_time:278785ms step_avg:44.97ms
+step:6400/20000 train_loss:2.1644 train_time:287748ms step_avg:44.96ms
+step:6600/20000 train_loss:2.1229 train_time:296701ms step_avg:44.95ms
+step:6800/20000 train_loss:2.1942 train_time:305656ms step_avg:44.95ms
+step:7000/20000 train_loss:2.2215 train_time:314611ms step_avg:44.94ms
+step:7000/20000 val_loss:2.1319 val_bpb:1.2626 train_time:314626ms step_avg:44.95ms
+step:7200/20000 train_loss:2.2010 train_time:323569ms step_avg:44.94ms
+step:7400/20000 train_loss:2.1209 train_time:332526ms step_avg:44.94ms
+step:7600/20000 train_loss:1.9998 train_time:341479ms step_avg:44.93ms
+step:7800/20000 train_loss:2.1445 train_time:350436ms step_avg:44.93ms
+step:8000/20000 train_loss:2.1144 train_time:359390ms step_avg:44.92ms
+step:8000/20000 val_loss:2.1217 val_bpb:1.2566 train_time:359406ms step_avg:44.93ms
+step:8200/20000 train_loss:2.1871 train_time:368351ms step_avg:44.92ms
+step:8400/20000 train_loss:2.1337 train_time:377368ms step_avg:44.92ms
+step:8600/20000 train_loss:2.1396 train_time:386317ms step_avg:44.92ms
+step:8800/20000 train_loss:2.1045 train_time:395273ms step_avg:44.92ms
+step:9000/20000 train_loss:2.0209 train_time:404224ms step_avg:44.91ms
+step:9000/20000 val_loss:2.1167 val_bpb:1.2536 train_time:404239ms step_avg:44.92ms
+step:9200/20000 train_loss:2.0830 train_time:413186ms step_avg:44.91ms
+step:9400/20000 train_loss:2.1304 train_time:422148ms step_avg:44.91ms
+step:9600/20000 train_loss:2.1473 train_time:431107ms step_avg:44.91ms
+step:9800/20000 train_loss:2.0728 train_time:440067ms step_avg:44.90ms
+step:10000/20000 train_loss:2.1115 train_time:449025ms step_avg:44.90ms
+step:10000/20000 val_loss:2.1111 val_bpb:1.2503 train_time:449040ms step_avg:44.90ms
+step:10200/20000 train_loss:2.0642 train_time:457980ms step_avg:44.90ms
+step:10400/20000 train_loss:2.0952 train_time:466940ms step_avg:44.90ms
+step:10600/20000 train_loss:1.9758 train_time:475901ms step_avg:44.90ms
+step:10800/20000 train_loss:2.1849 train_time:484863ms step_avg:44.89ms
+step:11000/20000 train_loss:2.1153 train_time:493816ms step_avg:44.89ms
+step:11000/20000 val_loss:2.1050 val_bpb:1.2467 train_time:493832ms step_avg:44.89ms
+step:11200/20000 train_loss:2.0673 train_time:502776ms step_avg:44.89ms
+step:11400/20000 train_loss:2.0560 train_time:511736ms step_avg:44.89ms
+step:11600/20000 train_loss:2.0633 train_time:520686ms step_avg:44.89ms
+step:11800/20000 train_loss:2.0936 train_time:529638ms step_avg:44.88ms
+step:12000/20000 train_loss:2.0713 train_time:538594ms step_avg:44.88ms
+step:12000/20000 val_loss:2.0999 val_bpb:1.2437 train_time:538610ms step_avg:44.88ms
+step:12200/20000 train_loss:2.2172 train_time:547551ms step_avg:44.88ms
+step:12400/20000 train_loss:1.8565 train_time:556577ms step_avg:44.89ms
+step:12600/20000 train_loss:2.0812 train_time:565528ms step_avg:44.88ms
+step:12800/20000 train_loss:2.0964 train_time:574485ms step_avg:44.88ms
+step:13000/20000 train_loss:2.1635 train_time:583446ms step_avg:44.88ms
+step:13000/20000 val_loss:2.0707 val_bpb:1.2264 train_time:583461ms step_avg:44.88ms
+step:13200/20000 train_loss:2.1702 train_time:592397ms step_avg:44.88ms
+step:13370/20000 val_loss:2.0590 val_bpb:1.2195 train_time:600031ms step_avg:44.88ms
+stopping_early: wallclock_cap train_time:600031ms step:13370/20000
+peak memory allocated: 10435 MiB reserved: 10822 MiB
+Serialized model: 67225304 bytes
+Code size: 48361 bytes
+Total submission size: 67273665 bytes
+Serialized model int8+zlib: 15827267 bytes (payload:17178948 raw_torch:17224279 payload_ratio:3.91x)
+Total submission size int8+zlib: 15875628 bytes
+final_int8_zlib_roundtrip val_loss:2.0708 val_bpb:1.2265 eval_time:1446ms
+final_int8_zlib_roundtrip_exact val_loss:2.07084452 val_bpb:1.22647077

--- a/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/baseline_off.log
+++ b/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/baseline_off.log
@@ -1,0 +1,133 @@
+logs/baseline_off.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=./data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=./data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+world_size:8 grad_accum_steps:1
+sdp_backends:cudnn=False flash=True mem_efficient=False math=False
+attention_mode:gqa num_heads:8 num_kv_heads:4
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+train_batch_tokens:524288 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:0/20000 val_loss:6.9357 val_bpb:4.1077 train_time:0ms step_avg:0.01ms
+step:1/20000 train_loss:6.9370 train_time:31ms step_avg:31.47ms
+step:2/20000 train_loss:16.8366 train_time:75ms step_avg:37.65ms
+step:3/20000 train_loss:8.7610 train_time:120ms step_avg:39.94ms
+step:4/20000 train_loss:6.6386 train_time:164ms step_avg:41.03ms
+step:5/20000 train_loss:6.6116 train_time:208ms step_avg:41.53ms
+step:6/20000 train_loss:7.4220 train_time:251ms step_avg:41.82ms
+step:7/20000 train_loss:6.3508 train_time:295ms step_avg:42.07ms
+step:8/20000 train_loss:6.1581 train_time:338ms step_avg:42.29ms
+step:9/20000 train_loss:6.0678 train_time:381ms step_avg:42.35ms
+step:10/20000 train_loss:5.9746 train_time:424ms step_avg:42.41ms
+step:200/20000 train_loss:2.8506 train_time:8730ms step_avg:43.65ms
+step:400/20000 train_loss:2.3588 train_time:17929ms step_avg:44.82ms
+step:600/20000 train_loss:2.5481 train_time:26677ms step_avg:44.46ms
+step:800/20000 train_loss:2.2987 train_time:35448ms step_avg:44.31ms
+step:1000/20000 train_loss:2.3722 train_time:44248ms step_avg:44.25ms
+step:1000/20000 val_loss:2.3358 val_bpb:1.3834 train_time:44263ms step_avg:44.26ms
+step:1200/20000 train_loss:2.3858 train_time:53052ms step_avg:44.21ms
+step:1400/20000 train_loss:2.4299 train_time:61870ms step_avg:44.19ms
+step:1600/20000 train_loss:2.0986 train_time:70692ms step_avg:44.18ms
+step:1800/20000 train_loss:2.2002 train_time:79509ms step_avg:44.17ms
+step:2000/20000 train_loss:2.2497 train_time:88330ms step_avg:44.16ms
+step:2000/20000 val_loss:2.2353 val_bpb:1.3239 train_time:88343ms step_avg:44.17ms
+step:2200/20000 train_loss:2.0721 train_time:97135ms step_avg:44.15ms
+step:2400/20000 train_loss:2.1981 train_time:105939ms step_avg:44.14ms
+step:2600/20000 train_loss:2.4131 train_time:114750ms step_avg:44.13ms
+step:2800/20000 train_loss:2.2353 train_time:123559ms step_avg:44.13ms
+step:3000/20000 train_loss:2.2292 train_time:132363ms step_avg:44.12ms
+step:3000/20000 val_loss:2.1947 val_bpb:1.2998 train_time:132379ms step_avg:44.13ms
+step:3200/20000 train_loss:2.1850 train_time:141163ms step_avg:44.11ms
+step:3400/20000 train_loss:2.1579 train_time:149966ms step_avg:44.11ms
+step:3600/20000 train_loss:2.1144 train_time:158758ms step_avg:44.10ms
+step:3800/20000 train_loss:2.2173 train_time:167551ms step_avg:44.09ms
+step:4000/20000 train_loss:2.1603 train_time:176326ms step_avg:44.08ms
+step:4000/20000 val_loss:2.1691 val_bpb:1.2847 train_time:176341ms step_avg:44.09ms
+step:4200/20000 train_loss:2.1748 train_time:185173ms step_avg:44.09ms
+step:4400/20000 train_loss:2.1075 train_time:193944ms step_avg:44.08ms
+step:4600/20000 train_loss:1.9698 train_time:202718ms step_avg:44.07ms
+step:4800/20000 train_loss:2.2619 train_time:211499ms step_avg:44.06ms
+step:5000/20000 train_loss:2.0277 train_time:220269ms step_avg:44.05ms
+step:5000/20000 val_loss:2.1522 val_bpb:1.2746 train_time:220284ms step_avg:44.06ms
+step:5200/20000 train_loss:2.1720 train_time:229043ms step_avg:44.05ms
+step:5400/20000 train_loss:2.1843 train_time:237812ms step_avg:44.04ms
+step:5600/20000 train_loss:2.1782 train_time:246579ms step_avg:44.03ms
+step:5800/20000 train_loss:2.1426 train_time:255342ms step_avg:44.02ms
+step:6000/20000 train_loss:2.2187 train_time:264111ms step_avg:44.02ms
+step:6000/20000 val_loss:2.1425 val_bpb:1.2689 train_time:264126ms step_avg:44.02ms
+step:6200/20000 train_loss:2.0903 train_time:272880ms step_avg:44.01ms
+step:6400/20000 train_loss:2.1592 train_time:281647ms step_avg:44.01ms
+step:6600/20000 train_loss:2.1230 train_time:290408ms step_avg:44.00ms
+step:6800/20000 train_loss:2.1930 train_time:299174ms step_avg:44.00ms
+step:7000/20000 train_loss:2.2263 train_time:308024ms step_avg:44.00ms
+step:7000/20000 val_loss:2.1315 val_bpb:1.2624 train_time:308039ms step_avg:44.01ms
+step:7200/20000 train_loss:2.1991 train_time:316785ms step_avg:44.00ms
+step:7400/20000 train_loss:2.1145 train_time:325541ms step_avg:43.99ms
+step:7600/20000 train_loss:1.9992 train_time:334296ms step_avg:43.99ms
+step:7800/20000 train_loss:2.1446 train_time:343053ms step_avg:43.98ms
+step:8000/20000 train_loss:2.1133 train_time:351818ms step_avg:43.98ms
+step:8000/20000 val_loss:2.1222 val_bpb:1.2569 train_time:351833ms step_avg:43.98ms
+step:8200/20000 train_loss:2.1845 train_time:360589ms step_avg:43.97ms
+step:8400/20000 train_loss:2.1354 train_time:369399ms step_avg:43.98ms
+step:8600/20000 train_loss:2.1380 train_time:378154ms step_avg:43.97ms
+step:8800/20000 train_loss:2.1016 train_time:386920ms step_avg:43.97ms
+step:9000/20000 train_loss:2.0269 train_time:395680ms step_avg:43.96ms
+step:9000/20000 val_loss:2.1167 val_bpb:1.2536 train_time:395695ms step_avg:43.97ms
+step:9200/20000 train_loss:2.0826 train_time:404441ms step_avg:43.96ms
+step:9400/20000 train_loss:2.1281 train_time:413208ms step_avg:43.96ms
+step:9600/20000 train_loss:2.1494 train_time:421967ms step_avg:43.95ms
+step:9800/20000 train_loss:2.0726 train_time:430733ms step_avg:43.95ms
+step:10000/20000 train_loss:2.1146 train_time:439496ms step_avg:43.95ms
+step:10000/20000 val_loss:2.1116 val_bpb:1.2506 train_time:439511ms step_avg:43.95ms
+step:10200/20000 train_loss:2.0625 train_time:448255ms step_avg:43.95ms
+step:10400/20000 train_loss:2.1010 train_time:457017ms step_avg:43.94ms
+step:10600/20000 train_loss:1.9761 train_time:465782ms step_avg:43.94ms
+step:10800/20000 train_loss:2.1853 train_time:474542ms step_avg:43.94ms
+step:11000/20000 train_loss:2.1158 train_time:483308ms step_avg:43.94ms
+step:11000/20000 val_loss:2.1049 val_bpb:1.2466 train_time:483324ms step_avg:43.94ms
+step:11200/20000 train_loss:2.0681 train_time:492077ms step_avg:43.94ms
+step:11400/20000 train_loss:2.0561 train_time:500845ms step_avg:43.93ms
+step:11600/20000 train_loss:2.0667 train_time:509608ms step_avg:43.93ms
+step:11800/20000 train_loss:2.0903 train_time:518368ms step_avg:43.93ms
+step:12000/20000 train_loss:2.0695 train_time:527133ms step_avg:43.93ms
+step:12000/20000 val_loss:2.1002 val_bpb:1.2439 train_time:527147ms step_avg:43.93ms
+step:12200/20000 train_loss:2.2181 train_time:535897ms step_avg:43.93ms
+step:12400/20000 train_loss:1.8608 train_time:544723ms step_avg:43.93ms
+step:12600/20000 train_loss:2.0902 train_time:553478ms step_avg:43.93ms
+step:12800/20000 train_loss:2.1060 train_time:562238ms step_avg:43.92ms
+step:13000/20000 train_loss:2.1769 train_time:571009ms step_avg:43.92ms
+step:13000/20000 val_loss:2.0812 val_bpb:1.2326 train_time:571025ms step_avg:43.92ms
+step:13200/20000 train_loss:2.1818 train_time:579770ms step_avg:43.92ms
+step:13400/20000 train_loss:2.0552 train_time:588534ms step_avg:43.92ms
+step:13600/20000 train_loss:1.9104 train_time:597308ms step_avg:43.92ms
+step:13662/20000 val_loss:2.0584 val_bpb:1.2191 train_time:600022ms step_avg:43.92ms
+stopping_early: wallclock_cap train_time:600022ms step:13662/20000
+peak memory allocated: 10119 MiB reserved: 10294 MiB
+Serialized model: 67224983 bytes
+Code size: 48361 bytes
+Total submission size: 67273344 bytes
+Serialized model int8+zlib: 15815983 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15864344 bytes
+final_int8_zlib_roundtrip val_loss:2.0703 val_bpb:1.2262 eval_time:1415ms
+final_int8_zlib_roundtrip_exact val_loss:2.07032871 val_bpb:1.22616528

--- a/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/submission.json
+++ b/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/submission.json
@@ -1,0 +1,10 @@
+{
+  "track": "non_record_16mb",
+  "date": "2026-04-30",
+  "name": "ACN Output Accumulator on the Naive Baseline",
+  "author": "Chris Coffee",
+  "github_id": "chrico-bu-uab",
+  "val_bpb": 1.2265,
+  "val_loss": 2.0708,
+  "bytes_total": 15875628
+}

--- a/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/train_gpt.py
+++ b/records/track_non_record_16mb/2026-04-30_ACN_OutputAccumulator/train_gpt.py
@@ -1,0 +1,1141 @@
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+
+    acn_output = bool(int(os.environ.get("ACN_OUTPUT", "0")))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(self, params, lr: float, momentum: float, backend_steps: int, nesterov: bool = True):
+        super().__init__(
+            params,
+            dict(lr=lr, momentum=momentum, backend_steps=backend_steps, nesterov=nesterov),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,output_scale,output_scales",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.
+    def forward(self, x: Tensor) -> Tensor:
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, self.weight.to(x.dtype), bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (param.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # Caches cos/sin tables per sequence length on the current device.
+    def __init__(self, dim: int, base: float = 10000.0):
+        super().__init__()
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)
+            freqs = torch.outer(t, self.inv_freq.to(device))
+            self._cos_cached = freqs.cos()[None, None, :, :]
+            self._sin_cached = freqs.sin()[None, None, :, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))
+        self.rotary = Rotary(self.head_dim, base=rope_base)
+
+    def forward(self, x: Tensor) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]
+        y = F.scaled_dot_product_attention(
+            q,
+            k,
+            v,
+            attn_mask=None,
+            is_causal=True,
+            enable_gqa=(self.num_kv_heads != self.num_heads),
+        )
+        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    # relu^2 MLP from the original modded-nanogpt setup
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = mlp_mult * dim
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(dim, num_heads, num_kv_heads, rope_base, qk_gain_init)
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())
+
+    def forward(self, x: Tensor, x0: Tensor) -> Tensor:
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x))
+        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out
+        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))
+        return x
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        acn_output: bool = False,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.num_encoder_layers = num_layers // 2
+        self.num_decoder_layers = num_layers - self.num_encoder_layers
+        self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
+        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.output_scales = nn.Parameter(torch.zeros(num_layers, dtype=torch.float32)) if acn_output else None
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for i in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for module in self.modules():
+            if isinstance(module, nn.Linear) and getattr(module, "_zero_init", False):
+                nn.init.zeros_(module.weight)
+
+    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips: list[Tensor] = []
+        hidden_states: list[Tensor] = []
+
+        # First half stores skips; second half reuses them in reverse order.
+        for i in range(self.num_encoder_layers):
+            x = self.blocks[i](x, x0)
+            skips.append(x)
+            hidden_states.append(x)
+        for i in range(self.num_decoder_layers):
+            if skips:
+                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
+            x = self.blocks[self.num_encoder_layers + i](x, x0)
+            hidden_states.append(x)
+
+        if self.output_scales is not None:
+            scales = self.output_scales.to(dtype=x.dtype)
+            for i, h in enumerate(hidden_states):
+                x = x + scales[i] * h
+
+        x = self.final_norm(x).reshape(-1, x.size(-1))
+        targets = target_ids.reshape(-1)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(logits.float(), targets, reduction="mean")
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = GPT(
+        vocab_size=args.vocab_size,
+        num_layers=args.num_layers,
+        model_dim=args.model_dim,
+        num_heads=args.num_heads,
+        num_kv_heads=args.num_kv_heads,
+        mlp_mult=args.mlp_mult,
+        tie_embeddings=args.tie_embeddings,
+        tied_embed_init_std=args.tied_embed_init_std,
+        logit_softcap=args.logit_softcap,
+        rope_base=args.rope_base,
+        qk_gain_init=args.qk_gain_init,
+        acn_output=args.acn_output,
+    ).to(device).bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    if base_model.output_scales is not None:
+        scalar_params.append(base_model.output_scales)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}")
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = last_step or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        code_bytes = len(code.encode("utf-8"))
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/train_gpt.py
+++ b/train_gpt.py
@@ -86,6 +86,8 @@ class Hyperparameters:
     adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
     grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
 
+    acn_output = bool(int(os.environ.get("ACN_OUTPUT", "0")))
+
 # -----------------------------
 # MUON OPTIMIZER 
 # -----------------------------
@@ -289,7 +291,7 @@ CONTROL_TENSOR_NAME_PATTERNS = tuple(
     pattern
     for pattern in os.environ.get(
         "CONTROL_TENSOR_NAME_PATTERNS",
-        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,output_scale,output_scales",
     ).split(",")
     if pattern
 )
@@ -659,6 +661,7 @@ class GPT(nn.Module):
         logit_softcap: float,
         rope_base: float,
         qk_gain_init: float,
+        acn_output: bool = False,
     ):
         super().__init__()
         if logit_softcap <= 0.0:
@@ -671,6 +674,7 @@ class GPT(nn.Module):
         self.num_decoder_layers = num_layers - self.num_encoder_layers
         self.num_skip_weights = min(self.num_encoder_layers, self.num_decoder_layers)
         self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))
+        self.output_scales = nn.Parameter(torch.zeros(num_layers, dtype=torch.float32)) if acn_output else None
         self.blocks = nn.ModuleList(
             [
                 Block(
@@ -702,15 +706,23 @@ class GPT(nn.Module):
         x = F.rms_norm(x, (x.size(-1),))
         x0 = x
         skips: list[Tensor] = []
+        hidden_states: list[Tensor] = []
 
         # First half stores skips; second half reuses them in reverse order.
         for i in range(self.num_encoder_layers):
             x = self.blocks[i](x, x0)
             skips.append(x)
+            hidden_states.append(x)
         for i in range(self.num_decoder_layers):
             if skips:
                 x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()
             x = self.blocks[self.num_encoder_layers + i](x, x0)
+            hidden_states.append(x)
+
+        if self.output_scales is not None:
+            scales = self.output_scales.to(dtype=x.dtype)
+            for i, h in enumerate(hidden_states):
+                x = x + scales[i] * h
 
         x = self.final_norm(x).reshape(-1, x.size(-1))
         targets = target_ids.reshape(-1)
@@ -835,6 +847,7 @@ def main() -> None:
         logit_softcap=args.logit_softcap,
         rope_base=args.rope_base,
         qk_gain_init=args.qk_gain_init,
+        acn_output=args.acn_output,
     ).to(device).bfloat16()
     for module in base_model.modules():
         if isinstance(module, CastedLinear):
@@ -861,6 +874,8 @@ def main() -> None:
     ]
     if base_model.skip_weights.numel() > 0:
         scalar_params.append(base_model.skip_weights)
+    if base_model.output_scales is not None:
+        scalar_params.append(base_model.output_scales)
     token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
     optimizer_tok = torch.optim.Adam(
         [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],


### PR DESCRIPTION
# ACN Output Accumulator on the Naive Baseline

**Non-Record Submission (Idea Probe)**
**Author:** Chris Coffee ([@chrico-bu-uab](https://github.com/chrico-bu-uab))
**Base:** Official `train_gpt.py` baseline (1.2244 bpb)
**Result:** 1.2265 bpb (ACN on) vs 1.2262 bpb (ACN off) — wallclock-tied
**Idea:** Auto-Compressing Networks (Bose et al., 2025 — arxiv [2506.09714](https://arxiv.org/abs/2506.09714)) output accumulator, gated behind `ACN_OUTPUT=1`.

## TL;DR

I added one knob to the official baseline: each transformer block's hidden state is added (with a learnable per-layer scalar, init to zero) to the final pre-`final_norm` representation. With the cap on, the result is essentially tied with the unmodified baseline. With the cap conceptually removed and runs compared at equal step counts, ACN is ~0.006 bpb better. The naive accumulator costs ~2 % wallclock per step, which exactly eats the per-step gain in this 10-minute regime.

That's the whole story: ACN gives a small but real signal on the baseline architecture, but the naive implementation is too expensive to convert into a record. This is a one-seed idea probe, not a tuned submission.

## What ACN does (and what's actually in the diff)

The Auto-Compressing Networks paper proposes letting every block contribute directly to the final representation, rather than having information flow only through the residual stream. With per-layer scales initialized to zero, the model starts identical to the baseline and only opts into auxiliary contributions where they pay for themselves.

The full diff against the official `train_gpt.py` is 16 lines. In the `GPT.forward` loop:

```python
hidden_states.append(x)              # collected after each block
...
if self.output_scales is not None:
    scales = self.output_scales.to(dtype=x.dtype)
    for i, h in enumerate(hidden_states):
        x = x + scales[i] * h
x = self.final_norm(x)
```

`output_scales` is a single `nn.Parameter` of shape `[num_layers]` (9 floats — adds 9 params total, +36 bytes uncompressed). It's added to the scalar-LR optimizer group, picked up automatically by `CONTROL_TENSOR_NAME_PATTERNS` for fp32 retention. Everything else is unchanged from the baseline.

Toggle: `ACN_OUTPUT=1` enables it. Default is off, so this is a strict superset of the official baseline.

## Results (1 seed, 8xH100 SXM, 600s wallclock cap)

Both runs use the official baseline config: 9 layers × 512d × vocab 1024, GQA 8/4, 2x MLP, tied embeddings, seed 1337, full 80 training shards.

### At equal step counts (the per-step picture)

| step | val_bpb (ACN off) | val_bpb (ACN on) | Δ |
|----:|---:|---:|---:|
| 1000  | 1.3834 | 1.3825 | −0.0009 |
| 5000  | 1.2746 | 1.2747 | +0.0001 |
| 9000  | 1.2536 | 1.2536 |  0.0000 |
| 12000 | 1.2439 | 1.2437 | −0.0002 |
| **13000** | **1.2326** | **1.2264** | **−0.0062** |

The gap opens up late, in the warmdown phase. The output_scales drift away from zero gradually; once they're nonzero the ACN forward starts to actually do something different.

### At equal wallclock (the headline picture)

|                                  | ACN off    | ACN on     |
|----------------------------------|-----------:|-----------:|
| model_params                     | 17,059,912 | 17,059,921 |
| step_avg                         | 43.92 ms   | 44.88 ms   |
| steps reached in 600 s           | 13,662     | 13,370     |
| pre-quant val_bpb (final step)   | 1.2191     | 1.2195     |
| **post-quant val_bpb (final)**   | **1.2262** | **1.2265** |
| compressed artifact (bytes)      | 15,864,344 | 15,875,628 |

ACN is +2.2 % wallclock per step (the per-block accumulator is on the hot path), so it gets 292 fewer training steps in the 600 s budget. The per-step win and the per-step cost roughly cancel.

## What this is and isn't

**What it is.** A single-seed, single-config probe to see whether the ACN paper's idea has any signal on the official baseline. The question was whether routing each block's hidden state directly into the final representation gives the model useful auxiliary supervision at this scale. The answer appears to be "a little, on the per-step axis."

**What it isn't.** A record submission. One seed, no hyperparameter tuning beyond the defaults, naive Python-loop accumulator with no kernel work. The 0.006-nat per-step gap is plausibly real (it is well above the ~0.001 jitter typically reported across seeds at this size in other PRs), but a single seed cannot statistically establish that on its own.

## Why I'm submitting this anyway

Three reasons, in order of honesty:

1. The README explicitly invites "interesting negative results" and "in-progress or unoptimized solutions" in the non-record track. This fits.
2. The diff is so small (16 lines, one env var) that anyone curious can run their own A/B in 20 minutes. Lowering the activation energy for someone with more compute to multi-seed this seems worth a few hundred lines of writeup.
3. The wallclock tax is 100 % implementation cost: nine `x = x + s * h` calls in Python in the hot loop. A fused kernel, or even just collapsing the accumulator into a single `einsum`, plausibly recovers the per-step gain at zero wallclock cost. That's the natural follow-up I'd run if I had the budget.

## Reproducing

From the official repo, on the `acn-baseline` branch of [chrico-bu-uab/parameter-golf](https://github.com/chrico-bu-uab/parameter-golf/tree/acn-baseline) (or just take the `train_gpt.py` in this folder):

```bash
python3 data/cached_challenge_fineweb.py --variant sp1024

# ACN off — should reproduce the baseline ~1.2244 bpb
RUN_ID=baseline_off VOCAB_SIZE=1024 \
DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
torchrun --standalone --nproc_per_node=8 train_gpt.py 2>&1 | tee baseline_off.log

# ACN on
RUN_ID=baseline_acn VOCAB_SIZE=1024 ACN_OUTPUT=1 \
DATA_PATH=./data/datasets/fineweb10B_sp1024/ \
TOKENIZER_PATH=./data/tokenizers/fineweb_1024_bpe.model \
torchrun --standalone --nproc_per_node=8 train_gpt.py 2>&1 | tee baseline_acn.log
```

Seed 1337 (default), 80 shards, 600 s wallclock cap. Logs from this submission are in `baseline_off.log` and `baseline_acn.log`.

## What would change my mind / suggested follow-ups

- **More seeds.** 3-seed pairs at minimum. The 0.006-nat per-step gap is plausibly real but unproven at one seed.
- **No-cap runs.** Run both to the full 20 k iterations to see whether the gap persists, grows, or collapses past where the 600 s cap currently cuts off.
- **Kill the wallclock tax.** Replace the per-layer accumulator loop with a single fused operation (or skip layers whose `output_scale` is below some threshold). If the per-step win survives a near-zero-cost implementation, ACN becomes a free lunch on the baseline.
- **Stack on top of a competitive run.** This was tested on the naive baseline only. Whether the auxiliary-supervision benefit holds on top of SP8192 + parallel residuals + TTT (where the model is already heavily over-supervised) is open.
