### PR TITLE
[Non-record] 1.1999 BPB on a single H100 GPU (~1.064 BPB on 8x): Adaptive Recurrent Transformer Architecture

### DIFF
--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/README.md
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/README.md
@@ -1,0 +1,118 @@
+# Adaptive Recurrent Transformer (ART)
+
+*Not every token deserves equal compute.*
+
+Standard language models allocate depth uniformly. Yet intuitively, some tokens are easier to predict than others. Take the following fragment:
+
+“After lunch, he was looking forward…”
+
+As humans, we easily recognize the next word to likely be “to”. Accordingly, I approached this challenge with a singular thesis: not every token deserves equal compute – and dynamic recurrence can provide this adaptability.
+
+## Summary
+
+ART adds routing MLPs which determine when/how to recurse within transformer architectures.
+
+This is a non-record research submission for `records/track_non_record_16mb/`. It packages the Adaptive Recurrent Transformer line of experiments, and the strongest recent ART edits on other Parameter Golf stacks.
+
+The core example is **PR1855-family + Simple ART**, which scored **1.19991555 BPB** after quantization and post-quant TTT on **1xH100**. That run is intentionally included as a research result rather than a leaderboard claim: its artifact was over the 16 MB cap and its full TTT evaluation exceeded the strict leaderboard runtime. The point of this PR is to demonstrate the architectural idea of ART.
+
+Note that although PR1855 + Simple ART is the upfront example, it is not the most interesting. The purpose of this PR, rather, is to demonstrate the architectural idea of Adaptive Recurrent Transformers and the variety of ART techniques – changing attention heads and MoE blocks, multiple-block and single-block recursion, etc.
+
+
+## Selected Results
+
+| Variation | Best BPB | Hardware |
+|---|---:|---|
+| PR1855 + Soft ART | 1.0643 | 8xH100 |
+| PR1812 + ART | 1.1183 | 8xH100 |
+| PR1855 + Simple ART | 1.1999 | 1xH100 |
+| Triple-ART Small Batch | 1.2410 | 1xH100 |
+| ART Saved-RoPE + TTT | 1.2413 | 1xH100 |
+| Adaptive Recurrent Transformer 1 | 1.3168 | 1xH100 |
+| ART-2 | 1.3207 | 1xH100 |
+| ART-3 | 1.4849 | 1xH100 |
+| ART-2.5 | 1.5285 | 1xH100 |
+
+## Included Files
+
+| File | Purpose |
+|---|---|
+| `train_gpt.py` | Canonical runnable Simple ART script for the 1.1999 BPB core example. |
+| `training_files/pr1855_simple_art.py` | Same Simple ART script, kept with the selected evidence bundle. |
+| `training_files/pr1855_soft_art.py` | Soft ART / delta-gated recurrence variant that reached 1.0643 BPB on 8xH100. |
+| `training_files/pr1812_art.py` | PR1812 + ART 8xH100 attempt that reached 1.1183 BPB. |
+| `training_files/triple_art_small_batch.py` | Triple-ART small-batch 1xH100 pre-TTT launcher. Uses `training_files/run_variant.py` and `training_files/train_gpt_base_prettt.py`. |
+| `training_files/run_variant.py` | Helper for the Triple-ART pre-TTT suite variants. |
+| `training_files/train_gpt_base_prettt.py` | Base Triple-ART pre-TTT script used by the small-batch launcher. |
+| `training_files/art_saved_rope_ttt.py` | Triple-ART saved-RoPE fix with post-quant TTT. |
+| `training_files/art_1.py` | First standalone Adaptive Recurrent Transformer implementation. |
+| `training_files/art_2.py` | ART-2 record-style training implementation. |
+| `training_files/art_3.py` | ART-3 sparse-head / MoE-router implementation. |
+| `training_files/art_2_5.py` | ART-2.5 outer-router shared-MoE implementation. |
+| `logs/` | One log for each row in the selected-results table. |
+
+## Evidence Logs
+
+| Variation | Script | Log |
+|---|---|---|
+| PR1855 + Soft ART | `training_files/pr1855_soft_art.py` | `logs/pr1855_soft_art_dashboard_20260430_204203_abf0ec8e.stdout.log` |
+| PR1812 + ART | `training_files/pr1812_art.py` | `logs/pr1812_art_dashboard_20260429_224456_a9eaabed.stdout.log` |
+| PR1855 + Simple ART | `training_files/pr1855_simple_art.py` | `logs/pr1855_simple_art_dashboard_20260430_224429_ad4a36d5.stdout.log` |
+| Triple-ART Small Batch | `training_files/triple_art_small_batch.py` | `logs/triple_art_small_batch_dashboard_20260429_192817_de3b33e8.stdout.log` |
+| ART Saved-RoPE + TTT | `training_files/art_saved_rope_ttt.py` | `logs/art_saved_rope_ttt_dashboard_20260429_162729_57cac6b0.stdout.log` |
+| Adaptive Recurrent Transformer 1 | `training_files/art_1.py` | `logs/art_1_dashboard_20260417_013525_a3d8aea8.stdout.log` |
+| ART-2 | `training_files/art_2.py` | `logs/art_2_dashboard_20260419_161439_9b946387.stdout.log` |
+| ART-3 | `training_files/art_3.py` | `logs/art_3_dashboard_20260419_225908_cf9443b3.stdout.log` |
+| ART-2.5 | `training_files/art_2_5.py` | `logs/art_2_5_dashboard_20260420_004715_e49b5f70.stdout.log` |
+
+## Simple ART Mechanism
+
+The submitted `train_gpt.py` keeps the proven record-family transformer mostly unchanged. After the normal recurrence phase begins and a delayed ART enable point is reached, a tiny router samples one whole-batch action:
+
+```text
+short: skip the two additional recurrent 3-4-5 cycles
+full:  run the original recurrent path with the additional six blocks
+```
+
+Both branches are compiled separately for training, logits, and TTT. In distributed runs, rank 0 samples the branch and broadcasts it so all GPUs execute the same static path. This is less expressive than token-level ART, but it avoids the packed-active dynamic routing overhead that made earlier ART variants too slow.
+
+## Reproducing The Core Example
+
+The exact data paths depend on the local Parameter Golf setup. This is the shape of the run used for the Simple ART 1xH100 result:
+
+```bash
+DATA_DIR=./data \
+VOCAB_SIZE=8192 \
+DATA_PATH=./data/datasets/fineweb10B_sp8192_lossless_caps_caseops_v1_reserved \
+TOKENIZER_PATH=./data/tokenizers/fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model \
+CASEOPS_ENABLED=1 \
+ITERATIONS=20000 MAX_WALLCLOCK_SECONDS=600 \
+ART_SIMPLE_ENABLED=1 ART_SIMPLE_ENABLE_AT=0.45 ART_EVAL_MODE=sample \
+ART_ROUTER_ENTROPY_START=0.02 ART_ROUTER_ENTROPY_END=0.002 ART_CYCLE_PENALTY=0.002 \
+EMA_ACTIVATE_AT=0.55 \
+PHASED_TTT_ENABLED=1 PHASED_TTT_PREFIX_DOCS=2500 PHASED_TTT_NUM_PHASES=3 \
+EMBED_BITS=7 MATRIX_LR=0.026 MIN_LR=0.1 \
+MLP_CLIP_SIGMAS=11.5 ATTN_CLIP_SIGMAS=13.0 EMBED_CLIP_SIGMAS=14.0 \
+GRAD_CLIP_NORM=0.3 TTT_CHUNK_SIZE=48 WARMUP_STEPS=20 MUON_BACKEND_STEPS=5 \
+GLOBAL_TTT_MOMENTUM=0.9 WARMDOWN_FRAC=0.85 BETA2=0.99 \
+TTT_BETA2=0.99 TTT_WEIGHT_DECAY=0.5 TTT_LORA_RANK=80 \
+SPARSE_ATTN_GATE_SCALE=0.5 \
+GPTQ_RESERVE_SECONDS=8.0 GPTQ_CALIBRATION_BATCHES=16 VAL_LOSS_EVERY=0 \
+GATED_ATTN_QUANT_GATE=1 SPARSE_ATTN_GATE_ENABLED=1 GATE_WINDOW=12 \
+SMEAR_GATE_ENABLED=1 \
+LQER_ENABLED=1 LQER_ASYM_ENABLED=1 LQER_RANK=4 LQER_FACTOR_BITS=4 LQER_ASYM_GROUP=64 LQER_TOP_K=3 \
+FUSED_CE_ENABLED=1 COMPRESSOR=pergroup NCCL_NET=Socket \
+torchrun --standalone --nproc_per_node=1 train_gpt.py
+```
+
+## Non-Record Notes
+
+- This PR is an architecture-research package.
+- The included scripts do not use network calls during scoring.
+- TTT variants use score-first TTT.
+
+## Acknowledgments
+
+The 1.1999 Simple ART script builds on the current SmearGateBOSFix / LQER / CaseOps / phased-TTT record-family stack documented locally at `records/track_10min_16mb/2026-04-29_SmearGateBOSFix_3Seed_1.06141/README.md`. That README identifies the stack as support for PR #1851 by @aquariouseworkman, with lineage from PR #1787 by @nprime06, PR #1797 by @dexhunter, PR #1729 by @romeerp, PR #1394 by @clarkkev, PR #549 by @abaybektursun, and the BOS bug identification by @cocohearts.
+
+The ART mechanisms in this folder are the new contribution: learned recurrent-depth control, soft recurrent-delta weighting, static-graph Simple ART branch selection, etc.

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_1_dashboard_20260417_013525_a3d8aea8.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_1_dashboard_20260417_013525_a3d8aea8.stdout.log
@@ -1,0 +1,2207 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260417_013525_a3d8aea8.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+model_params:42599521
+router_params:393860
+unique_blocks:3 recurrent_steps:12
+world_size:1 grad_accum_steps:8
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 num_recurrent_steps:12 max_wallclock_seconds:25000.000
+router_actions:4 eval_recurrent_steps:12
+router_input_dim:3072 router_hidden_dim:128 router_lr:0.0005 router_wd:0.01 router_entropy_bonus:0.2 router_step_penalty:0.0075 activation_checkpointing:1
+warmup_step:1/20
+warmup_step:10/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9803 train_time:2536ms step_avg:2535.86ms router_forward:1 router_objective:-0.3541 router_entropy:1.3053
+step:2/20000 train_loss:15.2218 train_time:5219ms step_avg:2609.72ms router_forward:1 router_objective:2.5349 router_entropy:1.3079
+step:3/20000 train_loss:10.4238 train_time:7717ms step_avg:2572.23ms router_forward:1 router_objective:2.0853 router_entropy:1.3052
+step:4/20000 train_loss:7.5848 train_time:10424ms step_avg:2606.11ms router_forward:1 router_objective:0.7389 router_entropy:1.3070
+step:5/20000 train_loss:6.3875 train_time:13445ms step_avg:2689.07ms router_forward:1 router_objective:-0.0246 router_entropy:1.3069
+step:6/20000 train_loss:6.3062 train_time:16790ms step_avg:2798.27ms router_forward:1 router_objective:-0.3446 router_entropy:1.2961
+step:7/20000 train_loss:6.4461 train_time:20492ms step_avg:2927.36ms router_forward:1 router_objective:-0.6722 router_entropy:1.2853
+step:8/20000 train_loss:6.3336 train_time:24319ms step_avg:3039.89ms router_forward:1 router_objective:-0.0483 router_entropy:1.2787
+step:9/20000 train_loss:6.3179 train_time:28262ms step_avg:3140.19ms router_forward:1 router_objective:-0.1907 router_entropy:1.2647
+step:10/20000 router_probe window_steps:10 avg_depth:5.346 router_objective:0.3551 router_entropy:1.2922
+step:10/20000 router_matrix
+step:10/20000 train_loss:6.1926 train_time:32571ms step_avg:3257.10ms router_forward:1 router_objective:-0.1731 router_entropy:1.2647
+step:20/20000 router_probe window_steps:10 avg_depth:9.547 router_objective:0.0719 router_entropy:1.1826
+step:20/20000 router_matrix
+step:20/20000 train_loss:5.0509 train_time:84959ms step_avg:4247.97ms router_forward:1 router_objective:-0.1209 router_entropy:1.1241
+step:30/20000 router_probe window_steps:10 avg_depth:10.122 router_objective:-0.1446 router_entropy:1.1543
+step:30/20000 router_matrix
+step:30/20000 train_loss:4.4538 train_time:140116ms step_avg:4670.54ms router_forward:1 router_objective:-0.2306 router_entropy:1.2473
+step:40/20000 router_probe window_steps:10 avg_depth:5.006 router_objective:-0.2753 router_entropy:1.2136
+step:40/20000 router_matrix
+step:40/20000 train_loss:4.1098 train_time:169773ms step_avg:4244.33ms router_forward:1 router_objective:-0.3282 router_entropy:1.2140
+step:50/20000 router_probe window_steps:10 avg_depth:4.011 router_objective:-0.2856 router_entropy:1.2244
+step:50/20000 router_matrix
+step:50/20000 train_loss:3.9317 train_time:194172ms step_avg:3883.44ms router_forward:1 router_objective:-0.4349 router_entropy:1.2407
+step:60/20000 router_probe window_steps:10 avg_depth:4.063 router_objective:-0.2786 router_entropy:1.2224
+step:60/20000 router_matrix
+step:60/20000 train_loss:3.7452 train_time:218825ms step_avg:3647.09ms router_forward:1 router_objective:-0.2260 router_entropy:1.2179
+step:70/20000 router_probe window_steps:10 avg_depth:3.880 router_objective:-0.2673 router_entropy:1.2507
+step:70/20000 router_matrix
+step:70/20000 train_loss:3.6626 train_time:242548ms step_avg:3464.97ms router_forward:1 router_objective:-0.3000 router_entropy:1.2496
+step:80/20000 router_probe window_steps:10 avg_depth:3.633 router_objective:-0.2709 router_entropy:1.2328
+step:80/20000 router_matrix
+step:80/20000 train_loss:3.6288 train_time:264940ms step_avg:3311.75ms router_forward:1 router_objective:-0.3073 router_entropy:1.2625
+step:90/20000 router_probe window_steps:10 avg_depth:3.821 router_objective:-0.2788 router_entropy:1.2591
+step:90/20000 router_matrix
+step:90/20000 train_loss:3.5343 train_time:288778ms step_avg:3208.64ms router_forward:1 router_objective:-0.3549 router_entropy:1.2588
+step:100/20000 router_probe window_steps:10 avg_depth:3.662 router_objective:-0.2746 router_entropy:1.2559
+step:100/20000 router_matrix
+step:100/20000 train_loss:3.5175 train_time:311522ms step_avg:3115.22ms router_forward:1 router_objective:-0.2816 router_entropy:1.2614
+step:110/20000 router_probe window_steps:10 avg_depth:3.716 router_objective:-0.2754 router_entropy:1.2791
+step:110/20000 router_matrix
+step:110/20000 train_loss:3.4868 train_time:335132ms step_avg:3046.65ms router_forward:1 router_objective:-0.2256 router_entropy:1.2877
+step:120/20000 router_probe window_steps:10 avg_depth:3.618 router_objective:-0.2788 router_entropy:1.2697
+step:120/20000 router_matrix
+step:120/20000 train_loss:3.4024 train_time:358399ms step_avg:2986.66ms router_forward:1 router_objective:-0.2552 router_entropy:1.2541
+step:130/20000 router_probe window_steps:10 avg_depth:4.213 router_objective:-0.2685 router_entropy:1.2326
+step:130/20000 router_matrix
+step:130/20000 train_loss:3.3872 train_time:384560ms step_avg:2958.15ms router_forward:1 router_objective:-0.3864 router_entropy:1.2537
+step:140/20000 router_probe window_steps:10 avg_depth:4.057 router_objective:-0.2653 router_entropy:1.2539
+step:140/20000 router_matrix
+step:140/20000 train_loss:3.3668 train_time:409798ms step_avg:2927.13ms router_forward:1 router_objective:-0.2778 router_entropy:1.2368
+step:150/20000 router_probe window_steps:10 avg_depth:4.065 router_objective:-0.2657 router_entropy:1.2365
+step:150/20000 router_matrix
+step:150/20000 train_loss:3.3285 train_time:434762ms step_avg:2898.41ms router_forward:1 router_objective:-0.2785 router_entropy:1.2414
+step:160/20000 router_probe window_steps:10 avg_depth:4.090 router_objective:-0.2879 router_entropy:1.2626
+step:160/20000 router_matrix
+step:160/20000 train_loss:3.3110 train_time:460284ms step_avg:2876.77ms router_forward:1 router_objective:-0.2966 router_entropy:1.2679
+step:170/20000 router_probe window_steps:10 avg_depth:4.004 router_objective:-0.2545 router_entropy:1.2479
+step:170/20000 router_matrix
+step:170/20000 train_loss:3.2649 train_time:485059ms step_avg:2853.29ms router_forward:1 router_objective:-0.1669 router_entropy:1.2303
+step:180/20000 router_probe window_steps:10 avg_depth:4.033 router_objective:-0.2682 router_entropy:1.2473
+step:180/20000 router_matrix
+step:180/20000 train_loss:3.1431 train_time:510150ms step_avg:2834.17ms router_forward:1 router_objective:-0.2717 router_entropy:1.2592
+step:190/20000 router_probe window_steps:10 avg_depth:4.202 router_objective:-0.2754 router_entropy:1.2547
+step:190/20000 router_matrix
+step:190/20000 train_loss:3.1269 train_time:536255ms step_avg:2822.39ms router_forward:1 router_objective:-0.2797 router_entropy:1.2418
+step:200/20000 router_probe window_steps:10 avg_depth:4.272 router_objective:-0.2931 router_entropy:1.2549
+step:200/20000 router_matrix
+step:200/20000 train_loss:3.0248 train_time:562972ms step_avg:2814.86ms router_forward:1 router_objective:-0.3715 router_entropy:1.2565
+step:210/20000 router_probe window_steps:10 avg_depth:4.335 router_objective:-0.2894 router_entropy:1.2336
+step:210/20000 router_matrix
+step:210/20000 train_loss:3.0027 train_time:589680ms step_avg:2808.00ms router_forward:1 router_objective:-0.2334 router_entropy:1.2262
+step:220/20000 router_probe window_steps:10 avg_depth:4.317 router_objective:-0.2577 router_entropy:1.2473
+step:220/20000 router_matrix
+step:220/20000 train_loss:3.0459 train_time:616497ms step_avg:2802.26ms router_forward:1 router_objective:-0.2710 router_entropy:1.2564
+step:230/20000 router_probe window_steps:10 avg_depth:4.491 router_objective:-0.2772 router_entropy:1.2415
+step:230/20000 router_matrix
+step:230/20000 train_loss:2.9525 train_time:643968ms step_avg:2799.86ms router_forward:1 router_objective:-0.2270 router_entropy:1.2247
+step:240/20000 router_probe window_steps:10 avg_depth:4.699 router_objective:-0.2621 router_entropy:1.2351
+step:240/20000 router_matrix
+step:240/20000 train_loss:2.9590 train_time:672760ms step_avg:2803.17ms router_forward:1 router_objective:-0.2655 router_entropy:1.2514
+step:250/20000 router_probe window_steps:10 avg_depth:4.334 router_objective:-0.2884 router_entropy:1.2386
+step:250/20000 router_matrix
+step:250/20000 train_loss:3.0037 train_time:699464ms step_avg:2797.86ms router_forward:1 router_objective:-0.3486 router_entropy:1.2556
+step:260/20000 router_probe window_steps:10 avg_depth:4.340 router_objective:-0.2590 router_entropy:1.2548
+step:260/20000 router_matrix
+step:260/20000 train_loss:2.9422 train_time:728521ms step_avg:2802.00ms router_forward:1 router_objective:-0.2424 router_entropy:1.2660
+step:270/20000 router_probe window_steps:10 avg_depth:4.218 router_objective:-0.2729 router_entropy:1.2600
+step:270/20000 router_matrix
+step:270/20000 train_loss:2.9294 train_time:754982ms step_avg:2796.23ms router_forward:1 router_objective:-0.1781 router_entropy:1.2437
+step:280/20000 router_probe window_steps:10 avg_depth:4.199 router_objective:-0.2650 router_entropy:1.2458
+step:280/20000 router_matrix
+step:280/20000 train_loss:2.8403 train_time:781114ms step_avg:2789.69ms router_forward:1 router_objective:-0.2295 router_entropy:1.2349
+step:290/20000 router_probe window_steps:10 avg_depth:4.446 router_objective:-0.2782 router_entropy:1.2549
+step:290/20000 router_matrix
+step:290/20000 train_loss:2.8751 train_time:808994ms step_avg:2789.63ms router_forward:1 router_objective:-0.2643 router_entropy:1.2607
+step:300/20000 router_probe window_steps:10 avg_depth:4.579 router_objective:-0.2703 router_entropy:1.2566
+step:300/20000 router_matrix
+step:300/20000 train_loss:2.8357 train_time:837764ms step_avg:2792.55ms router_forward:1 router_objective:-0.2633 router_entropy:1.2477
+step:310/20000 router_probe window_steps:10 avg_depth:4.265 router_objective:-0.2753 router_entropy:1.2298
+step:310/20000 router_matrix
+step:310/20000 train_loss:2.7699 train_time:864427ms step_avg:2788.47ms router_forward:1 router_objective:-0.3653 router_entropy:1.2497
+step:320/20000 router_probe window_steps:10 avg_depth:4.447 router_objective:-0.2502 router_entropy:1.2358
+step:320/20000 router_matrix
+step:320/20000 train_loss:2.8312 train_time:892062ms step_avg:2787.69ms router_forward:1 router_objective:-0.2322 router_entropy:1.2029
+step:330/20000 router_probe window_steps:10 avg_depth:6.882 router_objective:-0.2659 router_entropy:1.1993
+step:330/20000 router_matrix
+step:330/20000 train_loss:2.9050 train_time:932356ms step_avg:2825.32ms router_forward:1 router_objective:-0.2872 router_entropy:1.2345
+step:340/20000 router_probe window_steps:10 avg_depth:4.976 router_objective:-0.2726 router_entropy:1.2352
+step:340/20000 router_matrix
+step:340/20000 train_loss:2.8255 train_time:963352ms step_avg:2833.39ms router_forward:1 router_objective:-0.2879 router_entropy:1.2269
+step:350/20000 router_probe window_steps:10 avg_depth:4.727 router_objective:-0.3062 router_entropy:1.2321
+step:350/20000 router_matrix
+step:350/20000 train_loss:2.9088 train_time:993088ms step_avg:2837.39ms router_forward:1 router_objective:-0.3610 router_entropy:1.2211
+step:360/20000 router_probe window_steps:10 avg_depth:4.582 router_objective:-0.2713 router_entropy:1.1917
+step:360/20000 router_matrix
+step:360/20000 train_loss:2.6856 train_time:1021982ms step_avg:2838.84ms router_forward:1 router_objective:-0.2687 router_entropy:1.1871
+step:370/20000 router_probe window_steps:10 avg_depth:5.270 router_objective:-0.2846 router_entropy:1.1809
+step:370/20000 router_matrix
+step:370/20000 train_loss:2.8525 train_time:1054442ms step_avg:2849.84ms router_forward:1 router_objective:-0.3363 router_entropy:1.1769
+step:380/20000 router_probe window_steps:10 avg_depth:5.901 router_objective:-0.3081 router_entropy:1.1369
+step:380/20000 router_matrix
+step:380/20000 train_loss:2.8335 train_time:1090283ms step_avg:2869.17ms router_forward:1 router_objective:-0.2890 router_entropy:1.1528
+step:390/20000 router_probe window_steps:10 avg_depth:4.924 router_objective:-0.2640 router_entropy:1.1222
+step:390/20000 router_matrix
+step:390/20000 train_loss:2.7920 train_time:1122559ms step_avg:2878.36ms router_forward:1 router_objective:-0.2677 router_entropy:1.1126
+step:400/20000 router_probe window_steps:10 avg_depth:4.866 router_objective:-0.2955 router_entropy:1.0920
+step:400/20000 router_matrix
+step:400/20000 train_loss:2.8247 train_time:1152963ms step_avg:2882.41ms router_forward:1 router_objective:-0.2257 router_entropy:1.0821
+step:410/20000 router_probe window_steps:10 avg_depth:4.847 router_objective:-0.2636 router_entropy:1.0524
+step:410/20000 router_matrix
+step:410/20000 train_loss:2.7808 train_time:1182793ms step_avg:2884.86ms router_forward:1 router_objective:-0.2165 router_entropy:1.0097
+step:420/20000 router_probe window_steps:10 avg_depth:5.073 router_objective:-0.2071 router_entropy:1.0087
+step:420/20000 router_matrix
+step:420/20000 train_loss:2.8217 train_time:1213849ms step_avg:2890.12ms router_forward:1 router_objective:-0.1463 router_entropy:1.0197
+step:430/20000 router_probe window_steps:10 avg_depth:4.885 router_objective:-0.2074 router_entropy:1.0335
+step:430/20000 router_matrix
+step:430/20000 train_loss:2.7475 train_time:1244510ms step_avg:2894.21ms router_forward:1 router_objective:-0.2100 router_entropy:1.0292
+step:440/20000 router_probe window_steps:10 avg_depth:4.663 router_objective:-0.1734 router_entropy:1.0287
+step:440/20000 router_matrix
+step:440/20000 train_loss:2.8114 train_time:1273707ms step_avg:2894.79ms router_forward:1 router_objective:-0.1241 router_entropy:1.0314
+step:450/20000 router_probe window_steps:10 avg_depth:4.781 router_objective:-0.2215 router_entropy:1.0247
+step:450/20000 router_matrix
+step:450/20000 train_loss:2.6208 train_time:1303623ms step_avg:2896.94ms router_forward:1 router_objective:-0.1901 router_entropy:1.0228
+step:460/20000 router_probe window_steps:10 avg_depth:4.857 router_objective:-0.2286 router_entropy:1.0176
+step:460/20000 router_matrix
+step:460/20000 train_loss:2.7506 train_time:1333950ms step_avg:2899.89ms router_forward:1 router_objective:-0.1958 router_entropy:1.0035
+step:470/20000 router_probe window_steps:10 avg_depth:5.100 router_objective:-0.2282 router_entropy:1.0075
+step:470/20000 router_matrix
+step:470/20000 train_loss:2.6870 train_time:1365497ms step_avg:2905.31ms router_forward:1 router_objective:-0.1726 router_entropy:1.0124
+step:480/20000 router_probe window_steps:10 avg_depth:4.977 router_objective:-0.2074 router_entropy:1.0179
+step:480/20000 router_matrix
+step:480/20000 train_loss:2.6357 train_time:1396952ms step_avg:2910.32ms router_forward:1 router_objective:-0.2798 router_entropy:1.0111
+step:490/20000 router_probe window_steps:10 avg_depth:4.923 router_objective:-0.2070 router_entropy:0.9882
+step:490/20000 router_matrix
+step:490/20000 train_loss:2.6669 train_time:1428170ms step_avg:2914.63ms router_forward:1 router_objective:-0.2193 router_entropy:0.9989
+step:500/20000 router_probe window_steps:10 avg_depth:5.794 router_objective:-0.2487 router_entropy:0.9905
+step:500/20000 router_matrix
+step:500/20000 train_loss:2.6682 train_time:1463238ms step_avg:2926.48ms router_forward:1 router_objective:-0.2454 router_entropy:0.9908
+step:510/20000 router_probe window_steps:10 avg_depth:5.669 router_objective:-0.2529 router_entropy:1.0268
+step:510/20000 router_matrix
+step:510/20000 train_loss:2.6478 train_time:1498560ms step_avg:2938.35ms router_forward:1 router_objective:-0.2880 router_entropy:1.0384
+step:520/20000 router_probe window_steps:10 avg_depth:5.511 router_objective:-0.2501 router_entropy:1.0287
+step:520/20000 router_matrix
+step:520/20000 train_loss:2.6862 train_time:1531997ms step_avg:2946.15ms router_forward:1 router_objective:-0.2763 router_entropy:1.0123
+step:530/20000 router_probe window_steps:10 avg_depth:5.790 router_objective:-0.2834 router_entropy:1.0069
+step:530/20000 router_matrix
+step:530/20000 train_loss:2.6567 train_time:1566946ms step_avg:2956.50ms router_forward:1 router_objective:-0.3972 router_entropy:1.0189
+step:540/20000 router_probe window_steps:10 avg_depth:6.214 router_objective:-0.2670 router_entropy:1.0162
+step:540/20000 router_matrix
+step:540/20000 train_loss:2.6911 train_time:1603727ms step_avg:2969.86ms router_forward:1 router_objective:-0.2193 router_entropy:1.0219
+step:550/20000 router_probe window_steps:10 avg_depth:5.801 router_objective:-0.2361 router_entropy:1.0287
+step:550/20000 router_matrix
+step:550/20000 train_loss:2.7362 train_time:1638756ms step_avg:2979.56ms router_forward:1 router_objective:-0.2628 router_entropy:1.0310
+step:560/20000 router_probe window_steps:10 avg_depth:5.939 router_objective:-0.2774 router_entropy:1.0330
+step:560/20000 router_matrix
+step:560/20000 train_loss:2.6407 train_time:1674279ms step_avg:2989.78ms router_forward:1 router_objective:-0.1656 router_entropy:1.0364
+step:570/20000 router_probe window_steps:10 avg_depth:6.713 router_objective:-0.2342 router_entropy:1.0414
+step:570/20000 router_matrix
+step:570/20000 train_loss:2.6677 train_time:1713546ms step_avg:3006.22ms router_forward:1 router_objective:-0.2320 router_entropy:1.0455
+step:580/20000 router_probe window_steps:10 avg_depth:5.873 router_objective:-0.2641 router_entropy:1.0200
+step:580/20000 router_matrix
+step:580/20000 train_loss:2.6884 train_time:1749002ms step_avg:3015.52ms router_forward:1 router_objective:-0.2788 router_entropy:1.0120
+step:590/20000 router_probe window_steps:10 avg_depth:5.876 router_objective:-0.2299 router_entropy:1.0189
+step:590/20000 router_matrix
+step:590/20000 train_loss:2.5672 train_time:1784377ms step_avg:3024.37ms router_forward:1 router_objective:-0.2533 router_entropy:1.0162
+step:600/20000 router_probe window_steps:10 avg_depth:5.417 router_objective:-0.2517 router_entropy:0.9920
+step:600/20000 router_matrix
+step:600/20000 train_loss:2.5937 train_time:1817588ms step_avg:3029.31ms router_forward:1 router_objective:-0.2783 router_entropy:0.9805
+step:610/20000 router_probe window_steps:10 avg_depth:5.309 router_objective:-0.2430 router_entropy:0.9887
+step:610/20000 router_matrix
+step:610/20000 train_loss:2.6522 train_time:1850231ms step_avg:3033.17ms router_forward:1 router_objective:-0.2089 router_entropy:1.0023
+step:620/20000 router_probe window_steps:10 avg_depth:5.639 router_objective:-0.2115 router_entropy:0.9993
+step:620/20000 router_matrix
+step:620/20000 train_loss:2.6182 train_time:1884451ms step_avg:3039.44ms router_forward:1 router_objective:-0.2191 router_entropy:0.9857
+step:630/20000 router_probe window_steps:10 avg_depth:5.327 router_objective:-0.2538 router_entropy:0.9767
+step:630/20000 router_matrix
+step:630/20000 train_loss:2.6697 train_time:1917082ms step_avg:3042.99ms router_forward:1 router_objective:-0.3123 router_entropy:1.0202
+step:640/20000 router_probe window_steps:10 avg_depth:5.430 router_objective:-0.2329 router_entropy:1.0025
+step:640/20000 router_matrix
+step:640/20000 train_loss:2.6300 train_time:1951835ms step_avg:3049.74ms router_forward:1 router_objective:-0.2673 router_entropy:0.9666
+step:650/20000 router_probe window_steps:10 avg_depth:5.208 router_objective:-0.2325 router_entropy:0.9988
+step:650/20000 router_matrix
+step:650/20000 train_loss:2.5729 train_time:1983934ms step_avg:3052.21ms router_forward:1 router_objective:-0.2606 router_entropy:1.0100
+step:660/20000 router_probe window_steps:10 avg_depth:5.130 router_objective:-0.2501 router_entropy:0.9883
+step:660/20000 router_matrix
+step:660/20000 train_loss:2.6409 train_time:2015542ms step_avg:3053.85ms router_forward:1 router_objective:-0.2733 router_entropy:0.9812
+step:670/20000 router_probe window_steps:10 avg_depth:5.182 router_objective:-0.2558 router_entropy:0.9942
+step:670/20000 router_matrix
+step:670/20000 train_loss:2.5236 train_time:2047405ms step_avg:3055.83ms router_forward:1 router_objective:-0.2663 router_entropy:1.0008
+step:680/20000 router_probe window_steps:10 avg_depth:5.323 router_objective:-0.2413 router_entropy:1.0111
+step:680/20000 router_matrix
+step:680/20000 train_loss:2.5315 train_time:2080146ms step_avg:3059.04ms router_forward:1 router_objective:-0.2975 router_entropy:1.0149
+step:690/20000 router_probe window_steps:10 avg_depth:5.710 router_objective:-0.2572 router_entropy:1.0279
+step:690/20000 router_matrix
+step:690/20000 train_loss:2.5230 train_time:2114721ms step_avg:3064.81ms router_forward:1 router_objective:-0.2845 router_entropy:1.0045
+step:700/20000 router_probe window_steps:10 avg_depth:5.518 router_objective:-0.2279 router_entropy:1.0209
+step:700/20000 router_matrix
+step:700/20000 train_loss:2.6097 train_time:2148377ms step_avg:3069.11ms router_forward:1 router_objective:-0.2897 router_entropy:1.0315
+step:710/20000 router_probe window_steps:10 avg_depth:5.496 router_objective:-0.2381 router_entropy:0.9954
+step:710/20000 router_matrix
+step:710/20000 train_loss:2.5969 train_time:2181944ms step_avg:3073.16ms router_forward:1 router_objective:-0.3794 router_entropy:0.9907
+step:720/20000 router_probe window_steps:10 avg_depth:5.337 router_objective:-0.2483 router_entropy:0.9999
+step:720/20000 router_matrix
+step:720/20000 train_loss:2.5923 train_time:2214856ms step_avg:3076.19ms router_forward:1 router_objective:-0.2752 router_entropy:1.0069
+step:730/20000 router_probe window_steps:10 avg_depth:5.500 router_objective:-0.2548 router_entropy:1.0178
+step:730/20000 router_matrix
+step:730/20000 train_loss:2.5076 train_time:2248394ms step_avg:3079.99ms router_forward:1 router_objective:-0.2848 router_entropy:1.0185
+step:740/20000 router_probe window_steps:10 avg_depth:5.676 router_objective:-0.2451 router_entropy:1.0195
+step:740/20000 router_matrix
+step:740/20000 train_loss:2.4530 train_time:2282656ms step_avg:3084.67ms router_forward:1 router_objective:-0.1774 router_entropy:1.0257
+step:750/20000 router_probe window_steps:10 avg_depth:5.822 router_objective:-0.2375 router_entropy:1.0291
+step:750/20000 router_matrix
+step:750/20000 train_loss:2.5583 train_time:2317591ms step_avg:3090.12ms router_forward:1 router_objective:-0.2265 router_entropy:1.0141
+step:760/20000 router_probe window_steps:10 avg_depth:5.750 router_objective:-0.2511 router_entropy:1.0215
+step:760/20000 router_matrix
+step:760/20000 train_loss:2.5680 train_time:2352247ms step_avg:3095.06ms router_forward:1 router_objective:-0.2861 router_entropy:1.0427
+step:770/20000 router_probe window_steps:10 avg_depth:5.657 router_objective:-0.2217 router_entropy:1.0281
+step:770/20000 router_matrix
+step:770/20000 train_loss:2.5649 train_time:2387570ms step_avg:3100.74ms router_forward:1 router_objective:-0.2118 router_entropy:1.0078
+step:780/20000 router_probe window_steps:10 avg_depth:5.287 router_objective:-0.2513 router_entropy:0.9917
+step:780/20000 router_matrix
+step:780/20000 train_loss:2.4978 train_time:2420057ms step_avg:3102.64ms router_forward:1 router_objective:-0.2599 router_entropy:0.9843
+step:790/20000 router_probe window_steps:10 avg_depth:5.865 router_objective:-0.2361 router_entropy:1.0205
+step:790/20000 router_matrix
+step:790/20000 train_loss:2.5416 train_time:2455091ms step_avg:3107.71ms router_forward:1 router_objective:-0.2114 router_entropy:1.0347
+step:800/20000 router_probe window_steps:10 avg_depth:5.981 router_objective:-0.2355 router_entropy:1.0293
+step:800/20000 router_matrix
+step:800/20000 train_loss:2.5255 train_time:2490808ms step_avg:3113.51ms router_forward:1 router_objective:-0.3158 router_entropy:1.0371
+step:810/20000 router_probe window_steps:10 avg_depth:5.651 router_objective:-0.2421 router_entropy:1.0220
+step:810/20000 router_matrix
+step:810/20000 train_loss:2.3870 train_time:2524875ms step_avg:3117.13ms router_forward:1 router_objective:-0.2166 router_entropy:1.0125
+step:820/20000 router_probe window_steps:10 avg_depth:5.594 router_objective:-0.2199 router_entropy:1.0089
+step:820/20000 router_matrix
+step:820/20000 train_loss:2.4936 train_time:2558828ms step_avg:3120.52ms router_forward:1 router_objective:-0.1868 router_entropy:1.0287
+step:830/20000 router_probe window_steps:10 avg_depth:5.839 router_objective:-0.2457 router_entropy:1.0295
+step:830/20000 router_matrix
+step:830/20000 train_loss:2.4267 train_time:2594029ms step_avg:3125.34ms router_forward:1 router_objective:-0.2250 router_entropy:1.0135
+step:840/20000 router_probe window_steps:10 avg_depth:5.728 router_objective:-0.2352 router_entropy:1.0205
+step:840/20000 router_matrix
+step:840/20000 train_loss:2.5234 train_time:2628627ms step_avg:3129.32ms router_forward:1 router_objective:-0.2770 router_entropy:1.0435
+step:850/20000 router_probe window_steps:10 avg_depth:5.811 router_objective:-0.2438 router_entropy:1.0283
+step:850/20000 router_matrix
+step:850/20000 train_loss:2.4507 train_time:2663490ms step_avg:3133.52ms router_forward:1 router_objective:-0.3148 router_entropy:1.0157
+step:860/20000 router_probe window_steps:10 avg_depth:5.423 router_objective:-0.2292 router_entropy:1.0034
+step:860/20000 router_matrix
+step:860/20000 train_loss:2.4523 train_time:2696446ms step_avg:3135.40ms router_forward:1 router_objective:-0.1480 router_entropy:1.0165
+step:870/20000 router_probe window_steps:10 avg_depth:5.755 router_objective:-0.2279 router_entropy:1.0184
+step:870/20000 router_matrix
+step:870/20000 train_loss:2.4637 train_time:2731193ms step_avg:3139.30ms router_forward:1 router_objective:-0.1791 router_entropy:1.0006
+step:880/20000 router_probe window_steps:10 avg_depth:5.497 router_objective:-0.2443 router_entropy:1.0028
+step:880/20000 router_matrix
+step:880/20000 train_loss:2.4518 train_time:2764661ms step_avg:3141.66ms router_forward:1 router_objective:-0.2434 router_entropy:1.0161
+step:890/20000 router_probe window_steps:10 avg_depth:5.705 router_objective:-0.2383 router_entropy:1.0269
+step:890/20000 router_matrix
+step:890/20000 train_loss:2.4982 train_time:2799038ms step_avg:3144.99ms router_forward:1 router_objective:-0.2118 router_entropy:1.0234
+step:900/20000 router_probe window_steps:10 avg_depth:5.973 router_objective:-0.2798 router_entropy:1.0337
+step:900/20000 router_matrix
+step:900/20000 train_loss:2.3904 train_time:2835403ms step_avg:3150.45ms router_forward:1 router_objective:-0.6031 router_entropy:1.0416
+step:910/20000 router_probe window_steps:10 avg_depth:5.738 router_objective:-0.2799 router_entropy:1.0143
+step:910/20000 router_matrix
+step:910/20000 train_loss:2.4794 train_time:2870005ms step_avg:3153.85ms router_forward:1 router_objective:-0.2882 router_entropy:1.0064
+step:920/20000 router_probe window_steps:10 avg_depth:5.586 router_objective:-0.2603 router_entropy:1.0072
+step:920/20000 router_matrix
+step:920/20000 train_loss:2.3937 train_time:2903903ms step_avg:3156.42ms router_forward:1 router_objective:-0.2552 router_entropy:1.0324
+step:930/20000 router_probe window_steps:10 avg_depth:6.479 router_objective:-0.2687 router_entropy:1.0374
+step:930/20000 router_matrix
+step:930/20000 train_loss:2.4923 train_time:2942438ms step_avg:3163.91ms router_forward:1 router_objective:-0.2895 router_entropy:1.0423
+step:940/20000 router_probe window_steps:10 avg_depth:5.723 router_objective:-0.2593 router_entropy:1.0232
+step:940/20000 router_matrix
+step:940/20000 train_loss:2.4513 train_time:2977163ms step_avg:3167.19ms router_forward:1 router_objective:-0.2428 router_entropy:1.0265
+step:950/20000 router_probe window_steps:10 avg_depth:5.861 router_objective:-0.2732 router_entropy:1.0281
+step:950/20000 router_matrix
+step:950/20000 train_loss:2.5621 train_time:3012642ms step_avg:3171.20ms router_forward:1 router_objective:-0.2408 router_entropy:1.0292
+step:960/20000 router_probe window_steps:10 avg_depth:5.783 router_objective:-0.2394 router_entropy:1.0215
+step:960/20000 router_matrix
+step:960/20000 train_loss:2.3816 train_time:3047516ms step_avg:3174.50ms router_forward:1 router_objective:-0.1996 router_entropy:1.0129
+step:970/20000 router_probe window_steps:10 avg_depth:6.357 router_objective:-0.2225 router_entropy:1.0271
+step:970/20000 router_matrix
+step:970/20000 train_loss:2.5212 train_time:3084945ms step_avg:3180.36ms router_forward:1 router_objective:-0.2922 router_entropy:1.0370
+step:980/20000 router_probe window_steps:10 avg_depth:5.643 router_objective:-0.2408 router_entropy:1.0230
+step:980/20000 router_matrix
+step:980/20000 train_loss:2.4713 train_time:3118897ms step_avg:3182.55ms router_forward:1 router_objective:-0.2085 router_entropy:1.0123
+step:990/20000 router_probe window_steps:10 avg_depth:5.796 router_objective:-0.2464 router_entropy:1.0229
+step:990/20000 router_matrix
+step:990/20000 train_loss:2.4406 train_time:3153483ms step_avg:3185.34ms router_forward:1 router_objective:-0.3047 router_entropy:1.0181
+step:1000/20000 router_probe window_steps:10 avg_depth:5.644 router_objective:-0.2161 router_entropy:1.0137
+step:1000/20000 router_matrix
+step:1000/20000 train_loss:2.4938 train_time:3187295ms step_avg:3187.29ms router_forward:1 router_objective:-0.2090 router_entropy:1.0115
+step:1010/20000 router_probe window_steps:10 avg_depth:6.278 router_objective:-0.2092 router_entropy:0.9911
+step:1010/20000 router_matrix
+step:1010/20000 train_loss:2.4781 train_time:3224348ms step_avg:3192.42ms router_forward:1 router_objective:-0.2457 router_entropy:1.0152
+step:1020/20000 router_probe window_steps:10 avg_depth:5.861 router_objective:-0.2225 router_entropy:1.0301
+step:1020/20000 router_matrix
+step:1020/20000 train_loss:2.4905 train_time:3263691ms step_avg:3199.70ms router_forward:1 router_objective:-0.2324 router_entropy:1.0353
+step:1030/20000 router_probe window_steps:10 avg_depth:5.776 router_objective:-0.2350 router_entropy:1.0078
+step:1030/20000 router_matrix
+step:1030/20000 train_loss:2.4161 train_time:3298463ms step_avg:3202.39ms router_forward:1 router_objective:-0.2363 router_entropy:0.9820
+step:1040/20000 router_probe window_steps:10 avg_depth:5.725 router_objective:-0.2265 router_entropy:1.0087
+step:1040/20000 router_matrix
+step:1040/20000 train_loss:2.4789 train_time:3333253ms step_avg:3205.05ms router_forward:1 router_objective:-0.2662 router_entropy:1.0326
+step:1050/20000 router_probe window_steps:10 avg_depth:5.936 router_objective:-0.2640 router_entropy:1.0221
+step:1050/20000 router_matrix
+step:1050/20000 train_loss:2.4418 train_time:3368994ms step_avg:3208.57ms router_forward:1 router_objective:-0.2533 router_entropy:1.0111
+step:1060/20000 router_probe window_steps:10 avg_depth:6.021 router_objective:-0.2315 router_entropy:1.0080
+step:1060/20000 router_matrix
+step:1060/20000 train_loss:2.5053 train_time:3404963ms step_avg:3212.23ms router_forward:1 router_objective:-0.2629 router_entropy:1.0172
+step:1070/20000 router_probe window_steps:10 avg_depth:6.534 router_objective:-0.2398 router_entropy:1.0042
+step:1070/20000 router_matrix
+step:1070/20000 train_loss:2.5099 train_time:3443504ms step_avg:3218.23ms router_forward:1 router_objective:-0.2205 router_entropy:0.9782
+step:1080/20000 router_probe window_steps:10 avg_depth:6.072 router_objective:-0.2403 router_entropy:1.0221
+step:1080/20000 router_matrix
+step:1080/20000 train_loss:2.5340 train_time:3479486ms step_avg:3221.75ms router_forward:1 router_objective:-0.2577 router_entropy:1.0293
+step:1090/20000 router_probe window_steps:10 avg_depth:5.695 router_objective:-0.2529 router_entropy:1.0252
+step:1090/20000 router_matrix
+step:1090/20000 train_loss:2.4962 train_time:3513635ms step_avg:3223.52ms router_forward:1 router_objective:-0.2628 router_entropy:1.0204
+step:1100/20000 router_probe window_steps:10 avg_depth:5.578 router_objective:-0.2305 router_entropy:1.0138
+step:1100/20000 router_matrix
+step:1100/20000 train_loss:2.4673 train_time:3547145ms step_avg:3224.68ms router_forward:1 router_objective:-0.2523 router_entropy:1.0261
+step:1110/20000 router_probe window_steps:10 avg_depth:6.117 router_objective:-0.2508 router_entropy:1.0334
+step:1110/20000 router_matrix
+step:1110/20000 train_loss:2.4689 train_time:3583412ms step_avg:3228.30ms router_forward:1 router_objective:-0.3092 router_entropy:1.0367
+step:1120/20000 router_probe window_steps:10 avg_depth:5.537 router_objective:-0.2496 router_entropy:1.0077
+step:1120/20000 router_matrix
+step:1120/20000 train_loss:2.3933 train_time:3616865ms step_avg:3229.34ms router_forward:1 router_objective:-0.2409 router_entropy:1.0050
+step:1130/20000 router_probe window_steps:10 avg_depth:5.772 router_objective:-0.2635 router_entropy:0.9967
+step:1130/20000 router_matrix
+step:1130/20000 train_loss:2.4655 train_time:3651507ms step_avg:3231.42ms router_forward:1 router_objective:-0.2630 router_entropy:1.0143
+step:1140/20000 router_probe window_steps:10 avg_depth:6.192 router_objective:-0.2401 router_entropy:1.0251
+step:1140/20000 router_matrix
+step:1140/20000 train_loss:2.4508 train_time:3688294ms step_avg:3235.35ms router_forward:1 router_objective:-0.2233 router_entropy:1.0283
+step:1150/20000 router_probe window_steps:10 avg_depth:6.109 router_objective:-0.2430 router_entropy:1.0109
+step:1150/20000 router_matrix
+step:1150/20000 train_loss:2.4334 train_time:3729669ms step_avg:3243.19ms router_forward:1 router_objective:-0.2459 router_entropy:1.0235
+step:1160/20000 router_probe window_steps:10 avg_depth:5.734 router_objective:-0.2452 router_entropy:1.0192
+step:1160/20000 router_matrix
+step:1160/20000 train_loss:2.4452 train_time:3764086ms step_avg:3244.90ms router_forward:1 router_objective:-0.2167 router_entropy:0.9992
+step:1170/20000 router_probe window_steps:10 avg_depth:5.580 router_objective:-0.2679 router_entropy:1.0000
+step:1170/20000 router_matrix
+step:1170/20000 train_loss:2.4002 train_time:3797964ms step_avg:3246.12ms router_forward:1 router_objective:-0.2439 router_entropy:1.0136
+step:1180/20000 router_probe window_steps:10 avg_depth:6.065 router_objective:-0.2476 router_entropy:1.0234
+step:1180/20000 router_matrix
+step:1180/20000 train_loss:2.4511 train_time:3834186ms step_avg:3249.31ms router_forward:1 router_objective:-0.2466 router_entropy:1.0139
+step:1190/20000 router_probe window_steps:10 avg_depth:5.673 router_objective:-0.2292 router_entropy:1.0192
+step:1190/20000 router_matrix
+step:1190/20000 train_loss:2.4131 train_time:3868547ms step_avg:3250.88ms router_forward:1 router_objective:-0.2034 router_entropy:1.0221
+step:1200/20000 router_probe window_steps:10 avg_depth:5.926 router_objective:-0.2368 router_entropy:1.0313
+step:1200/20000 router_matrix
+step:1200/20000 train_loss:2.4550 train_time:3903873ms step_avg:3253.23ms router_forward:1 router_objective:-0.2679 router_entropy:1.0390
+step:1210/20000 router_probe window_steps:10 avg_depth:5.617 router_objective:-0.2215 router_entropy:1.0083
+step:1210/20000 router_matrix
+step:1210/20000 train_loss:2.4008 train_time:3937831ms step_avg:3254.41ms router_forward:1 router_objective:-0.2376 router_entropy:1.0028
+step:1220/20000 router_probe window_steps:10 avg_depth:5.596 router_objective:-0.2349 router_entropy:1.0126
+step:1220/20000 router_matrix
+step:1220/20000 train_loss:2.3673 train_time:3971793ms step_avg:3255.57ms router_forward:1 router_objective:-0.2589 router_entropy:1.0185
+step:1230/20000 router_probe window_steps:10 avg_depth:5.976 router_objective:-0.2344 router_entropy:1.0065
+step:1230/20000 router_matrix
+step:1230/20000 train_loss:2.4265 train_time:4008236ms step_avg:3258.73ms router_forward:1 router_objective:-0.2475 router_entropy:1.0190
+step:1240/20000 router_probe window_steps:10 avg_depth:5.805 router_objective:-0.2377 router_entropy:1.0143
+step:1240/20000 router_matrix
+step:1240/20000 train_loss:2.4101 train_time:4043250ms step_avg:3260.69ms router_forward:1 router_objective:-0.2594 router_entropy:0.9949
+step:1250/20000 router_probe window_steps:10 avg_depth:5.586 router_objective:-0.2338 router_entropy:0.9789
+step:1250/20000 router_matrix
+step:1250/20000 train_loss:2.4941 train_time:4076750ms step_avg:3261.40ms router_forward:1 router_objective:-0.2480 router_entropy:1.0009
+step:1260/20000 router_probe window_steps:10 avg_depth:5.845 router_objective:-0.2521 router_entropy:1.0170
+step:1260/20000 router_matrix
+step:1260/20000 train_loss:2.4247 train_time:4111733ms step_avg:3263.28ms router_forward:1 router_objective:-0.2056 router_entropy:1.0231
+step:1270/20000 router_probe window_steps:10 avg_depth:5.735 router_objective:-0.2649 router_entropy:1.0161
+step:1270/20000 router_matrix
+step:1270/20000 train_loss:2.3738 train_time:4146183ms step_avg:3264.71ms router_forward:1 router_objective:-0.2630 router_entropy:1.0029
+step:1280/20000 router_probe window_steps:10 avg_depth:5.451 router_objective:-0.2647 router_entropy:1.0026
+step:1280/20000 router_matrix
+step:1280/20000 train_loss:2.4136 train_time:4180323ms step_avg:3265.88ms router_forward:1 router_objective:-0.2686 router_entropy:0.9972
+step:1290/20000 router_probe window_steps:10 avg_depth:5.724 router_objective:-0.2567 router_entropy:1.0203
+step:1290/20000 router_matrix
+step:1290/20000 train_loss:2.4132 train_time:4214857ms step_avg:3267.33ms router_forward:1 router_objective:-0.2997 router_entropy:1.0189
+step:1300/20000 router_probe window_steps:10 avg_depth:6.071 router_objective:-0.2479 router_entropy:1.0206
+step:1300/20000 router_matrix
+step:1300/20000 train_loss:2.4733 train_time:4251076ms step_avg:3270.06ms router_forward:1 router_objective:-0.1838 router_entropy:1.0013
+step:1310/20000 router_probe window_steps:10 avg_depth:6.946 router_objective:-0.1758 router_entropy:1.0091
+step:1310/20000 router_matrix
+step:1310/20000 train_loss:2.4349 train_time:4291676ms step_avg:3276.09ms router_forward:1 router_objective:-0.2118 router_entropy:1.0166
+step:1320/20000 router_probe window_steps:10 avg_depth:7.121 router_objective:-0.2427 router_entropy:0.9849
+step:1320/20000 router_matrix
+step:1320/20000 train_loss:2.4856 train_time:4332918ms step_avg:3282.51ms router_forward:1 router_objective:-0.2793 router_entropy:1.0089
+step:1330/20000 router_probe window_steps:10 avg_depth:6.786 router_objective:-0.2672 router_entropy:1.0166
+step:1330/20000 router_matrix
+step:1330/20000 train_loss:2.4431 train_time:4372494ms step_avg:3287.59ms router_forward:1 router_objective:-0.2697 router_entropy:1.0240
+step:1340/20000 router_probe window_steps:10 avg_depth:9.293 router_objective:-0.2292 router_entropy:0.9832
+step:1340/20000 router_matrix
+step:1340/20000 train_loss:2.5089 train_time:4424215ms step_avg:3301.65ms router_forward:1 router_objective:-0.3012 router_entropy:1.0227
+step:1350/20000 router_probe window_steps:10 avg_depth:9.014 router_objective:-0.2072 router_entropy:0.9406
+step:1350/20000 router_matrix
+step:1350/20000 train_loss:2.5102 train_time:4474811ms step_avg:3314.68ms router_forward:1 router_objective:-0.2188 router_entropy:0.9706
+step:1360/20000 router_probe window_steps:10 avg_depth:9.356 router_objective:-0.2304 router_entropy:0.9790
+step:1360/20000 router_matrix
+step:1360/20000 train_loss:2.5958 train_time:4526701ms step_avg:3328.46ms router_forward:1 router_objective:-0.2083 router_entropy:0.9734
+step:1370/20000 router_probe window_steps:10 avg_depth:9.160 router_objective:-0.1847 router_entropy:0.9507
+step:1370/20000 router_matrix
+step:1370/20000 train_loss:2.6613 train_time:4577563ms step_avg:3341.29ms router_forward:1 router_objective:-0.2497 router_entropy:0.9044
+step:1380/20000 router_probe window_steps:10 avg_depth:8.531 router_objective:-0.1998 router_entropy:0.8784
+step:1380/20000 router_matrix
+step:1380/20000 train_loss:2.6181 train_time:4625434ms step_avg:3351.76ms router_forward:1 router_objective:-0.1601 router_entropy:0.9020
+step:1390/20000 router_probe window_steps:10 avg_depth:10.298 router_objective:-0.2028 router_entropy:0.9898
+step:1390/20000 router_matrix
+step:1390/20000 train_loss:2.6360 train_time:4681829ms step_avg:3368.22ms router_forward:1 router_objective:-0.2009 router_entropy:1.0155
+step:1400/20000 router_probe window_steps:10 avg_depth:8.032 router_objective:-0.1892 router_entropy:0.9952
+step:1400/20000 router_matrix
+step:1400/20000 train_loss:2.6635 train_time:4730506ms step_avg:3378.93ms router_forward:1 router_objective:-0.2364 router_entropy:1.0229
+step:1410/20000 router_probe window_steps:10 avg_depth:7.929 router_objective:-0.2320 router_entropy:1.0024
+step:1410/20000 router_matrix
+step:1410/20000 train_loss:2.5202 train_time:4775471ms step_avg:3386.86ms router_forward:1 router_objective:-0.2902 router_entropy:0.9994
+step:1420/20000 router_probe window_steps:10 avg_depth:7.818 router_objective:-0.2433 router_entropy:1.0081
+step:1420/20000 router_matrix
+step:1420/20000 train_loss:2.5479 train_time:4819681ms step_avg:3394.14ms router_forward:1 router_objective:-0.2053 router_entropy:0.9367
+step:1430/20000 router_probe window_steps:10 avg_depth:7.367 router_objective:-0.2291 router_entropy:0.9835
+step:1430/20000 router_matrix
+step:1430/20000 train_loss:2.4783 train_time:4861981ms step_avg:3399.99ms router_forward:1 router_objective:-0.1866 router_entropy:0.9887
+step:1440/20000 router_probe window_steps:10 avg_depth:5.766 router_objective:-0.1985 router_entropy:0.9953
+step:1440/20000 router_matrix
+step:1440/20000 train_loss:2.5783 train_time:4896659ms step_avg:3400.46ms router_forward:1 router_objective:-0.1076 router_entropy:1.0120
+step:1450/20000 router_probe window_steps:10 avg_depth:5.741 router_objective:-0.2264 router_entropy:1.0077
+step:1450/20000 router_matrix
+step:1450/20000 train_loss:2.4741 train_time:4931134ms step_avg:3400.78ms router_forward:1 router_objective:-0.2334 router_entropy:0.9796
+step:1460/20000 router_probe window_steps:10 avg_depth:5.507 router_objective:-0.1916 router_entropy:1.0039
+step:1460/20000 router_matrix
+step:1460/20000 train_loss:2.5120 train_time:4964300ms step_avg:3400.21ms router_forward:1 router_objective:-0.1113 router_entropy:1.0048
+step:1470/20000 router_probe window_steps:10 avg_depth:5.974 router_objective:-0.2228 router_entropy:1.0041
+step:1470/20000 router_matrix
+step:1470/20000 train_loss:2.4243 train_time:4999892ms step_avg:3401.29ms router_forward:1 router_objective:-0.1651 router_entropy:1.0267
+step:1480/20000 router_probe window_steps:10 avg_depth:5.856 router_objective:-0.2037 router_entropy:1.0180
+step:1480/20000 router_matrix
+step:1480/20000 train_loss:2.4939 train_time:5034995ms step_avg:3402.02ms router_forward:1 router_objective:-0.1917 router_entropy:1.0204
+step:1490/20000 router_probe window_steps:10 avg_depth:5.998 router_objective:-0.2433 router_entropy:1.0187
+step:1490/20000 router_matrix
+step:1490/20000 train_loss:2.3941 train_time:5070744ms step_avg:3403.18ms router_forward:1 router_objective:-0.3114 router_entropy:1.0053
+step:1500/20000 router_probe window_steps:10 avg_depth:5.580 router_objective:-0.2146 router_entropy:0.9813
+step:1500/20000 router_matrix
+step:1500/20000 train_loss:2.4296 train_time:5104261ms step_avg:3402.84ms router_forward:1 router_objective:-0.2316 router_entropy:1.0163
+step:1510/20000 router_probe window_steps:10 avg_depth:5.767 router_objective:-0.1951 router_entropy:1.0181
+step:1510/20000 router_matrix
+step:1510/20000 train_loss:2.3835 train_time:5138822ms step_avg:3403.19ms router_forward:1 router_objective:-0.2195 router_entropy:1.0146
+step:1520/20000 router_probe window_steps:10 avg_depth:5.813 router_objective:-0.2570 router_entropy:1.0140
+step:1520/20000 router_matrix
+step:1520/20000 train_loss:2.4357 train_time:5173562ms step_avg:3403.66ms router_forward:1 router_objective:-0.2577 router_entropy:1.0099
+step:1530/20000 router_probe window_steps:10 avg_depth:5.435 router_objective:-0.1774 router_entropy:1.0066
+step:1530/20000 router_matrix
+step:1530/20000 train_loss:2.4242 train_time:5207664ms step_avg:3403.70ms router_forward:1 router_objective:0.0728 router_entropy:1.0145
+step:1540/20000 router_probe window_steps:10 avg_depth:5.736 router_objective:-0.2210 router_entropy:1.0168
+step:1540/20000 router_matrix
+step:1540/20000 train_loss:2.4315 train_time:5242149ms step_avg:3403.99ms router_forward:1 router_objective:-0.2419 router_entropy:1.0230
+step:1550/20000 router_probe window_steps:10 avg_depth:5.844 router_objective:-0.2400 router_entropy:1.0132
+step:1550/20000 router_matrix
+step:1550/20000 train_loss:2.4101 train_time:5277350ms step_avg:3404.74ms router_forward:1 router_objective:-0.2156 router_entropy:1.0228
+step:1560/20000 router_probe window_steps:10 avg_depth:5.625 router_objective:-0.2543 router_entropy:1.0049
+step:1560/20000 router_matrix
+step:1560/20000 train_loss:2.3663 train_time:5311924ms step_avg:3405.08ms router_forward:1 router_objective:-0.2198 router_entropy:1.0043
+step:1570/20000 router_probe window_steps:10 avg_depth:5.938 router_objective:-0.2508 router_entropy:1.0180
+step:1570/20000 router_matrix
+step:1570/20000 train_loss:2.5183 train_time:5347888ms step_avg:3406.30ms router_forward:1 router_objective:-0.1649 router_entropy:0.9994
+step:1580/20000 router_probe window_steps:10 avg_depth:6.028 router_objective:-0.2234 router_entropy:1.0148
+step:1580/20000 router_matrix
+step:1580/20000 train_loss:2.4895 train_time:5384205ms step_avg:3407.72ms router_forward:1 router_objective:-0.2776 router_entropy:1.0085
+step:1590/20000 router_probe window_steps:10 avg_depth:5.944 router_objective:-0.2550 router_entropy:1.0141
+step:1590/20000 router_matrix
+step:1590/20000 train_loss:2.4897 train_time:5420050ms step_avg:3408.84ms router_forward:1 router_objective:-0.2907 router_entropy:0.9978
+step:1600/20000 router_probe window_steps:10 avg_depth:5.623 router_objective:-0.2527 router_entropy:1.0067
+step:1600/20000 router_matrix
+step:1600/20000 train_loss:2.4188 train_time:5454476ms step_avg:3409.05ms router_forward:1 router_objective:-0.2606 router_entropy:1.0123
+step:1610/20000 router_probe window_steps:10 avg_depth:5.553 router_objective:-0.2267 router_entropy:1.0075
+step:1610/20000 router_matrix
+step:1610/20000 train_loss:2.4689 train_time:5488376ms step_avg:3408.93ms router_forward:1 router_objective:-0.1880 router_entropy:0.9787
+step:1620/20000 router_probe window_steps:10 avg_depth:5.535 router_objective:-0.2213 router_entropy:1.0072
+step:1620/20000 router_matrix
+step:1620/20000 train_loss:2.3606 train_time:5522260ms step_avg:3408.80ms router_forward:1 router_objective:-0.1770 router_entropy:1.0072
+step:1630/20000 router_probe window_steps:10 avg_depth:5.673 router_objective:-0.2156 router_entropy:0.9971
+step:1630/20000 router_matrix
+step:1630/20000 train_loss:2.3507 train_time:5556916ms step_avg:3409.15ms router_forward:1 router_objective:-0.2801 router_entropy:1.0177
+step:1640/20000 router_probe window_steps:10 avg_depth:6.066 router_objective:-0.2430 router_entropy:1.0107
+step:1640/20000 router_matrix
+step:1640/20000 train_loss:2.4334 train_time:5593427ms step_avg:3410.63ms router_forward:1 router_objective:-0.2116 router_entropy:0.9918
+step:1650/20000 router_probe window_steps:10 avg_depth:5.990 router_objective:-0.2432 router_entropy:1.0158
+step:1650/20000 router_matrix
+step:1650/20000 train_loss:2.4509 train_time:5629160ms step_avg:3411.61ms router_forward:1 router_objective:-0.2992 router_entropy:1.0095
+step:1660/20000 router_probe window_steps:10 avg_depth:5.684 router_objective:-0.2318 router_entropy:1.0149
+step:1660/20000 router_matrix
+step:1660/20000 train_loss:2.3909 train_time:5665517ms step_avg:3412.96ms router_forward:1 router_objective:-0.2632 router_entropy:0.9956
+step:1670/20000 router_probe window_steps:10 avg_depth:5.449 router_objective:-0.2114 router_entropy:1.0044
+step:1670/20000 router_matrix
+step:1670/20000 train_loss:2.4109 train_time:5698537ms step_avg:3412.30ms router_forward:1 router_objective:-0.2795 router_entropy:1.0054
+step:1680/20000 router_probe window_steps:10 avg_depth:5.866 router_objective:-0.2136 router_entropy:0.9832
+step:1680/20000 router_matrix
+step:1680/20000 train_loss:2.3509 train_time:5733704ms step_avg:3412.92ms router_forward:1 router_objective:-0.2247 router_entropy:0.9437
+step:1690/20000 router_probe window_steps:10 avg_depth:6.222 router_objective:-0.2350 router_entropy:1.0082
+step:1690/20000 router_matrix
+step:1690/20000 train_loss:2.4623 train_time:5770641ms step_avg:3414.58ms router_forward:1 router_objective:-0.2585 router_entropy:1.0199
+step:1700/20000 router_probe window_steps:10 avg_depth:5.763 router_objective:-0.2243 router_entropy:1.0067
+step:1700/20000 router_matrix
+step:1700/20000 train_loss:2.4002 train_time:5805324ms step_avg:3414.90ms router_forward:1 router_objective:-0.2464 router_entropy:0.9825
+step:1710/20000 router_probe window_steps:10 avg_depth:6.374 router_objective:-0.2000 router_entropy:0.9641
+step:1710/20000 router_matrix
+step:1710/20000 train_loss:2.4381 train_time:5842978ms step_avg:3416.95ms router_forward:1 router_objective:-0.1479 router_entropy:0.9489
+step:1720/20000 router_probe window_steps:10 avg_depth:8.168 router_objective:-0.2097 router_entropy:0.9960
+step:1720/20000 router_matrix
+step:1720/20000 train_loss:2.5109 train_time:5889373ms step_avg:3424.05ms router_forward:1 router_objective:-0.2106 router_entropy:1.0044
+step:1730/20000 router_probe window_steps:10 avg_depth:5.788 router_objective:-0.2025 router_entropy:0.9848
+step:1730/20000 router_matrix
+step:1730/20000 train_loss:2.4916 train_time:5925465ms step_avg:3425.12ms router_forward:1 router_objective:-0.1430 router_entropy:0.9782
+step:1740/20000 router_probe window_steps:10 avg_depth:5.658 router_objective:-0.2563 router_entropy:0.9979
+step:1740/20000 router_matrix
+step:1740/20000 train_loss:2.4489 train_time:5960149ms step_avg:3425.37ms router_forward:1 router_objective:-0.2224 router_entropy:0.9963
+step:1750/20000 router_probe window_steps:10 avg_depth:5.717 router_objective:-0.2248 router_entropy:1.0081
+step:1750/20000 router_matrix
+step:1750/20000 train_loss:2.4100 train_time:5995007ms step_avg:3425.72ms router_forward:1 router_objective:-0.1772 router_entropy:1.0189
+step:1760/20000 router_probe window_steps:10 avg_depth:5.843 router_objective:-0.2179 router_entropy:1.0123
+step:1760/20000 router_matrix
+step:1760/20000 train_loss:2.3984 train_time:6030252ms step_avg:3426.28ms router_forward:1 router_objective:-0.2072 router_entropy:0.9935
+step:1770/20000 router_probe window_steps:10 avg_depth:5.606 router_objective:-0.2086 router_entropy:0.9607
+step:1770/20000 router_matrix
+step:1770/20000 train_loss:2.4894 train_time:6064049ms step_avg:3426.02ms router_forward:1 router_objective:-0.2407 router_entropy:0.9636
+step:1780/20000 router_probe window_steps:10 avg_depth:5.748 router_objective:-0.2678 router_entropy:1.0054
+step:1780/20000 router_matrix
+step:1780/20000 train_loss:2.4396 train_time:6098651ms step_avg:3426.21ms router_forward:1 router_objective:-0.2179 router_entropy:1.0253
+step:1790/20000 router_probe window_steps:10 avg_depth:5.571 router_objective:-0.2100 router_entropy:1.0150
+step:1790/20000 router_matrix
+step:1790/20000 train_loss:2.4752 train_time:6134559ms step_avg:3427.13ms router_forward:1 router_objective:-0.1573 router_entropy:1.0177
+step:1800/20000 router_probe window_steps:10 avg_depth:5.449 router_objective:-0.2324 router_entropy:1.0034
+step:1800/20000 router_matrix
+step:1800/20000 train_loss:2.4245 train_time:6167607ms step_avg:3426.45ms router_forward:1 router_objective:-0.2379 router_entropy:0.9835
+step:1810/20000 router_probe window_steps:10 avg_depth:5.601 router_objective:-0.2183 router_entropy:1.0102
+step:1810/20000 router_matrix
+step:1810/20000 train_loss:2.3664 train_time:6201513ms step_avg:3426.25ms router_forward:1 router_objective:-0.1922 router_entropy:1.0189
+step:1820/20000 router_probe window_steps:10 avg_depth:5.593 router_objective:-0.2233 router_entropy:1.0145
+step:1820/20000 router_matrix
+step:1820/20000 train_loss:2.3735 train_time:6235334ms step_avg:3426.01ms router_forward:1 router_objective:-0.2265 router_entropy:1.0153
+step:1830/20000 router_probe window_steps:10 avg_depth:5.434 router_objective:-0.2417 router_entropy:1.0027
+step:1830/20000 router_matrix
+step:1830/20000 train_loss:2.4042 train_time:6268372ms step_avg:3425.34ms router_forward:1 router_objective:-0.2037 router_entropy:1.0122
+step:1840/20000 router_probe window_steps:10 avg_depth:5.754 router_objective:-0.2416 router_entropy:1.0176
+step:1840/20000 router_matrix
+step:1840/20000 train_loss:2.3714 train_time:6303435ms step_avg:3425.78ms router_forward:1 router_objective:-0.1698 router_entropy:1.0210
+step:1850/20000 router_probe window_steps:10 avg_depth:5.601 router_objective:-0.2510 router_entropy:1.0149
+step:1850/20000 router_matrix
+step:1850/20000 train_loss:2.3519 train_time:6337215ms step_avg:3425.52ms router_forward:1 router_objective:-0.2038 router_entropy:1.0084
+step:1860/20000 router_probe window_steps:10 avg_depth:5.724 router_objective:-0.2408 router_entropy:1.0123
+step:1860/20000 router_matrix
+step:1860/20000 train_loss:2.3804 train_time:6371491ms step_avg:3425.53ms router_forward:1 router_objective:-0.2811 router_entropy:1.0273
+step:1870/20000 router_probe window_steps:10 avg_depth:5.732 router_objective:-0.2347 router_entropy:1.0200
+step:1870/20000 router_matrix
+step:1870/20000 train_loss:2.3853 train_time:6405941ms step_avg:3425.64ms router_forward:1 router_objective:-0.2916 router_entropy:1.0161
+step:1880/20000 router_probe window_steps:10 avg_depth:5.587 router_objective:-0.2535 router_entropy:1.0164
+step:1880/20000 router_matrix
+step:1880/20000 train_loss:2.3187 train_time:6439614ms step_avg:3425.33ms router_forward:1 router_objective:-0.2233 router_entropy:1.0127
+step:1890/20000 router_probe window_steps:10 avg_depth:5.485 router_objective:-0.2189 router_entropy:1.0108
+step:1890/20000 router_matrix
+step:1890/20000 train_loss:2.3898 train_time:6472684ms step_avg:3424.70ms router_forward:1 router_objective:-0.2908 router_entropy:1.0339
+step:1900/20000 router_probe window_steps:10 avg_depth:5.773 router_objective:-0.2569 router_entropy:1.0078
+step:1900/20000 router_matrix
+step:1900/20000 train_loss:2.3650 train_time:6507283ms step_avg:3424.89ms router_forward:1 router_objective:-0.2145 router_entropy:0.9811
+step:1910/20000 router_probe window_steps:10 avg_depth:5.417 router_objective:-0.2344 router_entropy:1.0025
+step:1910/20000 router_matrix
+step:1910/20000 train_loss:2.3362 train_time:6541735ms step_avg:3424.99ms router_forward:1 router_objective:-0.2370 router_entropy:1.0193
+step:1920/20000 router_probe window_steps:10 avg_depth:5.676 router_objective:-0.2560 router_entropy:1.0189
+step:1920/20000 router_matrix
+step:1920/20000 train_loss:2.4219 train_time:6575801ms step_avg:3424.90ms router_forward:1 router_objective:-0.2234 router_entropy:1.0175
+step:1930/20000 router_probe window_steps:10 avg_depth:5.487 router_objective:-0.2212 router_entropy:1.0103
+step:1930/20000 router_matrix
+step:1930/20000 train_loss:2.2988 train_time:6608887ms step_avg:3424.29ms router_forward:1 router_objective:-0.2676 router_entropy:1.0119
+step:1940/20000 router_probe window_steps:10 avg_depth:5.735 router_objective:-0.2391 router_entropy:1.0052
+step:1940/20000 router_matrix
+step:1940/20000 train_loss:2.3720 train_time:6643294ms step_avg:3424.38ms router_forward:1 router_objective:-0.2832 router_entropy:0.9742
+step:1950/20000 router_probe window_steps:10 avg_depth:5.493 router_objective:-0.2279 router_entropy:0.9955
+step:1950/20000 router_matrix
+step:1950/20000 train_loss:2.3455 train_time:6676998ms step_avg:3424.10ms router_forward:1 router_objective:-0.1700 router_entropy:1.0047
+step:1960/20000 router_probe window_steps:10 avg_depth:5.633 router_objective:-0.1961 router_entropy:1.0147
+step:1960/20000 router_matrix
+step:1960/20000 train_loss:2.3437 train_time:6710751ms step_avg:3423.85ms router_forward:1 router_objective:-0.2480 router_entropy:1.0176
+step:1970/20000 router_probe window_steps:10 avg_depth:5.930 router_objective:-0.2133 router_entropy:1.0069
+step:1970/20000 router_matrix
+step:1970/20000 train_loss:2.3560 train_time:6746108ms step_avg:3424.42ms router_forward:1 router_objective:-0.1699 router_entropy:1.0137
+step:1980/20000 router_probe window_steps:10 avg_depth:5.867 router_objective:-0.2546 router_entropy:1.0151
+step:1980/20000 router_matrix
+step:1980/20000 train_loss:2.3545 train_time:6781233ms step_avg:3424.86ms router_forward:1 router_objective:-0.2318 router_entropy:1.0087
+step:1990/20000 router_probe window_steps:10 avg_depth:5.453 router_objective:-0.2519 router_entropy:0.9974
+step:1990/20000 router_matrix
+step:1990/20000 train_loss:2.4187 train_time:6814205ms step_avg:3424.22ms router_forward:1 router_objective:-0.2265 router_entropy:0.9970
+step:2000/20000 router_probe window_steps:10 avg_depth:5.638 router_objective:-0.2514 router_entropy:1.0175
+step:2000/20000 router_matrix
+step:2000/20000 train_loss:2.3092 train_time:6848181ms step_avg:3424.09ms router_forward:1 router_objective:-0.3743 router_entropy:1.0236
+step:2010/20000 router_probe window_steps:10 avg_depth:5.561 router_objective:-0.2360 router_entropy:1.0040
+step:2010/20000 router_matrix
+step:2010/20000 train_loss:2.3812 train_time:6881637ms step_avg:3423.70ms router_forward:1 router_objective:-0.1632 router_entropy:1.0083
+step:2020/20000 router_probe window_steps:10 avg_depth:5.366 router_objective:-0.2412 router_entropy:1.0001
+step:2020/20000 router_matrix
+step:2020/20000 train_loss:2.4016 train_time:6914049ms step_avg:3422.80ms router_forward:1 router_objective:-0.1620 router_entropy:0.9959
+step:2030/20000 router_probe window_steps:10 avg_depth:5.667 router_objective:-0.2437 router_entropy:1.0014
+step:2030/20000 router_matrix
+step:2030/20000 train_loss:2.3855 train_time:6948222ms step_avg:3422.77ms router_forward:1 router_objective:-0.2647 router_entropy:0.9999
+step:2040/20000 router_probe window_steps:10 avg_depth:5.390 router_objective:-0.2148 router_entropy:1.0032
+step:2040/20000 router_matrix
+step:2040/20000 train_loss:2.4327 train_time:6982387ms step_avg:3422.74ms router_forward:1 router_objective:-0.2118 router_entropy:1.0086
+step:2050/20000 router_probe window_steps:10 avg_depth:5.428 router_objective:-0.1525 router_entropy:0.9922
+step:2050/20000 router_matrix
+step:2050/20000 train_loss:2.3860 train_time:7015508ms step_avg:3422.20ms router_forward:1 router_objective:-0.1722 router_entropy:0.9801
+step:2060/20000 router_probe window_steps:10 avg_depth:5.773 router_objective:-0.2358 router_entropy:1.0145
+step:2060/20000 router_matrix
+step:2060/20000 train_loss:2.3901 train_time:7050199ms step_avg:3422.43ms router_forward:1 router_objective:-0.2328 router_entropy:1.0186
+step:2070/20000 router_probe window_steps:10 avg_depth:6.312 router_objective:-0.1958 router_entropy:1.0080
+step:2070/20000 router_matrix
+step:2070/20000 train_loss:2.4817 train_time:7087323ms step_avg:3423.83ms router_forward:1 router_objective:-0.3029 router_entropy:1.0098
+step:2080/20000 router_probe window_steps:10 avg_depth:6.480 router_objective:-0.1977 router_entropy:0.9726
+step:2080/20000 router_matrix
+step:2080/20000 train_loss:2.4067 train_time:7125257ms step_avg:3425.60ms router_forward:1 router_objective:-0.1995 router_entropy:0.9856
+step:2090/20000 router_probe window_steps:10 avg_depth:5.800 router_objective:-0.2536 router_entropy:1.0034
+step:2090/20000 router_matrix
+step:2090/20000 train_loss:2.4912 train_time:7160142ms step_avg:3425.91ms router_forward:1 router_objective:-0.2911 router_entropy:1.0141
+step:2100/20000 router_probe window_steps:10 avg_depth:5.745 router_objective:-0.2498 router_entropy:1.0047
+step:2100/20000 router_matrix
+step:2100/20000 train_loss:2.3240 train_time:7194761ms step_avg:3426.08ms router_forward:1 router_objective:-0.2215 router_entropy:1.0071
+step:2110/20000 router_probe window_steps:10 avg_depth:5.549 router_objective:-0.2594 router_entropy:1.0054
+step:2110/20000 router_matrix
+step:2110/20000 train_loss:2.4291 train_time:7228604ms step_avg:3425.88ms router_forward:1 router_objective:-0.3076 router_entropy:1.0190
+step:2120/20000 router_probe window_steps:10 avg_depth:5.875 router_objective:-0.2629 router_entropy:1.0176
+step:2120/20000 router_matrix
+step:2120/20000 train_loss:2.3658 train_time:7263629ms step_avg:3426.24ms router_forward:1 router_objective:-0.2631 router_entropy:1.0125
+step:2130/20000 router_probe window_steps:10 avg_depth:5.517 router_objective:-0.2309 router_entropy:1.0094
+step:2130/20000 router_matrix
+step:2130/20000 train_loss:2.4112 train_time:7297175ms step_avg:3425.90ms router_forward:1 router_objective:-0.2049 router_entropy:1.0088
+step:2140/20000 router_probe window_steps:10 avg_depth:5.593 router_objective:-0.2218 router_entropy:1.0097
+step:2140/20000 router_matrix
+step:2140/20000 train_loss:2.3490 train_time:7331201ms step_avg:3425.79ms router_forward:1 router_objective:-0.2981 router_entropy:1.0163
+step:2150/20000 router_probe window_steps:10 avg_depth:5.565 router_objective:-0.2314 router_entropy:1.0054
+step:2150/20000 router_matrix
+step:2150/20000 train_loss:2.3755 train_time:7365228ms step_avg:3425.69ms router_forward:1 router_objective:-0.1600 router_entropy:0.9770
+step:2160/20000 router_probe window_steps:10 avg_depth:5.547 router_objective:-0.2722 router_entropy:1.0032
+step:2160/20000 router_matrix
+step:2160/20000 train_loss:2.3880 train_time:7398834ms step_avg:3425.39ms router_forward:1 router_objective:-0.2854 router_entropy:1.0108
+step:2170/20000 router_probe window_steps:10 avg_depth:5.561 router_objective:-0.2344 router_entropy:1.0115
+step:2170/20000 router_matrix
+step:2170/20000 train_loss:2.2498 train_time:7435222ms step_avg:3426.37ms router_forward:1 router_objective:-0.2545 router_entropy:1.0029
+step:2180/20000 router_probe window_steps:10 avg_depth:5.390 router_objective:-0.3009 router_entropy:0.9626
+step:2180/20000 router_matrix
+step:2180/20000 train_loss:2.3701 train_time:7468123ms step_avg:3425.74ms router_forward:1 router_objective:-0.1988 router_entropy:0.9693
+step:2190/20000 router_probe window_steps:10 avg_depth:5.643 router_objective:-0.2543 router_entropy:1.0035
+step:2190/20000 router_matrix
+step:2190/20000 train_loss:2.2622 train_time:7502479ms step_avg:3425.79ms router_forward:1 router_objective:-0.3019 router_entropy:1.0097
+step:2200/20000 router_probe window_steps:10 avg_depth:5.628 router_objective:-0.2449 router_entropy:1.0117
+step:2200/20000 router_matrix
+step:2200/20000 train_loss:2.3910 train_time:7537637ms step_avg:3426.20ms router_forward:1 router_objective:-0.2021 router_entropy:1.0093
+step:2210/20000 router_probe window_steps:10 avg_depth:5.669 router_objective:-0.2290 router_entropy:1.0141
+step:2210/20000 router_matrix
+step:2210/20000 train_loss:2.3396 train_time:7572918ms step_avg:3426.66ms router_forward:1 router_objective:-0.1557 router_entropy:1.0122
+step:2220/20000 router_probe window_steps:10 avg_depth:5.702 router_objective:-0.2135 router_entropy:0.9950
+step:2220/20000 router_matrix
+step:2220/20000 train_loss:2.3781 train_time:7607713ms step_avg:3426.90ms router_forward:1 router_objective:-0.1988 router_entropy:0.9937
+step:2230/20000 router_probe window_steps:10 avg_depth:5.727 router_objective:-0.2528 router_entropy:1.0078
+step:2230/20000 router_matrix
+step:2230/20000 train_loss:2.3470 train_time:7642217ms step_avg:3427.00ms router_forward:1 router_objective:-0.2776 router_entropy:1.0203
+step:2240/20000 router_probe window_steps:10 avg_depth:5.482 router_objective:-0.2507 router_entropy:1.0043
+step:2240/20000 router_matrix
+step:2240/20000 train_loss:2.3255 train_time:7675328ms step_avg:3426.49ms router_forward:1 router_objective:-0.2222 router_entropy:0.9861
+step:2250/20000 router_probe window_steps:10 avg_depth:5.518 router_objective:-0.2444 router_entropy:0.9977
+step:2250/20000 router_matrix
+step:2250/20000 train_loss:2.3625 train_time:7708643ms step_avg:3426.06ms router_forward:1 router_objective:-0.2306 router_entropy:1.0155
+step:2260/20000 router_probe window_steps:10 avg_depth:5.505 router_objective:-0.2349 router_entropy:1.0107
+step:2260/20000 router_matrix
+step:2260/20000 train_loss:2.3678 train_time:7742091ms step_avg:3425.70ms router_forward:1 router_objective:-0.2593 router_entropy:1.0082
+step:2270/20000 router_probe window_steps:10 avg_depth:5.317 router_objective:-0.2373 router_entropy:0.9727
+step:2270/20000 router_matrix
+step:2270/20000 train_loss:2.3439 train_time:7774422ms step_avg:3424.86ms router_forward:1 router_objective:-0.2291 router_entropy:0.9266
+step:2280/20000 router_probe window_steps:10 avg_depth:5.689 router_objective:-0.2151 router_entropy:0.9486
+step:2280/20000 router_matrix
+step:2280/20000 train_loss:2.3056 train_time:7808584ms step_avg:3424.82ms router_forward:1 router_objective:-0.2759 router_entropy:0.9739
+step:2290/20000 router_probe window_steps:10 avg_depth:5.803 router_objective:-0.2443 router_entropy:1.0067
+step:2290/20000 router_matrix
+step:2290/20000 train_loss:2.4337 train_time:7844344ms step_avg:3425.48ms router_forward:1 router_objective:-0.2544 router_entropy:1.0214
+step:2300/20000 router_probe window_steps:10 avg_depth:5.830 router_objective:-0.2425 router_entropy:0.9942
+step:2300/20000 router_matrix
+step:2300/20000 train_loss:2.3298 train_time:7879007ms step_avg:3425.66ms router_forward:1 router_objective:-0.3074 router_entropy:0.9939
+step:2310/20000 router_probe window_steps:10 avg_depth:5.448 router_objective:-0.2609 router_entropy:1.0000
+step:2310/20000 router_matrix
+step:2310/20000 train_loss:2.4389 train_time:7911835ms step_avg:3425.04ms router_forward:1 router_objective:-0.2843 router_entropy:1.0068
+step:2320/20000 router_probe window_steps:10 avg_depth:5.435 router_objective:-0.2566 router_entropy:1.0090
+step:2320/20000 router_matrix
+step:2320/20000 train_loss:2.3347 train_time:7944712ms step_avg:3424.44ms router_forward:1 router_objective:-0.1753 router_entropy:1.0188
+step:2330/20000 router_probe window_steps:10 avg_depth:5.546 router_objective:-0.2614 router_entropy:1.0020
+step:2330/20000 router_matrix
+step:2330/20000 train_loss:2.3816 train_time:7978124ms step_avg:3424.09ms router_forward:1 router_objective:-0.3575 router_entropy:0.9751
+step:2340/20000 router_probe window_steps:10 avg_depth:5.403 router_objective:-0.2493 router_entropy:0.9708
+step:2340/20000 router_matrix
+step:2340/20000 train_loss:2.3616 train_time:8010712ms step_avg:3423.38ms router_forward:1 router_objective:-0.2486 router_entropy:0.9846
+step:2350/20000 router_probe window_steps:10 avg_depth:5.493 router_objective:-0.2223 router_entropy:0.9931
+step:2350/20000 router_matrix
+step:2350/20000 train_loss:2.4462 train_time:8044120ms step_avg:3423.03ms router_forward:1 router_objective:-0.2608 router_entropy:1.0020
+step:2360/20000 router_probe window_steps:10 avg_depth:5.598 router_objective:-0.2011 router_entropy:0.9855
+step:2360/20000 router_matrix
+step:2360/20000 train_loss:2.3993 train_time:8077743ms step_avg:3422.77ms router_forward:1 router_objective:-0.1289 router_entropy:0.9848
+step:2370/20000 router_probe window_steps:10 avg_depth:5.707 router_objective:-0.2474 router_entropy:1.0072
+step:2370/20000 router_matrix
+step:2370/20000 train_loss:2.3740 train_time:8112126ms step_avg:3422.84ms router_forward:1 router_objective:-0.2228 router_entropy:1.0000
+step:2380/20000 router_probe window_steps:10 avg_depth:7.746 router_objective:-0.1952 router_entropy:0.9863
+step:2380/20000 router_matrix
+step:2380/20000 train_loss:2.5260 train_time:8156214ms step_avg:3426.98ms router_forward:1 router_objective:-0.2556 router_entropy:0.9820
+step:2390/20000 router_probe window_steps:10 avg_depth:7.988 router_objective:-0.1882 router_entropy:0.9730
+step:2390/20000 router_matrix
+step:2390/20000 train_loss:2.4547 train_time:8201448ms step_avg:3431.57ms router_forward:1 router_objective:-0.1909 router_entropy:0.9877
+step:2400/20000 router_probe window_steps:10 avg_depth:8.706 router_objective:-0.1624 router_entropy:0.9673
+step:2400/20000 router_matrix
+step:2400/20000 train_loss:2.4918 train_time:8250306ms step_avg:3437.63ms router_forward:1 router_objective:-0.2060 router_entropy:0.9278
+step:2410/20000 router_probe window_steps:10 avg_depth:7.142 router_objective:-0.1842 router_entropy:0.9333
+step:2410/20000 router_matrix
+step:2410/20000 train_loss:2.5271 train_time:8292041ms step_avg:3440.68ms router_forward:1 router_objective:-0.1305 router_entropy:0.9367
+step:2420/20000 router_probe window_steps:10 avg_depth:7.341 router_objective:-0.2092 router_entropy:0.9691
+step:2420/20000 router_matrix
+step:2420/20000 train_loss:2.5236 train_time:8336975ms step_avg:3445.03ms router_forward:1 router_objective:-0.2893 router_entropy:0.9713
+step:2430/20000 router_probe window_steps:10 avg_depth:7.985 router_objective:-0.1779 router_entropy:0.8655
+step:2430/20000 router_matrix
+step:2430/20000 train_loss:2.5897 train_time:8382113ms step_avg:3449.43ms router_forward:1 router_objective:-0.2270 router_entropy:0.7776
+step:2440/20000 router_probe window_steps:10 avg_depth:10.214 router_objective:-0.1733 router_entropy:0.8679
+step:2440/20000 router_matrix
+step:2440/20000 train_loss:2.5757 train_time:8438284ms step_avg:3458.31ms router_forward:1 router_objective:-0.1300 router_entropy:0.9664
+step:2450/20000 router_probe window_steps:10 avg_depth:7.885 router_objective:-0.2281 router_entropy:0.9375
+step:2450/20000 router_matrix
+step:2450/20000 train_loss:2.5515 train_time:8483574ms step_avg:3462.68ms router_forward:1 router_objective:-0.2564 router_entropy:0.9517
+step:2460/20000 router_probe window_steps:10 avg_depth:6.455 router_objective:-0.2067 router_entropy:0.9464
+step:2460/20000 router_matrix
+step:2460/20000 train_loss:2.6109 train_time:8521828ms step_avg:3464.16ms router_forward:1 router_objective:-0.1784 router_entropy:0.9138
+step:2470/20000 router_probe window_steps:10 avg_depth:6.396 router_objective:-0.1438 router_entropy:0.8251
+step:2470/20000 router_matrix
+step:2470/20000 train_loss:2.6321 train_time:8559963ms step_avg:3465.57ms router_forward:1 router_objective:-0.1610 router_entropy:0.7642
+step:2480/20000 router_probe window_steps:10 avg_depth:7.138 router_objective:-0.2193 router_entropy:0.8424
+step:2480/20000 router_matrix
+step:2480/20000 train_loss:2.5630 train_time:8601350ms step_avg:3468.29ms router_forward:1 router_objective:-0.2604 router_entropy:0.8305
+step:2490/20000 router_probe window_steps:10 avg_depth:5.760 router_objective:-0.2357 router_entropy:0.9267
+step:2490/20000 router_matrix
+step:2490/20000 train_loss:2.5999 train_time:8636436ms step_avg:3468.45ms router_forward:1 router_objective:-0.2562 router_entropy:0.9871
+step:2500/20000 router_probe window_steps:10 avg_depth:5.455 router_objective:-0.2651 router_entropy:0.9893
+step:2500/20000 router_matrix
+step:2500/20000 train_loss:2.5092 train_time:8669651ms step_avg:3467.86ms router_forward:1 router_objective:-0.2363 router_entropy:0.9788
+step:2510/20000 router_probe window_steps:10 avg_depth:5.348 router_objective:-0.2529 router_entropy:1.0002
+step:2510/20000 router_matrix
+step:2510/20000 train_loss:2.4968 train_time:8702556ms step_avg:3467.15ms router_forward:1 router_objective:-0.2406 router_entropy:1.0182
+step:2520/20000 router_probe window_steps:10 avg_depth:5.452 router_objective:-0.2548 router_entropy:0.9985
+step:2520/20000 router_matrix
+step:2520/20000 train_loss:2.4610 train_time:8736173ms step_avg:3466.74ms router_forward:1 router_objective:-0.2730 router_entropy:0.9982
+step:2530/20000 router_probe window_steps:10 avg_depth:5.411 router_objective:-0.2431 router_entropy:1.0051
+step:2530/20000 router_matrix
+step:2530/20000 train_loss:2.4434 train_time:8769259ms step_avg:3466.11ms router_forward:1 router_objective:-0.1733 router_entropy:0.9981
+step:2540/20000 router_probe window_steps:10 avg_depth:5.426 router_objective:-0.2082 router_entropy:0.9965
+step:2540/20000 router_matrix
+step:2540/20000 train_loss:2.4486 train_time:8802192ms step_avg:3465.43ms router_forward:1 router_objective:-0.2265 router_entropy:0.9771
+step:2550/20000 router_probe window_steps:10 avg_depth:5.475 router_objective:-0.2471 router_entropy:0.9855
+step:2550/20000 router_matrix
+step:2550/20000 train_loss:2.4844 train_time:8840318ms step_avg:3466.79ms router_forward:1 router_objective:-0.1016 router_entropy:0.9799
+step:2560/20000 router_probe window_steps:10 avg_depth:5.802 router_objective:-0.2440 router_entropy:1.0049
+step:2560/20000 router_matrix
+step:2560/20000 train_loss:2.4246 train_time:8875081ms step_avg:3466.83ms router_forward:1 router_objective:-0.2973 router_entropy:1.0017
+step:2570/20000 router_probe window_steps:10 avg_depth:6.096 router_objective:-0.2325 router_entropy:1.0064
+step:2570/20000 router_matrix
+step:2570/20000 train_loss:2.4472 train_time:8911392ms step_avg:3467.47ms router_forward:1 router_objective:-0.2976 router_entropy:1.0029
+step:2580/20000 router_probe window_steps:10 avg_depth:5.424 router_objective:-0.2145 router_entropy:0.9911
+step:2580/20000 router_matrix
+step:2580/20000 train_loss:2.4856 train_time:8945048ms step_avg:3467.07ms router_forward:1 router_objective:-0.2599 router_entropy:0.9863
+step:2590/20000 router_probe window_steps:10 avg_depth:5.525 router_objective:-0.2501 router_entropy:1.0054
+step:2590/20000 router_matrix
+step:2590/20000 train_loss:2.3836 train_time:8978821ms step_avg:3466.73ms router_forward:1 router_objective:-0.2061 router_entropy:1.0109
+step:2600/20000 router_probe window_steps:10 avg_depth:5.322 router_objective:-0.2460 router_entropy:0.9988
+step:2600/20000 router_matrix
+step:2600/20000 train_loss:2.4023 train_time:9011633ms step_avg:3466.01ms router_forward:1 router_objective:-0.2759 router_entropy:0.9950
+step:2610/20000 router_probe window_steps:10 avg_depth:5.637 router_objective:-0.2547 router_entropy:1.0053
+step:2610/20000 router_matrix
+step:2610/20000 train_loss:2.4717 train_time:9045809ms step_avg:3465.83ms router_forward:1 router_objective:-0.2967 router_entropy:1.0127
+step:2620/20000 router_probe window_steps:10 avg_depth:5.553 router_objective:-0.2343 router_entropy:0.9913
+step:2620/20000 router_matrix
+step:2620/20000 train_loss:2.3635 train_time:9079342ms step_avg:3465.40ms router_forward:1 router_objective:-0.2690 router_entropy:0.9748
+step:2630/20000 router_probe window_steps:10 avg_depth:5.411 router_objective:-0.2223 router_entropy:1.0037
+step:2630/20000 router_matrix
+step:2630/20000 train_loss:2.3777 train_time:9112347ms step_avg:3464.77ms router_forward:1 router_objective:-0.2686 router_entropy:1.0038
+step:2640/20000 router_probe window_steps:10 avg_depth:5.278 router_objective:-0.2403 router_entropy:0.9885
+step:2640/20000 router_matrix
+step:2640/20000 train_loss:2.3513 train_time:9144590ms step_avg:3463.86ms router_forward:1 router_objective:-0.1199 router_entropy:0.9858
+step:2650/20000 router_probe window_steps:10 avg_depth:5.318 router_objective:-0.2658 router_entropy:0.9894
+step:2650/20000 router_matrix
+step:2650/20000 train_loss:2.3350 train_time:9176979ms step_avg:3463.01ms router_forward:1 router_objective:-0.2443 router_entropy:0.9984
+step:2660/20000 router_probe window_steps:10 avg_depth:5.327 router_objective:-0.2211 router_entropy:0.9816
+step:2660/20000 router_matrix
+step:2660/20000 train_loss:2.3784 train_time:9209585ms step_avg:3462.25ms router_forward:1 router_objective:-0.2269 router_entropy:0.9611
+step:2670/20000 router_probe window_steps:10 avg_depth:5.910 router_objective:-0.2099 router_entropy:0.9750
+step:2670/20000 router_matrix
+step:2670/20000 train_loss:2.3482 train_time:9244857ms step_avg:3462.49ms router_forward:1 router_objective:-0.2135 router_entropy:0.9642
+step:2680/20000 router_probe window_steps:10 avg_depth:6.448 router_objective:-0.2404 router_entropy:0.9943
+step:2680/20000 router_matrix
+step:2680/20000 train_loss:2.4118 train_time:9285618ms step_avg:3464.78ms router_forward:1 router_objective:-0.3025 router_entropy:1.0049
+step:2690/20000 router_probe window_steps:10 avg_depth:4.952 router_objective:-0.2214 router_entropy:0.9517
+step:2690/20000 router_matrix
+step:2690/20000 train_loss:2.3985 train_time:9316224ms step_avg:3463.28ms router_forward:1 router_objective:-0.1696 router_entropy:0.9625
+step:2700/20000 router_probe window_steps:10 avg_depth:5.395 router_objective:-0.1741 router_entropy:0.9671
+step:2700/20000 router_matrix
+step:2700/20000 train_loss:2.4221 train_time:9349361ms step_avg:3462.73ms router_forward:1 router_objective:-0.2860 router_entropy:1.0129
+step:2710/20000 router_probe window_steps:10 avg_depth:5.620 router_objective:-0.2876 router_entropy:0.9814
+step:2710/20000 router_matrix
+step:2710/20000 train_loss:2.4364 train_time:9383141ms step_avg:3462.41ms router_forward:1 router_objective:-0.2541 router_entropy:0.9597
+step:2720/20000 router_probe window_steps:10 avg_depth:6.004 router_objective:-0.2466 router_entropy:0.9323
+step:2720/20000 router_matrix
+step:2720/20000 train_loss:2.3703 train_time:9418804ms step_avg:3462.80ms router_forward:1 router_objective:-0.2485 router_entropy:0.9462
+step:2730/20000 router_probe window_steps:10 avg_depth:5.485 router_objective:-0.2424 router_entropy:0.9414
+step:2730/20000 router_matrix
+step:2730/20000 train_loss:2.4101 train_time:9452090ms step_avg:3462.30ms router_forward:1 router_objective:-0.2550 router_entropy:0.9641
+step:2740/20000 router_probe window_steps:10 avg_depth:7.467 router_objective:-0.1852 router_entropy:0.8712
+step:2740/20000 router_matrix
+step:2740/20000 train_loss:2.4584 train_time:9494671ms step_avg:3465.21ms router_forward:1 router_objective:-0.0885 router_entropy:0.6175
+step:2750/20000 router_probe window_steps:10 avg_depth:11.871 router_objective:-0.2435 router_entropy:0.7504
+step:2750/20000 router_matrix
+step:2750/20000 train_loss:2.4700 train_time:9557858ms step_avg:3475.58ms router_forward:1 router_objective:-0.1688 router_entropy:0.9183
+step:2760/20000 router_probe window_steps:10 avg_depth:11.914 router_objective:-0.1813 router_entropy:0.9161
+step:2760/20000 router_matrix
+step:2760/20000 train_loss:2.4534 train_time:9621175ms step_avg:3485.93ms router_forward:1 router_objective:-0.2043 router_entropy:0.9299
+step:2770/20000 router_probe window_steps:10 avg_depth:11.908 router_objective:-0.1932 router_entropy:0.9539
+step:2770/20000 router_matrix
+step:2770/20000 train_loss:2.3891 train_time:9684789ms step_avg:3496.31ms router_forward:1 router_objective:-0.1763 router_entropy:0.9177
+step:2780/20000 router_probe window_steps:10 avg_depth:11.745 router_objective:-0.1926 router_entropy:0.9724
+step:2780/20000 router_matrix
+step:2780/20000 train_loss:2.4467 train_time:9747463ms step_avg:3506.28ms router_forward:1 router_objective:-0.2090 router_entropy:0.9588
+step:2790/20000 router_probe window_steps:10 avg_depth:11.993 router_objective:-0.1837 router_entropy:0.9595
+step:2790/20000 router_matrix
+step:2790/20000 train_loss:2.3446 train_time:9811154ms step_avg:3516.54ms router_forward:1 router_objective:-0.1805 router_entropy:0.9728
+step:2800/20000 router_probe window_steps:10 avg_depth:11.995 router_objective:-0.1913 router_entropy:0.9878
+step:2800/20000 router_matrix
+step:2800/20000 train_loss:2.4255 train_time:9876403ms step_avg:3527.29ms router_forward:1 router_objective:-0.2020 router_entropy:0.9951
+step:2810/20000 router_probe window_steps:10 avg_depth:11.973 router_objective:-0.2023 router_entropy:0.9895
+step:2810/20000 router_matrix
+step:2810/20000 train_loss:2.4750 train_time:9940067ms step_avg:3537.39ms router_forward:1 router_objective:-0.2090 router_entropy:0.9759
+step:2820/20000 router_probe window_steps:10 avg_depth:11.893 router_objective:-0.2085 router_entropy:0.9921
+step:2820/20000 router_matrix
+step:2820/20000 train_loss:2.3887 train_time:10003298ms step_avg:3547.27ms router_forward:1 router_objective:-0.2210 router_entropy:0.9567
+step:2830/20000 router_probe window_steps:10 avg_depth:11.217 router_objective:-0.1944 router_entropy:0.9352
+step:2830/20000 router_matrix
+step:2830/20000 train_loss:2.3618 train_time:10063597ms step_avg:3556.04ms router_forward:1 router_objective:-0.2240 router_entropy:0.9510
+step:2840/20000 router_probe window_steps:10 avg_depth:8.485 router_objective:-0.2237 router_entropy:0.9982
+step:2840/20000 router_matrix
+step:2840/20000 train_loss:2.5485 train_time:10111113ms step_avg:3560.25ms router_forward:1 router_objective:-0.2691 router_entropy:1.0085
+step:2850/20000 router_probe window_steps:10 avg_depth:5.226 router_objective:-0.2339 router_entropy:0.9900
+step:2850/20000 router_matrix
+step:2850/20000 train_loss:2.3779 train_time:10143317ms step_avg:3559.06ms router_forward:1 router_objective:-0.2035 router_entropy:1.0026
+step:2860/20000 router_probe window_steps:10 avg_depth:5.321 router_objective:-0.2580 router_entropy:0.9985
+step:2860/20000 router_matrix
+step:2860/20000 train_loss:2.6266 train_time:10176152ms step_avg:3558.10ms router_forward:1 router_objective:-0.3137 router_entropy:1.0006
+step:2870/20000 router_probe window_steps:10 avg_depth:5.234 router_objective:-0.2264 router_entropy:0.9946
+step:2870/20000 router_matrix
+step:2870/20000 train_loss:2.4074 train_time:10208214ms step_avg:3556.87ms router_forward:1 router_objective:-0.2049 router_entropy:0.9720
+step:2880/20000 router_probe window_steps:10 avg_depth:6.032 router_objective:-0.2386 router_entropy:0.9800
+step:2880/20000 router_matrix
+step:2880/20000 train_loss:2.4183 train_time:10244070ms step_avg:3556.97ms router_forward:1 router_objective:-0.2785 router_entropy:1.0128
+step:2890/20000 router_probe window_steps:10 avg_depth:5.334 router_objective:-0.2234 router_entropy:0.9999
+step:2890/20000 router_matrix
+step:2890/20000 train_loss:2.3193 train_time:10276432ms step_avg:3555.86ms router_forward:1 router_objective:-0.2734 router_entropy:1.0016
+step:2900/20000 router_probe window_steps:10 avg_depth:5.428 router_objective:-0.2721 router_entropy:0.9985
+step:2900/20000 router_matrix
+step:2900/20000 train_loss:2.3980 train_time:10309251ms step_avg:3554.91ms router_forward:1 router_objective:-0.2742 router_entropy:0.9926
+step:2910/20000 router_probe window_steps:10 avg_depth:5.372 router_objective:-0.2463 router_entropy:0.9930
+step:2910/20000 router_matrix
+step:2910/20000 train_loss:2.2894 train_time:10341710ms step_avg:3553.85ms router_forward:1 router_objective:-0.2761 router_entropy:0.9948
+step:2920/20000 router_probe window_steps:10 avg_depth:5.180 router_objective:-0.2299 router_entropy:0.9892
+step:2920/20000 router_matrix
+step:2920/20000 train_loss:2.3269 train_time:10373481ms step_avg:3552.56ms router_forward:1 router_objective:-0.2289 router_entropy:0.9756
+step:2930/20000 router_probe window_steps:10 avg_depth:5.433 router_objective:-0.2479 router_entropy:0.9978
+step:2930/20000 router_matrix
+step:2930/20000 train_loss:2.2795 train_time:10407418ms step_avg:3552.02ms router_forward:1 router_objective:-0.3207 router_entropy:0.9991
+step:2940/20000 router_probe window_steps:10 avg_depth:5.411 router_objective:-0.2792 router_entropy:1.0028
+step:2940/20000 router_matrix
+step:2940/20000 train_loss:2.3596 train_time:10440003ms step_avg:3551.02ms router_forward:1 router_objective:-0.2997 router_entropy:1.0039
+step:2950/20000 router_probe window_steps:10 avg_depth:5.483 router_objective:-0.2500 router_entropy:0.9871
+step:2950/20000 router_matrix
+step:2950/20000 train_loss:2.3646 train_time:10473053ms step_avg:3550.19ms router_forward:1 router_objective:-0.2095 router_entropy:0.9744
+step:2960/20000 router_probe window_steps:10 avg_depth:5.174 router_objective:-0.2046 router_entropy:0.9557
+step:2960/20000 router_matrix
+step:2960/20000 train_loss:2.3357 train_time:10504525ms step_avg:3548.83ms router_forward:1 router_objective:-0.2455 router_entropy:0.9447
+step:2970/20000 router_probe window_steps:10 avg_depth:5.303 router_objective:-0.2364 router_entropy:0.9839
+step:2970/20000 router_matrix
+step:2970/20000 train_loss:2.3346 train_time:10536734ms step_avg:3547.72ms router_forward:1 router_objective:-0.2000 router_entropy:1.0025
+step:2980/20000 router_probe window_steps:10 avg_depth:5.445 router_objective:-0.2710 router_entropy:0.9981
+step:2980/20000 router_matrix
+step:2980/20000 train_loss:2.3139 train_time:10570116ms step_avg:3547.02ms router_forward:1 router_objective:-0.3009 router_entropy:0.9748
+step:2990/20000 router_probe window_steps:10 avg_depth:5.605 router_objective:-0.2171 router_entropy:0.9525
+step:2990/20000 router_matrix
+step:2990/20000 train_loss:2.3321 train_time:10604627ms step_avg:3546.70ms router_forward:1 router_objective:-0.2208 router_entropy:0.9533
+step:3000/20000 router_probe window_steps:10 avg_depth:5.427 router_objective:-0.2518 router_entropy:0.9940
+step:3000/20000 router_matrix
+step:3000/20000 train_loss:2.3358 train_time:10637699ms step_avg:3545.90ms router_forward:1 router_objective:-0.2677 router_entropy:1.0154
+step:3010/20000 router_probe window_steps:10 avg_depth:5.260 router_objective:-0.2346 router_entropy:0.9971
+step:3010/20000 router_matrix
+step:3010/20000 train_loss:2.3762 train_time:10670075ms step_avg:3544.88ms router_forward:1 router_objective:-0.1459 router_entropy:0.9923
+step:3020/20000 router_probe window_steps:10 avg_depth:5.486 router_objective:-0.2617 router_entropy:0.9932
+step:3020/20000 router_matrix
+step:3020/20000 train_loss:2.4024 train_time:10703613ms step_avg:3544.24ms router_forward:1 router_objective:-0.2656 router_entropy:1.0021
+step:3030/20000 router_probe window_steps:10 avg_depth:5.380 router_objective:-0.2616 router_entropy:0.9862
+step:3030/20000 router_matrix
+step:3030/20000 train_loss:2.3447 train_time:10736656ms step_avg:3543.45ms router_forward:1 router_objective:-0.2399 router_entropy:0.9805
+step:3040/20000 router_probe window_steps:10 avg_depth:5.533 router_objective:-0.2446 router_entropy:1.0004
+step:3040/20000 router_matrix
+step:3040/20000 train_loss:2.3067 train_time:10770017ms step_avg:3542.77ms router_forward:1 router_objective:-0.2590 router_entropy:1.0168
+step:3050/20000 router_probe window_steps:10 avg_depth:5.466 router_objective:-0.2424 router_entropy:0.9975
+step:3050/20000 router_matrix
+step:3050/20000 train_loss:2.3148 train_time:10802994ms step_avg:3541.97ms router_forward:1 router_objective:-0.2483 router_entropy:0.9915
+step:3060/20000 router_probe window_steps:10 avg_depth:5.698 router_objective:-0.1887 router_entropy:0.9407
+step:3060/20000 router_matrix
+step:3060/20000 train_loss:2.3297 train_time:10838118ms step_avg:3541.87ms router_forward:1 router_objective:-0.1256 router_entropy:0.9375
+step:3070/20000 router_probe window_steps:10 avg_depth:6.034 router_objective:-0.2366 router_entropy:0.9844
+step:3070/20000 router_matrix
+step:3070/20000 train_loss:2.4568 train_time:10873691ms step_avg:3541.92ms router_forward:1 router_objective:-0.2747 router_entropy:0.9845
+step:3080/20000 router_probe window_steps:10 avg_depth:5.431 router_objective:-0.2395 router_entropy:0.9874
+step:3080/20000 router_matrix
+step:3080/20000 train_loss:2.3698 train_time:10906513ms step_avg:3541.08ms router_forward:1 router_objective:-0.2283 router_entropy:0.9637
+step:3090/20000 router_probe window_steps:10 avg_depth:5.354 router_objective:-0.2531 router_entropy:0.9847
+step:3090/20000 router_matrix
+step:3090/20000 train_loss:2.3799 train_time:10939224ms step_avg:3540.20ms router_forward:1 router_objective:-0.2600 router_entropy:1.0201
+step:3100/20000 router_probe window_steps:10 avg_depth:5.530 router_objective:-0.2565 router_entropy:1.0019
+step:3100/20000 router_matrix
+step:3100/20000 train_loss:2.3183 train_time:10972813ms step_avg:3539.62ms router_forward:1 router_objective:-0.3270 router_entropy:0.9881
+step:3110/20000 router_probe window_steps:10 avg_depth:5.481 router_objective:-0.2314 router_entropy:1.0010
+step:3110/20000 router_matrix
+step:3110/20000 train_loss:2.3461 train_time:11006154ms step_avg:3538.96ms router_forward:1 router_objective:-0.2502 router_entropy:1.0027
+step:3120/20000 router_probe window_steps:10 avg_depth:5.215 router_objective:-0.2491 router_entropy:0.9729
+step:3120/20000 router_matrix
+step:3120/20000 train_loss:2.3245 train_time:11038302ms step_avg:3537.92ms router_forward:1 router_objective:-0.2161 router_entropy:0.9708
+step:3130/20000 router_probe window_steps:10 avg_depth:5.592 router_objective:-0.2567 router_entropy:0.9940
+step:3130/20000 router_matrix
+step:3130/20000 train_loss:2.2840 train_time:11072121ms step_avg:3537.42ms router_forward:1 router_objective:-0.2161 router_entropy:0.9833
+step:3140/20000 router_probe window_steps:10 avg_depth:5.294 router_objective:-0.2553 router_entropy:0.9789
+step:3140/20000 router_matrix
+step:3140/20000 train_loss:2.3406 train_time:11104840ms step_avg:3536.57ms router_forward:1 router_objective:-0.2926 router_entropy:0.9905
+step:3150/20000 router_probe window_steps:10 avg_depth:5.517 router_objective:-0.2292 router_entropy:0.9731
+step:3150/20000 router_matrix
+step:3150/20000 train_loss:2.2968 train_time:11138051ms step_avg:3535.89ms router_forward:1 router_objective:-0.1651 router_entropy:0.9788
+step:3160/20000 router_probe window_steps:10 avg_depth:5.971 router_objective:-0.2515 router_entropy:0.9670
+step:3160/20000 router_matrix
+step:3160/20000 train_loss:2.4398 train_time:11173562ms step_avg:3535.94ms router_forward:1 router_objective:-0.2214 router_entropy:0.9031
+step:3170/20000 router_probe window_steps:10 avg_depth:6.237 router_objective:-0.2190 router_entropy:0.9259
+step:3170/20000 router_matrix
+step:3170/20000 train_loss:2.3544 train_time:11210446ms step_avg:3536.42ms router_forward:1 router_objective:-0.3144 router_entropy:0.9516
+step:3180/20000 router_probe window_steps:10 avg_depth:5.058 router_objective:-0.2614 router_entropy:0.9743
+step:3180/20000 router_matrix
+step:3180/20000 train_loss:2.4048 train_time:11243469ms step_avg:3535.68ms router_forward:1 router_objective:-0.2391 router_entropy:0.9878
+step:3190/20000 router_probe window_steps:10 avg_depth:5.584 router_objective:-0.2270 router_entropy:0.9991
+step:3190/20000 router_matrix
+step:3190/20000 train_loss:2.3719 train_time:11277167ms step_avg:3535.16ms router_forward:1 router_objective:-0.2609 router_entropy:1.0028
+step:3200/20000 router_probe window_steps:10 avg_depth:5.331 router_objective:-0.2724 router_entropy:0.9941
+step:3200/20000 router_matrix
+step:3200/20000 train_loss:2.3659 train_time:11309710ms step_avg:3534.28ms router_forward:1 router_objective:-0.3081 router_entropy:0.9927
+step:3210/20000 router_probe window_steps:10 avg_depth:5.393 router_objective:-0.2643 router_entropy:0.9964
+step:3210/20000 router_matrix
+step:3210/20000 train_loss:2.4035 train_time:11343079ms step_avg:3533.67ms router_forward:1 router_objective:-0.2579 router_entropy:1.0019
+step:3220/20000 router_probe window_steps:10 avg_depth:5.399 router_objective:-0.2063 router_entropy:0.9927
+step:3220/20000 router_matrix
+step:3220/20000 train_loss:2.3686 train_time:11376286ms step_avg:3533.01ms router_forward:1 router_objective:-0.1633 router_entropy:0.9637
+step:3230/20000 router_probe window_steps:10 avg_depth:5.484 router_objective:-0.1380 router_entropy:0.9727
+step:3230/20000 router_matrix
+step:3230/20000 train_loss:2.4910 train_time:11409506ms step_avg:3532.35ms router_forward:1 router_objective:0.0497 router_entropy:0.9685
+step:3240/20000 router_probe window_steps:10 avg_depth:5.292 router_objective:-0.0779 router_entropy:0.9695
+step:3240/20000 router_matrix
+step:3240/20000 train_loss:2.3102 train_time:11442266ms step_avg:3531.56ms router_forward:1 router_objective:-0.1379 router_entropy:0.9739
+step:3250/20000 router_probe window_steps:10 avg_depth:5.405 router_objective:-0.1229 router_entropy:0.9676
+step:3250/20000 router_matrix
+step:3250/20000 train_loss:2.2736 train_time:11475361ms step_avg:3530.88ms router_forward:1 router_objective:-0.1262 router_entropy:0.9900
+step:3260/20000 router_probe window_steps:10 avg_depth:5.619 router_objective:-0.1094 router_entropy:0.9772
+step:3260/20000 router_matrix
+step:3260/20000 train_loss:2.3433 train_time:11509475ms step_avg:3530.51ms router_forward:1 router_objective:-0.1037 router_entropy:0.9671
+step:3270/20000 router_probe window_steps:10 avg_depth:5.164 router_objective:-0.1251 router_entropy:0.9574
+step:3270/20000 router_matrix
+step:3270/20000 train_loss:2.3184 train_time:11540810ms step_avg:3529.30ms router_forward:1 router_objective:-0.2071 router_entropy:0.9316
+step:3280/20000 router_probe window_steps:10 avg_depth:5.884 router_objective:-0.0527 router_entropy:0.8556
+step:3280/20000 router_matrix
+step:3280/20000 train_loss:2.4120 train_time:11575929ms step_avg:3529.25ms router_forward:1 router_objective:-0.1355 router_entropy:0.9206
+step:3290/20000 router_probe window_steps:10 avg_depth:5.274 router_objective:-0.2309 router_entropy:0.9538
+step:3290/20000 router_matrix
+step:3290/20000 train_loss:2.4062 train_time:11607993ms step_avg:3528.27ms router_forward:1 router_objective:-0.1714 router_entropy:0.9454
+step:3300/20000 router_probe window_steps:10 avg_depth:5.230 router_objective:-0.2712 router_entropy:0.9684
+step:3300/20000 router_matrix
+step:3300/20000 train_loss:2.4384 train_time:11640301ms step_avg:3527.36ms router_forward:1 router_objective:-0.2555 router_entropy:0.9645
+step:3310/20000 router_probe window_steps:10 avg_depth:5.177 router_objective:-0.2425 router_entropy:0.9417
+step:3310/20000 router_matrix
+step:3310/20000 train_loss:2.4384 train_time:11674822ms step_avg:3527.14ms router_forward:1 router_objective:-0.2790 router_entropy:0.9486
+step:3320/20000 router_probe window_steps:10 avg_depth:5.067 router_objective:-0.2709 router_entropy:0.9704
+step:3320/20000 router_matrix
+step:3320/20000 train_loss:2.3912 train_time:11705962ms step_avg:3525.89ms router_forward:1 router_objective:-0.4431 router_entropy:0.9990
+step:3330/20000 router_probe window_steps:10 avg_depth:5.206 router_objective:-0.2603 router_entropy:0.9671
+step:3330/20000 router_matrix
+step:3330/20000 train_loss:2.3894 train_time:11737636ms step_avg:3524.82ms router_forward:1 router_objective:-0.2544 router_entropy:0.9305
+step:3340/20000 router_probe window_steps:10 avg_depth:4.996 router_objective:-0.2178 router_entropy:0.9222
+step:3340/20000 router_matrix
+step:3340/20000 train_loss:2.3870 train_time:11768156ms step_avg:3523.40ms router_forward:1 router_objective:-0.2408 router_entropy:0.9515
+step:3350/20000 router_probe window_steps:10 avg_depth:5.231 router_objective:-0.2640 router_entropy:0.9694
+step:3350/20000 router_matrix
+step:3350/20000 train_loss:2.4048 train_time:11799868ms step_avg:3522.35ms router_forward:1 router_objective:-0.2554 router_entropy:0.9799
+step:3360/20000 router_probe window_steps:10 avg_depth:5.400 router_objective:-0.2659 router_entropy:0.9572
+step:3360/20000 router_matrix
+step:3360/20000 train_loss:2.3857 train_time:11832274ms step_avg:3521.51ms router_forward:1 router_objective:-0.2233 router_entropy:0.9548
+step:3370/20000 router_probe window_steps:10 avg_depth:5.360 router_objective:-0.2396 router_entropy:0.9538
+step:3370/20000 router_matrix
+step:3370/20000 train_loss:2.4549 train_time:11864611ms step_avg:3520.66ms router_forward:1 router_objective:-0.1691 router_entropy:0.9641
+step:3380/20000 router_probe window_steps:10 avg_depth:5.138 router_objective:-0.2440 router_entropy:0.9758
+step:3380/20000 router_matrix
+step:3380/20000 train_loss:2.4149 train_time:11895915ms step_avg:3519.50ms router_forward:1 router_objective:-0.2850 router_entropy:0.9965
+step:3390/20000 router_probe window_steps:10 avg_depth:5.168 router_objective:-0.2344 router_entropy:0.9792
+step:3390/20000 router_matrix
+step:3390/20000 train_loss:2.3940 train_time:11927638ms step_avg:3518.48ms router_forward:1 router_objective:-0.2614 router_entropy:0.9719
+step:3400/20000 router_probe window_steps:10 avg_depth:8.610 router_objective:-0.2019 router_entropy:0.9555
+step:3400/20000 router_matrix
+step:3400/20000 train_loss:2.4181 train_time:11976115ms step_avg:3522.39ms router_forward:1 router_objective:-0.1768 router_entropy:0.9526
+step:3410/20000 router_probe window_steps:10 avg_depth:6.086 router_objective:-0.2011 router_entropy:0.9057
+step:3410/20000 router_matrix
+step:3410/20000 train_loss:2.4132 train_time:12012027ms step_avg:3522.59ms router_forward:1 router_objective:-0.2474 router_entropy:0.9097
+step:3420/20000 router_probe window_steps:10 avg_depth:5.130 router_objective:-0.2535 router_entropy:0.9629
+step:3420/20000 router_matrix
+step:3420/20000 train_loss:2.4512 train_time:12043388ms step_avg:3521.46ms router_forward:1 router_objective:-0.2719 router_entropy:0.9601
+step:3430/20000 router_probe window_steps:10 avg_depth:5.043 router_objective:-0.2571 router_entropy:0.9528
+step:3430/20000 router_matrix
+step:3430/20000 train_loss:2.4506 train_time:12074305ms step_avg:3520.21ms router_forward:1 router_objective:-0.2752 router_entropy:0.9834
+step:3440/20000 router_probe window_steps:10 avg_depth:5.253 router_objective:-0.2486 router_entropy:0.9849
+step:3440/20000 router_matrix
+step:3440/20000 train_loss:2.3711 train_time:12107120ms step_avg:3519.51ms router_forward:1 router_objective:-0.2928 router_entropy:0.9718
+step:3450/20000 router_probe window_steps:10 avg_depth:5.924 router_objective:-0.1856 router_entropy:0.9263
+step:3450/20000 router_matrix
+step:3450/20000 train_loss:2.3640 train_time:12142087ms step_avg:3519.45ms router_forward:1 router_objective:-0.2884 router_entropy:0.9894
+step:3460/20000 router_probe window_steps:10 avg_depth:5.321 router_objective:-0.2516 router_entropy:0.9823
+step:3460/20000 router_matrix
+step:3460/20000 train_loss:2.3960 train_time:12174412ms step_avg:3518.62ms router_forward:1 router_objective:-0.2072 router_entropy:0.9686
+step:3470/20000 router_probe window_steps:10 avg_depth:5.126 router_objective:-0.2744 router_entropy:0.9793
+step:3470/20000 router_matrix
+step:3470/20000 train_loss:2.3717 train_time:12205877ms step_avg:3517.54ms router_forward:1 router_objective:-0.2181 router_entropy:0.9589
+step:3480/20000 router_probe window_steps:10 avg_depth:5.229 router_objective:-0.2795 router_entropy:0.9878
+step:3480/20000 router_matrix
+step:3480/20000 train_loss:2.3412 train_time:12237724ms step_avg:3516.59ms router_forward:1 router_objective:-0.3431 router_entropy:0.9830
+step:3490/20000 router_probe window_steps:10 avg_depth:5.188 router_objective:-0.2494 router_entropy:0.9849
+step:3490/20000 router_matrix
+step:3490/20000 train_loss:2.3731 train_time:12269299ms step_avg:3515.56ms router_forward:1 router_objective:-0.2372 router_entropy:0.9761
+step:3500/20000 router_probe window_steps:10 avg_depth:5.357 router_objective:-0.2330 router_entropy:0.9881
+step:3500/20000 router_matrix
+step:3500/20000 train_loss:2.3531 train_time:12301770ms step_avg:3514.79ms router_forward:1 router_objective:-0.2595 router_entropy:0.9913
+step:3510/20000 router_probe window_steps:10 avg_depth:5.113 router_objective:-0.2323 router_entropy:0.9777
+step:3510/20000 router_matrix
+step:3510/20000 train_loss:2.3521 train_time:12332805ms step_avg:3513.62ms router_forward:1 router_objective:-0.2235 router_entropy:0.9875
+step:3520/20000 router_probe window_steps:10 avg_depth:5.474 router_objective:-0.2880 router_entropy:0.9885
+step:3520/20000 router_matrix
+step:3520/20000 train_loss:2.3408 train_time:12366106ms step_avg:3513.10ms router_forward:1 router_objective:-0.2988 router_entropy:0.9617
+step:3530/20000 router_probe window_steps:10 avg_depth:5.238 router_objective:-0.2925 router_entropy:0.9868
+step:3530/20000 router_matrix
+step:3530/20000 train_loss:2.3466 train_time:12398117ms step_avg:3512.21ms router_forward:1 router_objective:-0.2761 router_entropy:1.0060
+step:3540/20000 router_probe window_steps:10 avg_depth:5.205 router_objective:-0.2595 router_entropy:0.9872
+step:3540/20000 router_matrix
+step:3540/20000 train_loss:2.3488 train_time:12429931ms step_avg:3511.28ms router_forward:1 router_objective:-0.2092 router_entropy:1.0004
+step:3550/20000 router_probe window_steps:10 avg_depth:5.370 router_objective:-0.2411 router_entropy:0.9906
+step:3550/20000 router_matrix
+step:3550/20000 train_loss:2.2866 train_time:12462784ms step_avg:3510.64ms router_forward:1 router_objective:-0.1586 router_entropy:0.9907
+step:3560/20000 router_probe window_steps:10 avg_depth:5.258 router_objective:-0.2663 router_entropy:0.9838
+step:3560/20000 router_matrix
+step:3560/20000 train_loss:2.3373 train_time:12495132ms step_avg:3509.87ms router_forward:1 router_objective:-0.2239 router_entropy:0.9855
+step:3570/20000 router_probe window_steps:10 avg_depth:5.227 router_objective:-0.2344 router_entropy:0.9815
+step:3570/20000 router_matrix
+step:3570/20000 train_loss:2.2427 train_time:12529337ms step_avg:3509.62ms router_forward:1 router_objective:-0.2321 router_entropy:0.9723
+step:3580/20000 router_probe window_steps:10 avg_depth:5.065 router_objective:-0.2528 router_entropy:0.9828
+step:3580/20000 router_matrix
+step:3580/20000 train_loss:2.3805 train_time:12560563ms step_avg:3508.54ms router_forward:1 router_objective:-0.2301 router_entropy:0.9715
+step:3590/20000 router_probe window_steps:10 avg_depth:5.445 router_objective:-0.2465 router_entropy:0.9919
+step:3590/20000 router_matrix
+step:3590/20000 train_loss:2.2461 train_time:12593576ms step_avg:3507.96ms router_forward:1 router_objective:-0.2679 router_entropy:1.0026
+step:3600/20000 router_probe window_steps:10 avg_depth:5.382 router_objective:-0.2791 router_entropy:0.9829
+step:3600/20000 router_matrix
+step:3600/20000 train_loss:2.3403 train_time:12626187ms step_avg:3507.27ms router_forward:1 router_objective:-0.2534 router_entropy:0.9839
+step:3610/20000 router_probe window_steps:10 avg_depth:5.345 router_objective:-0.2419 router_entropy:0.9896
+step:3610/20000 router_matrix
+step:3610/20000 train_loss:2.2115 train_time:12659552ms step_avg:3506.80ms router_forward:1 router_objective:-0.2034 router_entropy:0.9877
+step:3620/20000 router_probe window_steps:10 avg_depth:5.444 router_objective:-0.2537 router_entropy:0.9855
+step:3620/20000 router_matrix
+step:3620/20000 train_loss:2.3393 train_time:12693106ms step_avg:3506.38ms router_forward:1 router_objective:-0.1879 router_entropy:1.0008
+step:3630/20000 router_probe window_steps:10 avg_depth:5.561 router_objective:-0.2633 router_entropy:0.9830
+step:3630/20000 router_matrix
+step:3630/20000 train_loss:2.2419 train_time:12726810ms step_avg:3506.01ms router_forward:1 router_objective:-0.2866 router_entropy:0.9682
+step:3640/20000 router_probe window_steps:10 avg_depth:5.270 router_objective:-0.2753 router_entropy:0.9857
+step:3640/20000 router_matrix
+step:3640/20000 train_loss:2.3452 train_time:12758747ms step_avg:3505.15ms router_forward:1 router_objective:-0.2417 router_entropy:0.9911
+step:3650/20000 router_probe window_steps:10 avg_depth:5.197 router_objective:-0.2486 router_entropy:0.9882
+step:3650/20000 router_matrix
+step:3650/20000 train_loss:2.1863 train_time:12790270ms step_avg:3504.18ms router_forward:1 router_objective:-0.1940 router_entropy:0.9925
+step:3660/20000 router_probe window_steps:10 avg_depth:5.215 router_objective:-0.2634 router_entropy:0.9758
+step:3660/20000 router_matrix
+step:3660/20000 train_loss:2.3642 train_time:12822115ms step_avg:3503.31ms router_forward:1 router_objective:-0.2928 router_entropy:0.9682
+step:3670/20000 router_probe window_steps:10 avg_depth:5.253 router_objective:-0.2216 router_entropy:0.9861
+step:3670/20000 router_matrix
+step:3670/20000 train_loss:2.2347 train_time:12854110ms step_avg:3502.48ms router_forward:1 router_objective:-0.1820 router_entropy:1.0006
+step:3680/20000 router_probe window_steps:10 avg_depth:5.343 router_objective:-0.2187 router_entropy:0.9908
+step:3680/20000 router_matrix
+step:3680/20000 train_loss:2.3354 train_time:12886481ms step_avg:3501.76ms router_forward:1 router_objective:-0.2208 router_entropy:0.9801
+step:3690/20000 router_probe window_steps:10 avg_depth:5.414 router_objective:-0.2336 router_entropy:0.9870
+step:3690/20000 router_matrix
+step:3690/20000 train_loss:2.1618 train_time:12920479ms step_avg:3501.48ms router_forward:1 router_objective:-0.2271 router_entropy:0.9906
+step:3700/20000 router_probe window_steps:10 avg_depth:5.403 router_objective:-0.2523 router_entropy:0.9906
+step:3700/20000 router_matrix
+step:3700/20000 train_loss:2.2968 train_time:12953096ms step_avg:3500.84ms router_forward:1 router_objective:-0.2916 router_entropy:0.9966
+step:3710/20000 router_probe window_steps:10 avg_depth:5.215 router_objective:-0.2568 router_entropy:0.9811
+step:3710/20000 router_matrix
+step:3710/20000 train_loss:2.1860 train_time:12984865ms step_avg:3499.96ms router_forward:1 router_objective:-0.2888 router_entropy:0.9836
+step:3720/20000 router_probe window_steps:10 avg_depth:5.308 router_objective:-0.2483 router_entropy:0.9863
+step:3720/20000 router_matrix
+step:3720/20000 train_loss:2.2956 train_time:13017580ms step_avg:3499.35ms router_forward:1 router_objective:-0.2108 router_entropy:0.9813
+step:3730/20000 router_probe window_steps:10 avg_depth:5.405 router_objective:-0.2506 router_entropy:0.9814
+step:3730/20000 router_matrix
+step:3730/20000 train_loss:2.3596 train_time:13050920ms step_avg:3498.91ms router_forward:1 router_objective:-0.2681 router_entropy:0.9794
+step:3740/20000 router_probe window_steps:10 avg_depth:4.996 router_objective:-0.2274 router_entropy:0.9638
+step:3740/20000 router_matrix
+step:3740/20000 train_loss:2.3436 train_time:13081955ms step_avg:3497.85ms router_forward:1 router_objective:-0.2311 router_entropy:0.9320
+step:3750/20000 router_probe window_steps:10 avg_depth:5.311 router_objective:-0.2082 router_entropy:0.9312
+step:3750/20000 router_matrix
+step:3750/20000 train_loss:2.2973 train_time:13114231ms step_avg:3497.13ms router_forward:1 router_objective:-0.1750 router_entropy:0.9141
+step:3760/20000 router_probe window_steps:10 avg_depth:5.135 router_objective:-0.2622 router_entropy:0.9610
+step:3760/20000 router_matrix
+step:3760/20000 train_loss:2.3210 train_time:13145466ms step_avg:3496.13ms router_forward:1 router_objective:-0.3023 router_entropy:0.9742
+step:3770/20000 router_probe window_steps:10 avg_depth:4.920 router_objective:-0.2611 router_entropy:0.9592
+step:3770/20000 router_matrix
+step:3770/20000 train_loss:2.3441 train_time:13175591ms step_avg:3494.85ms router_forward:1 router_objective:-0.3460 router_entropy:0.9760
+step:3780/20000 router_probe window_steps:10 avg_depth:4.951 router_objective:-0.2444 router_entropy:0.9540
+step:3780/20000 router_matrix
+step:3780/20000 train_loss:2.3676 train_time:13205868ms step_avg:3493.62ms router_forward:1 router_objective:-0.2783 router_entropy:0.9794
+step:3790/20000 router_probe window_steps:10 avg_depth:5.249 router_objective:-0.2353 router_entropy:0.9619
+step:3790/20000 router_matrix
+step:3790/20000 train_loss:2.2920 train_time:13237819ms step_avg:3492.83ms router_forward:1 router_objective:-0.2010 router_entropy:0.9010
+step:3800/20000 router_probe window_steps:10 avg_depth:4.996 router_objective:-0.2466 router_entropy:0.9245
+step:3800/20000 router_matrix
+step:3800/20000 train_loss:2.3625 train_time:13268383ms step_avg:3491.68ms router_forward:1 router_objective:-0.2889 router_entropy:0.9573
+step:3810/20000 router_probe window_steps:10 avg_depth:5.003 router_objective:-0.2516 router_entropy:0.9588
+step:3810/20000 router_matrix
+step:3810/20000 train_loss:2.3107 train_time:13299169ms step_avg:3490.60ms router_forward:1 router_objective:-0.2556 router_entropy:0.9585
+step:3820/20000 router_probe window_steps:10 avg_depth:5.648 router_objective:-0.2400 router_entropy:0.9507
+step:3820/20000 router_matrix
+step:3820/20000 train_loss:2.3574 train_time:13334509ms step_avg:3490.71ms router_forward:1 router_objective:-0.2261 router_entropy:0.9438
+step:3830/20000 router_probe window_steps:10 avg_depth:6.817 router_objective:-0.2196 router_entropy:0.9334
+step:3830/20000 router_matrix
+step:3830/20000 train_loss:2.4283 train_time:13374164ms step_avg:3491.95ms router_forward:1 router_objective:-0.2008 router_entropy:0.8940
+step:3840/20000 router_probe window_steps:10 avg_depth:5.548 router_objective:-0.2300 router_entropy:0.8665
+step:3840/20000 router_matrix
+step:3840/20000 train_loss:2.3691 train_time:13408250ms step_avg:3491.73ms router_forward:1 router_objective:-0.2197 router_entropy:0.8237
+step:3850/20000 router_probe window_steps:10 avg_depth:4.902 router_objective:-0.2405 router_entropy:0.9166
+step:3850/20000 router_matrix
+step:3850/20000 train_loss:2.3946 train_time:13438988ms step_avg:3490.65ms router_forward:1 router_objective:-0.2768 router_entropy:0.9756
+step:3860/20000 router_probe window_steps:10 avg_depth:4.865 router_objective:-0.2562 router_entropy:0.9609
+step:3860/20000 router_matrix
+step:3860/20000 train_loss:2.4201 train_time:13469272ms step_avg:3489.45ms router_forward:1 router_objective:-0.2571 router_entropy:0.9553
+step:3870/20000 router_probe window_steps:10 avg_depth:5.524 router_objective:-0.3205 router_entropy:0.9918
+step:3870/20000 router_matrix
+step:3870/20000 train_loss:2.3365 train_time:13503064ms step_avg:3489.16ms router_forward:1 router_objective:-0.2460 router_entropy:0.9866
+step:3880/20000 router_probe window_steps:10 avg_depth:4.925 router_objective:-0.2046 router_entropy:0.9723
+step:3880/20000 router_matrix
+step:3880/20000 train_loss:2.3774 train_time:13534169ms step_avg:3488.19ms router_forward:1 router_objective:-0.2123 router_entropy:0.9556
+step:3890/20000 router_probe window_steps:10 avg_depth:5.142 router_objective:-0.2723 router_entropy:0.9812
+step:3890/20000 router_matrix
+step:3890/20000 train_loss:2.3786 train_time:13565631ms step_avg:3487.31ms router_forward:1 router_objective:-0.3736 router_entropy:1.0130
+step:3900/20000 router_probe window_steps:10 avg_depth:5.345 router_objective:-0.3211 router_entropy:0.9837
+step:3900/20000 router_matrix
+step:3900/20000 train_loss:2.3465 train_time:13598339ms step_avg:3486.75ms router_forward:1 router_objective:-0.2530 router_entropy:0.9619
+step:3910/20000 router_probe window_steps:10 avg_depth:5.230 router_objective:-0.2684 router_entropy:0.9881
+step:3910/20000 router_matrix
+step:3910/20000 train_loss:2.2933 train_time:13630668ms step_avg:3486.10ms router_forward:1 router_objective:-0.2217 router_entropy:0.9881
+step:3920/20000 router_probe window_steps:10 avg_depth:5.023 router_objective:-0.2412 router_entropy:0.9744
+step:3920/20000 router_matrix
+step:3920/20000 train_loss:2.3207 train_time:13661420ms step_avg:3485.06ms router_forward:1 router_objective:-0.2354 router_entropy:0.9909
+step:3930/20000 router_probe window_steps:10 avg_depth:5.643 router_objective:-0.2976 router_entropy:0.9921
+step:3930/20000 router_matrix
+step:3930/20000 train_loss:2.3567 train_time:13695550ms step_avg:3484.87ms router_forward:1 router_objective:-0.2197 router_entropy:0.9769
+step:3940/20000 router_probe window_steps:10 avg_depth:5.186 router_objective:-0.2326 router_entropy:0.9829
+step:3940/20000 router_matrix
+step:3940/20000 train_loss:2.2970 train_time:13727153ms step_avg:3484.05ms router_forward:1 router_objective:-0.2582 router_entropy:1.0010
+step:3950/20000 router_probe window_steps:10 avg_depth:5.257 router_objective:-0.2125 router_entropy:0.9760
+step:3950/20000 router_matrix
+step:3950/20000 train_loss:2.3289 train_time:13760640ms step_avg:3483.71ms router_forward:1 router_objective:-0.2781 router_entropy:0.9825
+step:3960/20000 router_probe window_steps:10 avg_depth:5.403 router_objective:-0.2522 router_entropy:0.9903
+step:3960/20000 router_matrix
+step:3960/20000 train_loss:2.2949 train_time:13793456ms step_avg:3483.20ms router_forward:1 router_objective:-0.1985 router_entropy:0.9909
+step:3970/20000 router_probe window_steps:10 avg_depth:5.784 router_objective:-0.3172 router_entropy:0.9863
+step:3970/20000 router_matrix
+step:3970/20000 train_loss:2.4267 train_time:13828080ms step_avg:3483.14ms router_forward:1 router_objective:-0.3003 router_entropy:0.9955
+step:3980/20000 router_probe window_steps:10 avg_depth:5.053 router_objective:-0.2612 router_entropy:0.9834
+step:3980/20000 router_matrix
+step:3980/20000 train_loss:2.3161 train_time:13858827ms step_avg:3482.12ms router_forward:1 router_objective:-0.2540 router_entropy:0.9841
+step:3990/20000 router_probe window_steps:10 avg_depth:5.073 router_objective:-0.2378 router_entropy:0.9843
+step:3990/20000 router_matrix
+step:3990/20000 train_loss:2.3417 train_time:13890098ms step_avg:3481.23ms router_forward:1 router_objective:-0.2006 router_entropy:0.9732
+step:4000/20000 router_probe window_steps:10 avg_depth:5.256 router_objective:-0.2440 router_entropy:0.9848
+step:4000/20000 router_matrix
+step:4000/20000 train_loss:2.4107 train_time:13922294ms step_avg:3480.57ms router_forward:1 router_objective:-0.1826 router_entropy:0.9853
+step:4010/20000 router_probe window_steps:10 avg_depth:4.839 router_objective:-0.1917 router_entropy:0.9634
+step:4010/20000 router_matrix
+step:4010/20000 train_loss:2.3156 train_time:13952015ms step_avg:3479.31ms router_forward:1 router_objective:-0.2645 router_entropy:0.9839
+step:4020/20000 router_probe window_steps:10 avg_depth:5.590 router_objective:-0.2614 router_entropy:0.9618
+step:4020/20000 router_matrix
+step:4020/20000 train_loss:2.3273 train_time:13985623ms step_avg:3479.01ms router_forward:1 router_objective:-0.2199 router_entropy:0.9784
+step:4030/20000 router_probe window_steps:10 avg_depth:4.803 router_objective:-0.2563 router_entropy:0.9647
+step:4030/20000 router_matrix
+step:4030/20000 train_loss:2.3043 train_time:14015153ms step_avg:3477.71ms router_forward:1 router_objective:-0.3487 router_entropy:0.9766
+step:4040/20000 router_probe window_steps:10 avg_depth:5.049 router_objective:-0.2473 router_entropy:0.9398
+step:4040/20000 router_matrix
+step:4040/20000 train_loss:2.2876 train_time:14046268ms step_avg:3476.80ms router_forward:1 router_objective:-0.3034 router_entropy:0.9112
+step:4050/20000 router_probe window_steps:10 avg_depth:4.898 router_objective:-0.2150 router_entropy:0.9466
+step:4050/20000 router_matrix
+step:4050/20000 train_loss:2.3000 train_time:14076337ms step_avg:3475.64ms router_forward:1 router_objective:-0.3016 router_entropy:1.0031
+step:4060/20000 router_probe window_steps:10 avg_depth:5.346 router_objective:-0.2452 router_entropy:0.9882
+step:4060/20000 router_matrix
+step:4060/20000 train_loss:2.2834 train_time:14109111ms step_avg:3475.15ms router_forward:1 router_objective:-0.2370 router_entropy:0.9921
+step:4070/20000 router_probe window_steps:10 avg_depth:5.356 router_objective:-0.2323 router_entropy:0.9778
+step:4070/20000 router_matrix
+step:4070/20000 train_loss:2.2563 train_time:14142819ms step_avg:3474.89ms router_forward:1 router_objective:-0.2482 router_entropy:0.9889
+step:4080/20000 router_probe window_steps:10 avg_depth:5.192 router_objective:-0.2618 router_entropy:0.9835
+step:4080/20000 router_matrix
+step:4080/20000 train_loss:2.3536 train_time:14174241ms step_avg:3474.08ms router_forward:1 router_objective:-0.1919 router_entropy:0.9801
+step:4090/20000 router_probe window_steps:10 avg_depth:5.268 router_objective:-0.2045 router_entropy:0.9877
+step:4090/20000 router_matrix
+step:4090/20000 train_loss:2.3241 train_time:14206382ms step_avg:3473.44ms router_forward:1 router_objective:-0.2507 router_entropy:0.9758
+step:4100/20000 router_probe window_steps:10 avg_depth:5.348 router_objective:-0.2550 router_entropy:0.9733
+step:4100/20000 router_matrix
+step:4100/20000 train_loss:2.2965 train_time:14238733ms step_avg:3472.86ms router_forward:1 router_objective:-0.3102 router_entropy:0.9602
+step:4110/20000 router_probe window_steps:10 avg_depth:5.193 router_objective:-0.2227 router_entropy:0.9662
+step:4110/20000 router_matrix
+step:4110/20000 train_loss:2.3004 train_time:14270305ms step_avg:3472.09ms router_forward:1 router_objective:-0.2035 router_entropy:0.9790
+step:4120/20000 router_probe window_steps:10 avg_depth:5.919 router_objective:-0.2041 router_entropy:0.9895
+step:4120/20000 router_matrix
+step:4120/20000 train_loss:2.3549 train_time:14305577ms step_avg:3472.23ms router_forward:1 router_objective:-0.2768 router_entropy:0.9952
+step:4130/20000 router_probe window_steps:10 avg_depth:5.065 router_objective:-0.2515 router_entropy:0.9763
+step:4130/20000 router_matrix
+step:4130/20000 train_loss:2.3169 train_time:14336456ms step_avg:3471.30ms router_forward:1 router_objective:-0.2719 router_entropy:0.9694
+step:4140/20000 router_probe window_steps:10 avg_depth:5.254 router_objective:-0.2420 router_entropy:0.9782
+step:4140/20000 router_matrix
+step:4140/20000 train_loss:2.3580 train_time:14368271ms step_avg:3470.60ms router_forward:1 router_objective:-0.2623 router_entropy:0.9850
+step:4150/20000 router_probe window_steps:10 avg_depth:5.218 router_objective:-0.2149 router_entropy:0.9859
+step:4150/20000 router_matrix
+step:4150/20000 train_loss:2.3399 train_time:14399952ms step_avg:3469.87ms router_forward:1 router_objective:-0.2351 router_entropy:0.9752
+step:4160/20000 router_probe window_steps:10 avg_depth:5.140 router_objective:-0.2639 router_entropy:0.9647
+step:4160/20000 router_matrix
+step:4160/20000 train_loss:2.3127 train_time:14431115ms step_avg:3469.02ms router_forward:1 router_objective:-0.2813 router_entropy:0.9491
+step:4170/20000 router_probe window_steps:10 avg_depth:5.184 router_objective:-0.2345 router_entropy:0.9737
+step:4170/20000 router_matrix
+step:4170/20000 train_loss:2.3523 train_time:14462847ms step_avg:3468.31ms router_forward:1 router_objective:-0.1923 router_entropy:0.9951
+step:4180/20000 router_probe window_steps:10 avg_depth:5.017 router_objective:-0.2508 router_entropy:0.9732
+step:4180/20000 router_matrix
+step:4180/20000 train_loss:2.2522 train_time:14493708ms step_avg:3467.39ms router_forward:1 router_objective:-0.2254 router_entropy:0.9426
+step:4190/20000 router_probe window_steps:10 avg_depth:5.235 router_objective:-0.2350 router_entropy:0.9686
+step:4190/20000 router_matrix
+step:4190/20000 train_loss:2.1934 train_time:14526346ms step_avg:3466.91ms router_forward:1 router_objective:-0.1489 router_entropy:0.9827
+step:4200/20000 router_probe window_steps:10 avg_depth:5.234 router_objective:-0.2486 router_entropy:0.9881
+step:4200/20000 router_matrix
+step:4200/20000 train_loss:2.2755 train_time:14559892ms step_avg:3466.64ms router_forward:1 router_objective:-0.2224 router_entropy:1.0021
+step:4210/20000 router_probe window_steps:10 avg_depth:5.226 router_objective:-0.2213 router_entropy:0.9864
+step:4210/20000 router_matrix
+step:4210/20000 train_loss:2.3106 train_time:14592051ms step_avg:3466.05ms router_forward:1 router_objective:-0.2524 router_entropy:0.9782
+step:4220/20000 router_probe window_steps:10 avg_depth:5.333 router_objective:-0.2564 router_entropy:0.9807
+step:4220/20000 router_matrix
+step:4220/20000 train_loss:2.2545 train_time:14624881ms step_avg:3465.61ms router_forward:1 router_objective:-0.2679 router_entropy:0.9614
+step:4230/20000 router_probe window_steps:10 avg_depth:4.986 router_objective:-0.2450 router_entropy:0.9272
+step:4230/20000 router_matrix
+step:4230/20000 train_loss:2.3239 train_time:14655900ms step_avg:3464.75ms router_forward:1 router_objective:-0.2130 router_entropy:0.9314
+step:4240/20000 router_probe window_steps:10 avg_depth:5.498 router_objective:-0.2576 router_entropy:0.9682
+step:4240/20000 router_matrix
+step:4240/20000 train_loss:2.2690 train_time:14688980ms step_avg:3464.38ms router_forward:1 router_objective:-0.2178 router_entropy:0.9819
+step:4250/20000 router_probe window_steps:10 avg_depth:5.222 router_objective:-0.2141 router_entropy:0.9822
+step:4250/20000 router_matrix
+step:4250/20000 train_loss:2.3336 train_time:14720884ms step_avg:3463.74ms router_forward:1 router_objective:-0.1680 router_entropy:0.9738
+step:4260/20000 router_probe window_steps:10 avg_depth:5.082 router_objective:-0.2472 router_entropy:0.9820
+step:4260/20000 router_matrix
+step:4260/20000 train_loss:2.2610 train_time:14752160ms step_avg:3462.95ms router_forward:1 router_objective:-0.2478 router_entropy:0.9800
+step:4270/20000 router_probe window_steps:10 avg_depth:5.259 router_objective:-0.2688 router_entropy:0.9735
+step:4270/20000 router_matrix
+step:4270/20000 train_loss:2.3807 train_time:14784102ms step_avg:3462.32ms router_forward:1 router_objective:-0.2672 router_entropy:0.9648
+step:4280/20000 router_probe window_steps:10 avg_depth:5.332 router_objective:-0.2754 router_entropy:0.9833
+step:4280/20000 router_matrix
+step:4280/20000 train_loss:2.2747 train_time:14816475ms step_avg:3461.79ms router_forward:1 router_objective:-0.3861 router_entropy:0.9997
+step:4290/20000 router_probe window_steps:10 avg_depth:5.177 router_objective:-0.2383 router_entropy:0.9822
+step:4290/20000 router_matrix
+step:4290/20000 train_loss:2.2959 train_time:14848172ms step_avg:3461.11ms router_forward:1 router_objective:-0.1959 router_entropy:0.9858
+step:4300/20000 router_probe window_steps:10 avg_depth:5.477 router_objective:-0.2095 router_entropy:0.9611
+step:4300/20000 router_matrix
+step:4300/20000 train_loss:2.3136 train_time:14881466ms step_avg:3460.81ms router_forward:1 router_objective:-0.2378 router_entropy:0.9634
+step:4310/20000 router_probe window_steps:10 avg_depth:4.985 router_objective:-0.2342 router_entropy:0.9725
+step:4310/20000 router_matrix
+step:4310/20000 train_loss:2.3212 train_time:14912403ms step_avg:3459.95ms router_forward:1 router_objective:-0.2650 router_entropy:0.9806
+step:4320/20000 router_probe window_steps:10 avg_depth:5.381 router_objective:-0.2517 router_entropy:0.9814
+step:4320/20000 router_matrix
+step:4320/20000 train_loss:2.3432 train_time:14944902ms step_avg:3459.47ms router_forward:1 router_objective:-0.2045 router_entropy:0.9814
+step:4330/20000 router_probe window_steps:10 avg_depth:5.345 router_objective:-0.2269 router_entropy:0.9786
+step:4330/20000 router_matrix
+step:4330/20000 train_loss:2.3853 train_time:14978049ms step_avg:3459.13ms router_forward:1 router_objective:-0.1681 router_entropy:0.9952
+step:4340/20000 router_probe window_steps:10 avg_depth:5.062 router_objective:-0.2467 router_entropy:0.9765
+step:4340/20000 router_matrix
+step:4340/20000 train_loss:2.3196 train_time:15008909ms step_avg:3458.27ms router_forward:1 router_objective:-0.2775 router_entropy:0.9560
+step:4350/20000 router_probe window_steps:10 avg_depth:5.392 router_objective:-0.2374 router_entropy:0.9796
+step:4350/20000 router_matrix
+step:4350/20000 train_loss:2.2996 train_time:15041458ms step_avg:3457.81ms router_forward:1 router_objective:-0.2836 router_entropy:0.9867
+step:4360/20000 router_probe window_steps:10 avg_depth:5.161 router_objective:-0.1477 router_entropy:0.9614
+step:4360/20000 router_matrix
+step:4360/20000 train_loss:2.3593 train_time:15073994ms step_avg:3457.34ms router_forward:1 router_objective:-0.1978 router_entropy:0.9341
+step:4370/20000 router_probe window_steps:10 avg_depth:4.680 router_objective:-0.1867 router_entropy:0.9396
+step:4370/20000 router_matrix
+step:4370/20000 train_loss:2.2903 train_time:15103027ms step_avg:3456.07ms router_forward:1 router_objective:-0.0920 router_entropy:0.9603
+step:4380/20000 router_probe window_steps:10 avg_depth:4.977 router_objective:-0.1490 router_entropy:0.9574
+step:4380/20000 router_matrix
+step:4380/20000 train_loss:2.3248 train_time:15133674ms step_avg:3455.18ms router_forward:1 router_objective:-0.1730 router_entropy:0.9551
+step:4390/20000 router_probe window_steps:10 avg_depth:5.010 router_objective:-0.2152 router_entropy:0.9590
+step:4390/20000 router_matrix
+step:4390/20000 train_loss:2.2873 train_time:15164452ms step_avg:3454.32ms router_forward:1 router_objective:-0.2197 router_entropy:0.9870
+step:4400/20000 router_probe window_steps:10 avg_depth:5.147 router_objective:-0.2517 router_entropy:0.9789
+step:4400/20000 router_matrix
+step:4400/20000 train_loss:2.2735 train_time:15196051ms step_avg:3453.65ms router_forward:1 router_objective:-0.2824 router_entropy:0.9636
+step:4410/20000 router_probe window_steps:10 avg_depth:5.158 router_objective:-0.2421 router_entropy:0.9641
+step:4410/20000 router_matrix
+step:4410/20000 train_loss:2.2664 train_time:15227743ms step_avg:3453.00ms router_forward:1 router_objective:-0.2652 router_entropy:0.9865
+step:4420/20000 router_probe window_steps:10 avg_depth:5.240 router_objective:-0.2434 router_entropy:0.9870
+step:4420/20000 router_matrix
+step:4420/20000 train_loss:2.2763 train_time:15259690ms step_avg:3452.42ms router_forward:1 router_objective:-0.2244 router_entropy:0.9940
+step:4430/20000 router_probe window_steps:10 avg_depth:5.336 router_objective:-0.2435 router_entropy:0.9918
+step:4430/20000 router_matrix
+step:4430/20000 train_loss:2.2765 train_time:15292309ms step_avg:3451.99ms router_forward:1 router_objective:-0.2716 router_entropy:0.9992
+step:4440/20000 router_probe window_steps:10 avg_depth:5.213 router_objective:-0.2346 router_entropy:0.9757
+step:4440/20000 router_matrix
+step:4440/20000 train_loss:2.2862 train_time:15324020ms step_avg:3451.36ms router_forward:1 router_objective:-0.1909 router_entropy:0.9576
+step:4450/20000 router_probe window_steps:10 avg_depth:5.339 router_objective:-0.2538 router_entropy:0.9844
+step:4450/20000 router_matrix
+step:4450/20000 train_loss:2.3476 train_time:15356838ms step_avg:3450.97ms router_forward:1 router_objective:-0.1880 router_entropy:0.9780
+step:4460/20000 router_probe window_steps:10 avg_depth:5.123 router_objective:-0.2464 router_entropy:0.9789
+step:4460/20000 router_matrix
+step:4460/20000 train_loss:2.2380 train_time:15390197ms step_avg:3450.72ms router_forward:1 router_objective:-0.2798 router_entropy:0.9881
+step:4470/20000 router_probe window_steps:10 avg_depth:5.388 router_objective:-0.2340 router_entropy:0.9908
+step:4470/20000 router_matrix
+step:4470/20000 train_loss:2.2542 train_time:15422913ms step_avg:3450.32ms router_forward:1 router_objective:-0.2615 router_entropy:0.9942
+step:4480/20000 router_probe window_steps:10 avg_depth:5.044 router_objective:-0.2121 router_entropy:0.9606
+step:4480/20000 router_matrix
+step:4480/20000 train_loss:2.2968 train_time:15453852ms step_avg:3449.52ms router_forward:1 router_objective:-0.3026 router_entropy:0.9449
+step:4490/20000 router_probe window_steps:10 avg_depth:5.271 router_objective:-0.2410 router_entropy:0.9770
+step:4490/20000 router_matrix
+step:4490/20000 train_loss:2.2349 train_time:15485961ms step_avg:3448.99ms router_forward:1 router_objective:-0.2040 router_entropy:0.9920
+step:4500/20000 router_probe window_steps:10 avg_depth:5.530 router_objective:-0.2287 router_entropy:0.9742
+step:4500/20000 router_matrix
+step:4500/20000 train_loss:2.3976 train_time:15519360ms step_avg:3448.75ms router_forward:1 router_objective:-0.2416 router_entropy:0.9589
+step:4510/20000 router_probe window_steps:10 avg_depth:6.058 router_objective:-0.2418 router_entropy:0.9882
+step:4510/20000 router_matrix
+step:4510/20000 train_loss:2.2172 train_time:15555341ms step_avg:3449.08ms router_forward:1 router_objective:-0.2792 router_entropy:1.0017
+step:4520/20000 router_probe window_steps:10 avg_depth:5.042 router_objective:-0.2332 router_entropy:0.9554
+step:4520/20000 router_matrix
+step:4520/20000 train_loss:2.3588 train_time:15586054ms step_avg:3448.24ms router_forward:1 router_objective:0.0602 router_entropy:0.9447
+step:4530/20000 router_probe window_steps:10 avg_depth:5.577 router_objective:-0.2768 router_entropy:0.9773
+step:4530/20000 router_matrix
+step:4530/20000 train_loss:2.3160 train_time:15619559ms step_avg:3448.03ms router_forward:1 router_objective:-0.2615 router_entropy:0.9718
+step:4540/20000 router_probe window_steps:10 avg_depth:5.213 router_objective:-0.2399 router_entropy:0.9699
+step:4540/20000 router_matrix
+step:4540/20000 train_loss:2.1669 train_time:15651349ms step_avg:3447.43ms router_forward:1 router_objective:-0.2176 router_entropy:0.9738
+step:4550/20000 router_probe window_steps:10 avg_depth:4.911 router_objective:-0.2460 router_entropy:0.9689
+step:4550/20000 router_matrix
+step:4550/20000 train_loss:2.3280 train_time:15681570ms step_avg:3446.50ms router_forward:1 router_objective:-0.2773 router_entropy:0.9772
+step:4560/20000 router_probe window_steps:10 avg_depth:5.287 router_objective:-0.2701 router_entropy:0.9869
+step:4560/20000 router_matrix
+step:4560/20000 train_loss:2.2893 train_time:15713663ms step_avg:3445.98ms router_forward:1 router_objective:-0.1614 router_entropy:0.9699
+step:4570/20000 router_probe window_steps:10 avg_depth:5.211 router_objective:-0.2452 router_entropy:0.9837
+step:4570/20000 router_matrix
+step:4570/20000 train_loss:2.1807 train_time:15745331ms step_avg:3445.37ms router_forward:1 router_objective:-0.1594 router_entropy:0.9913
+step:4580/20000 router_probe window_steps:10 avg_depth:5.275 router_objective:-0.2390 router_entropy:0.9841
+step:4580/20000 router_matrix
+step:4580/20000 train_loss:2.3350 train_time:15778754ms step_avg:3445.14ms router_forward:1 router_objective:-0.3347 router_entropy:0.9899
+step:4590/20000 router_probe window_steps:10 avg_depth:5.420 router_objective:-0.2608 router_entropy:0.9857
+step:4590/20000 router_matrix
+step:4590/20000 train_loss:2.2609 train_time:15811522ms step_avg:3444.78ms router_forward:1 router_objective:-0.1866 router_entropy:0.9922
+step:4600/20000 router_probe window_steps:10 avg_depth:5.300 router_objective:-0.2487 router_entropy:0.9842
+step:4600/20000 router_matrix
+step:4600/20000 train_loss:2.2528 train_time:15843480ms step_avg:3444.23ms router_forward:1 router_objective:-0.3030 router_entropy:0.9766
+step:4610/20000 router_probe window_steps:10 avg_depth:5.163 router_objective:-0.2133 router_entropy:0.9724
+step:4610/20000 router_matrix
+step:4610/20000 train_loss:2.2776 train_time:15874748ms step_avg:3443.55ms router_forward:1 router_objective:-0.2095 router_entropy:0.9997
+step:4620/20000 router_probe window_steps:10 avg_depth:5.813 router_objective:-0.3368 router_entropy:0.9905
+step:4620/20000 router_matrix
+step:4620/20000 train_loss:2.2367 train_time:15909381ms step_avg:3443.59ms router_forward:1 router_objective:-0.2224 router_entropy:0.9722
+step:4630/20000 router_probe window_steps:10 avg_depth:5.140 router_objective:-0.2608 router_entropy:0.9733
+step:4630/20000 router_matrix
+step:4630/20000 train_loss:2.2795 train_time:15940714ms step_avg:3442.92ms router_forward:1 router_objective:-0.2799 router_entropy:0.9795
+step:4640/20000 router_probe window_steps:10 avg_depth:5.166 router_objective:-0.2375 router_entropy:0.9760
+step:4640/20000 router_matrix
+step:4640/20000 train_loss:2.2438 train_time:15972130ms step_avg:3442.27ms router_forward:1 router_objective:-0.1791 router_entropy:0.9715
+step:4650/20000 router_probe window_steps:10 avg_depth:5.102 router_objective:-0.1733 router_entropy:0.9584
+step:4650/20000 router_matrix
+step:4650/20000 train_loss:2.3141 train_time:16003399ms step_avg:3441.59ms router_forward:1 router_objective:-0.2123 router_entropy:0.9459
+step:4660/20000 router_probe window_steps:10 avg_depth:5.332 router_objective:-0.2889 router_entropy:0.9761
+step:4660/20000 router_matrix
+step:4660/20000 train_loss:2.2979 train_time:16035716ms step_avg:3441.14ms router_forward:1 router_objective:-0.3519 router_entropy:1.0031
+step:4670/20000 router_probe window_steps:10 avg_depth:5.311 router_objective:-0.2377 router_entropy:0.9748
+step:4670/20000 router_matrix
+step:4670/20000 train_loss:2.2730 train_time:16067932ms step_avg:3440.67ms router_forward:1 router_objective:-0.2925 router_entropy:0.9595
+step:4680/20000 router_probe window_steps:10 avg_depth:5.075 router_objective:-0.2380 router_entropy:0.9756
+step:4680/20000 router_matrix
+step:4680/20000 train_loss:2.3126 train_time:16099015ms step_avg:3439.96ms router_forward:1 router_objective:-0.2453 router_entropy:0.9842
+step:4690/20000 router_probe window_steps:10 avg_depth:5.265 router_objective:-0.2620 router_entropy:0.9840
+step:4690/20000 router_matrix
+step:4690/20000 train_loss:2.2301 train_time:16130886ms step_avg:3439.42ms router_forward:1 router_objective:-0.1977 router_entropy:0.9707
+step:4700/20000 router_probe window_steps:10 avg_depth:5.008 router_objective:-0.2301 router_entropy:0.9663
+step:4700/20000 router_matrix
+step:4700/20000 train_loss:2.2946 train_time:16161513ms step_avg:3438.62ms router_forward:1 router_objective:-0.2585 router_entropy:0.9769
+step:4710/20000 router_probe window_steps:10 avg_depth:5.708 router_objective:-0.2790 router_entropy:0.9849
+step:4710/20000 router_matrix
+step:4710/20000 train_loss:2.2606 train_time:16197234ms step_avg:3438.90ms router_forward:1 router_objective:-0.2241 router_entropy:0.9601
+step:4720/20000 router_probe window_steps:10 avg_depth:6.101 router_objective:-0.2137 router_entropy:0.9562
+step:4720/20000 router_matrix
+step:4720/20000 train_loss:2.3930 train_time:16233455ms step_avg:3439.29ms router_forward:1 router_objective:-0.1850 router_entropy:0.9643
+step:4730/20000 router_probe window_steps:10 avg_depth:5.092 router_objective:-0.2408 router_entropy:0.9512
+step:4730/20000 router_matrix
+step:4730/20000 train_loss:2.3968 train_time:16264522ms step_avg:3438.59ms router_forward:1 router_objective:-0.2052 router_entropy:0.9403
+step:4740/20000 router_probe window_steps:10 avg_depth:5.277 router_objective:-0.2551 router_entropy:0.9745
+step:4740/20000 router_matrix
+step:4740/20000 train_loss:2.3786 train_time:16296866ms step_avg:3438.16ms router_forward:1 router_objective:-0.2926 router_entropy:0.9968
+step:4750/20000 router_probe window_steps:10 avg_depth:5.337 router_objective:-0.2394 router_entropy:0.9857
+step:4750/20000 router_matrix
+step:4750/20000 train_loss:2.3486 train_time:16329275ms step_avg:3437.74ms router_forward:1 router_objective:-0.1931 router_entropy:0.9810
+step:4760/20000 router_probe window_steps:10 avg_depth:5.272 router_objective:-0.2389 router_entropy:0.9842
+step:4760/20000 router_matrix
+step:4760/20000 train_loss:2.3159 train_time:16361371ms step_avg:3437.26ms router_forward:1 router_objective:-0.2909 router_entropy:1.0018
+step:4770/20000 router_probe window_steps:10 avg_depth:5.364 router_objective:-0.2395 router_entropy:0.9901
+step:4770/20000 router_matrix
+step:4770/20000 train_loss:2.2726 train_time:16394013ms step_avg:3436.90ms router_forward:1 router_objective:-0.2083 router_entropy:0.9881
+step:4780/20000 router_probe window_steps:10 avg_depth:5.299 router_objective:-0.2460 router_entropy:0.9860
+step:4780/20000 router_matrix
+step:4780/20000 train_loss:2.2766 train_time:16426104ms step_avg:3436.42ms router_forward:1 router_objective:-0.2350 router_entropy:0.9802
+step:4790/20000 router_probe window_steps:10 avg_depth:5.003 router_objective:-0.1852 router_entropy:0.9700
+step:4790/20000 router_matrix
+step:4790/20000 train_loss:2.3142 train_time:16456595ms step_avg:3435.61ms router_forward:1 router_objective:-0.2616 router_entropy:0.9702
+step:4800/20000 router_probe window_steps:10 avg_depth:5.601 router_objective:-0.2966 router_entropy:0.9876
+step:4800/20000 router_matrix
+step:4800/20000 train_loss:2.4189 train_time:16490416ms step_avg:3435.50ms router_forward:1 router_objective:-0.2988 router_entropy:0.9984
+step:4810/20000 router_probe window_steps:10 avg_depth:5.165 router_objective:-0.2366 router_entropy:0.9779
+step:4810/20000 router_matrix
+step:4810/20000 train_loss:2.3270 train_time:16521903ms step_avg:3434.91ms router_forward:1 router_objective:-0.3378 router_entropy:0.9788
+step:4820/20000 router_probe window_steps:10 avg_depth:4.966 router_objective:-0.2574 router_entropy:0.9525
+step:4820/20000 router_matrix
+step:4820/20000 train_loss:2.3054 train_time:16552254ms step_avg:3434.08ms router_forward:1 router_objective:-0.2227 router_entropy:0.9522
+step:4830/20000 router_probe window_steps:10 avg_depth:5.261 router_objective:-0.2570 router_entropy:0.9870
+step:4830/20000 router_matrix
+step:4830/20000 train_loss:2.3286 train_time:16584267ms step_avg:3433.60ms router_forward:1 router_objective:-0.3622 router_entropy:0.9967
+step:4840/20000 router_probe window_steps:10 avg_depth:5.213 router_objective:-0.2439 router_entropy:0.9782
+step:4840/20000 router_matrix
+step:4840/20000 train_loss:2.2560 train_time:16618082ms step_avg:3433.49ms router_forward:1 router_objective:-0.2202 router_entropy:0.9682
+step:4850/20000 router_probe window_steps:10 avg_depth:5.140 router_objective:-0.2288 router_entropy:0.9799
+step:4850/20000 router_matrix
+step:4850/20000 train_loss:2.2909 train_time:16649665ms step_avg:3432.92ms router_forward:1 router_objective:-0.1713 router_entropy:0.9823
+step:4860/20000 router_probe window_steps:10 avg_depth:5.283 router_objective:-0.2375 router_entropy:0.9808
+step:4860/20000 router_matrix
+step:4860/20000 train_loss:2.3076 train_time:16681766ms step_avg:3432.46ms router_forward:1 router_objective:-0.1980 router_entropy:0.9832
+step:4870/20000 router_probe window_steps:10 avg_depth:5.330 router_objective:-0.2342 router_entropy:0.9871
+step:4870/20000 router_matrix
+step:4870/20000 train_loss:2.3159 train_time:16714214ms step_avg:3432.08ms router_forward:1 router_objective:-0.2850 router_entropy:0.9713
+step:4880/20000 router_probe window_steps:10 avg_depth:5.528 router_objective:-0.2587 router_entropy:0.9841
+step:4880/20000 router_matrix
+step:4880/20000 train_loss:2.2874 train_time:16747450ms step_avg:3431.85ms router_forward:1 router_objective:-0.2277 router_entropy:0.9815
+step:4890/20000 router_probe window_steps:10 avg_depth:5.240 router_objective:-0.2169 router_entropy:0.9708
+step:4890/20000 router_matrix
+step:4890/20000 train_loss:2.2349 train_time:16779080ms step_avg:3431.30ms router_forward:1 router_objective:-0.1469 router_entropy:0.9789
+step:4900/20000 router_probe window_steps:10 avg_depth:5.293 router_objective:-0.2481 router_entropy:0.9829
+step:4900/20000 router_matrix
+step:4900/20000 train_loss:2.2915 train_time:16811168ms step_avg:3430.85ms router_forward:1 router_objective:-0.2163 router_entropy:0.9813
+step:4910/20000 router_probe window_steps:10 avg_depth:5.337 router_objective:-0.2210 router_entropy:0.9839
+step:4910/20000 router_matrix
+step:4910/20000 train_loss:2.2640 train_time:16843386ms step_avg:3430.42ms router_forward:1 router_objective:-0.2545 router_entropy:0.9882
+step:4920/20000 router_probe window_steps:10 avg_depth:5.211 router_objective:-0.2241 router_entropy:0.9792
+step:4920/20000 router_matrix
+step:4920/20000 train_loss:2.2797 train_time:16875120ms step_avg:3429.90ms router_forward:1 router_objective:-0.1214 router_entropy:0.9628
+step:4930/20000 router_probe window_steps:10 avg_depth:5.947 router_objective:-0.2420 router_entropy:0.9815
+step:4930/20000 router_matrix
+step:4930/20000 train_loss:2.3202 train_time:16911121ms step_avg:3430.25ms router_forward:1 router_objective:-0.1280 router_entropy:0.9598
+step:4940/20000 router_probe window_steps:10 avg_depth:5.282 router_objective:-0.2131 router_entropy:0.9802
+step:4940/20000 router_matrix
+step:4940/20000 train_loss:2.2867 train_time:16943367ms step_avg:3429.83ms router_forward:1 router_objective:-0.2806 router_entropy:0.9889
+step:4950/20000 router_probe window_steps:10 avg_depth:5.203 router_objective:-0.2250 router_entropy:0.9858
+step:4950/20000 router_matrix
+step:4950/20000 train_loss:2.3400 train_time:16975023ms step_avg:3429.30ms router_forward:1 router_objective:-0.2508 router_entropy:0.9817
+step:4960/20000 router_probe window_steps:10 avg_depth:5.142 router_objective:-0.2447 router_entropy:0.9641
+step:4960/20000 router_matrix
+step:4960/20000 train_loss:2.3367 train_time:17008312ms step_avg:3429.10ms router_forward:1 router_objective:-0.2590 router_entropy:0.9488
+step:4970/20000 router_probe window_steps:10 avg_depth:5.050 router_objective:-0.2100 router_entropy:0.9654
+step:4970/20000 router_matrix
+step:4970/20000 train_loss:2.3126 train_time:17039392ms step_avg:3428.45ms router_forward:1 router_objective:-0.0718 router_entropy:0.9644
+step:4980/20000 router_probe window_steps:10 avg_depth:5.473 router_objective:-0.2300 router_entropy:0.9854
+step:4980/20000 router_matrix
+step:4980/20000 train_loss:2.4289 train_time:17072789ms step_avg:3428.27ms router_forward:1 router_objective:-0.2083 router_entropy:0.9603
+step:4990/20000 router_probe window_steps:10 avg_depth:5.053 router_objective:-0.2417 router_entropy:0.9517
+step:4990/20000 router_matrix
+step:4990/20000 train_loss:2.2549 train_time:17104009ms step_avg:3427.66ms router_forward:1 router_objective:-0.2886 router_entropy:0.9787
+step:5000/20000 router_probe window_steps:10 avg_depth:5.469 router_objective:-0.2431 router_entropy:0.9886
+step:5000/20000 router_matrix
+step:5000/20000 train_loss:2.3093 train_time:17137084ms step_avg:3427.42ms router_forward:1 router_objective:-0.2686 router_entropy:0.9953
+step:5010/20000 router_probe window_steps:10 avg_depth:5.353 router_objective:-0.2482 router_entropy:0.9796
+step:5010/20000 router_matrix
+step:5010/20000 train_loss:2.1916 train_time:17169671ms step_avg:3427.08ms router_forward:1 router_objective:-0.2789 router_entropy:0.9634
+step:5020/20000 router_probe window_steps:10 avg_depth:5.352 router_objective:-0.2228 router_entropy:0.9861
+step:5020/20000 router_matrix
+step:5020/20000 train_loss:2.3004 train_time:17202386ms step_avg:3426.77ms router_forward:1 router_objective:-0.1998 router_entropy:0.9851
+step:5030/20000 router_probe window_steps:10 avg_depth:5.240 router_objective:-0.2686 router_entropy:0.9715
+step:5030/20000 router_matrix
+step:5030/20000 train_loss:2.3264 train_time:17234675ms step_avg:3426.38ms router_forward:1 router_objective:-0.2897 router_entropy:0.9531
+step:5040/20000 router_probe window_steps:10 avg_depth:5.591 router_objective:-0.2658 router_entropy:0.9773
+step:5040/20000 router_matrix
+step:5040/20000 train_loss:2.2815 train_time:17269288ms step_avg:3426.45ms router_forward:1 router_objective:-0.3221 router_entropy:0.9884
+step:5050/20000 router_probe window_steps:10 avg_depth:5.312 router_objective:-0.2228 router_entropy:0.9819
+step:5050/20000 router_matrix
+step:5050/20000 train_loss:2.2467 train_time:17302100ms step_avg:3426.16ms router_forward:1 router_objective:-0.2337 router_entropy:0.9591
+step:5060/20000 router_probe window_steps:10 avg_depth:5.172 router_objective:-0.0962 router_entropy:0.9661
+step:5060/20000 router_matrix
+step:5060/20000 train_loss:2.3202 train_time:17334141ms step_avg:3425.72ms router_forward:1 router_objective:-0.0051 router_entropy:0.9681
+step:5070/20000 router_probe window_steps:10 avg_depth:5.141 router_objective:-0.1784 router_entropy:0.9824
+step:5070/20000 router_matrix
+step:5070/20000 train_loss:2.2461 train_time:17365515ms step_avg:3425.15ms router_forward:1 router_objective:-0.2731 router_entropy:1.0007
+step:5080/20000 router_probe window_steps:10 avg_depth:5.202 router_objective:-0.2596 router_entropy:0.9700
+step:5080/20000 router_matrix
+step:5080/20000 train_loss:2.2771 train_time:17397475ms step_avg:3424.70ms router_forward:1 router_objective:-0.1712 router_entropy:0.9443
+step:5090/20000 router_probe window_steps:10 avg_depth:5.457 router_objective:-0.2804 router_entropy:0.9775
+step:5090/20000 router_matrix
+step:5090/20000 train_loss:2.3110 train_time:17432529ms step_avg:3424.86ms router_forward:1 router_objective:-0.2282 router_entropy:0.9943
+step:5100/20000 router_probe window_steps:10 avg_depth:5.176 router_objective:-0.2028 router_entropy:0.9767
+step:5100/20000 router_matrix
+step:5100/20000 train_loss:2.3205 train_time:17464523ms step_avg:3424.42ms router_forward:1 router_objective:-0.1953 router_entropy:0.9717
+step:5110/20000 router_probe window_steps:10 avg_depth:5.256 router_objective:-0.2517 router_entropy:0.9538
+step:5110/20000 router_matrix
+step:5110/20000 train_loss:2.3321 train_time:17496505ms step_avg:3423.97ms router_forward:1 router_objective:-0.3106 router_entropy:0.9659
+step:5120/20000 router_probe window_steps:10 avg_depth:5.440 router_objective:-0.2471 router_entropy:0.9901
+step:5120/20000 router_matrix
+step:5120/20000 train_loss:2.2911 train_time:17529469ms step_avg:3423.72ms router_forward:1 router_objective:-0.2427 router_entropy:0.9843
+step:5130/20000 router_probe window_steps:10 avg_depth:5.364 router_objective:-0.2419 router_entropy:0.9840
+step:5130/20000 router_matrix
+step:5130/20000 train_loss:2.2323 train_time:17561954ms step_avg:3423.38ms router_forward:1 router_objective:-0.2118 router_entropy:0.9748
+step:5140/20000 router_probe window_steps:10 avg_depth:5.160 router_objective:-0.2401 router_entropy:0.9768
+step:5140/20000 router_matrix
+step:5140/20000 train_loss:2.2903 train_time:17593379ms step_avg:3422.84ms router_forward:1 router_objective:-0.2047 router_entropy:0.9733
+step:5150/20000 router_probe window_steps:10 avg_depth:5.122 router_objective:-0.2044 router_entropy:0.9566
+step:5150/20000 router_matrix
+step:5150/20000 train_loss:2.2697 train_time:17624554ms step_avg:3422.24ms router_forward:1 router_objective:-0.2530 router_entropy:0.9287
+step:5160/20000 router_probe window_steps:10 avg_depth:5.457 router_objective:-0.2884 router_entropy:0.9721
+step:5160/20000 router_matrix
+step:5160/20000 train_loss:2.3306 train_time:17657354ms step_avg:3421.97ms router_forward:1 router_objective:-0.3620 router_entropy:0.9964
+step:5170/20000 router_probe window_steps:10 avg_depth:4.837 router_objective:-0.2052 router_entropy:0.9603
+step:5170/20000 router_matrix
+step:5170/20000 train_loss:2.2495 train_time:17687149ms step_avg:3421.11ms router_forward:1 router_objective:-0.1785 router_entropy:0.9585
+step:5180/20000 router_probe window_steps:10 avg_depth:5.558 router_objective:-0.2608 router_entropy:0.9805
+step:5180/20000 router_matrix
+step:5180/20000 train_loss:2.2437 train_time:17720931ms step_avg:3421.03ms router_forward:1 router_objective:-0.2231 router_entropy:0.9949
+step:5190/20000 router_probe window_steps:10 avg_depth:5.060 router_objective:-0.2472 router_entropy:0.9724
+step:5190/20000 router_matrix
+step:5190/20000 train_loss:2.1948 train_time:17752104ms step_avg:3420.44ms router_forward:1 router_objective:-0.2786 router_entropy:0.9638
+step:5200/20000 router_probe window_steps:10 avg_depth:5.093 router_objective:-0.1951 router_entropy:0.9618
+step:5200/20000 router_matrix
+step:5200/20000 train_loss:2.2677 train_time:17783314ms step_avg:3419.87ms router_forward:1 router_objective:-0.1608 router_entropy:0.9452
+step:5210/20000 router_probe window_steps:10 avg_depth:5.414 router_objective:-0.2672 router_entropy:0.9811
+step:5210/20000 router_matrix
+step:5210/20000 train_loss:2.3071 train_time:17816379ms step_avg:3419.65ms router_forward:1 router_objective:-0.3073 router_entropy:0.9918
+step:5220/20000 router_probe window_steps:10 avg_depth:5.067 router_objective:-0.2315 router_entropy:0.9709
+step:5220/20000 router_matrix
+step:5220/20000 train_loss:2.2657 train_time:17848092ms step_avg:3419.17ms router_forward:1 router_objective:-0.2155 router_entropy:0.9644
+step:5230/20000 router_probe window_steps:10 avg_depth:5.456 router_objective:-0.0234 router_entropy:0.9676
+step:5230/20000 router_matrix
+step:5230/20000 train_loss:2.4950 train_time:17881215ms step_avg:3418.97ms router_forward:1 router_objective:0.8179 router_entropy:0.8916
+step:5240/20000 router_probe window_steps:10 avg_depth:4.980 router_objective:-0.1311 router_entropy:0.8609
+step:5240/20000 router_matrix
+step:5240/20000 train_loss:2.3063 train_time:17911699ms step_avg:3418.26ms router_forward:1 router_objective:-0.1811 router_entropy:0.9081
+step:5250/20000 router_probe window_steps:10 avg_depth:5.245 router_objective:-0.2210 router_entropy:0.9446
+step:5250/20000 router_matrix
+step:5250/20000 train_loss:2.3432 train_time:17943525ms step_avg:3417.81ms router_forward:1 router_objective:-0.2121 router_entropy:0.9761
+step:5260/20000 router_probe window_steps:10 avg_depth:5.342 router_objective:-0.2077 router_entropy:0.9839
+step:5260/20000 router_matrix
+step:5260/20000 train_loss:2.2861 train_time:17975946ms step_avg:3417.48ms router_forward:1 router_objective:-0.2933 router_entropy:0.9905
+step:5270/20000 router_probe window_steps:10 avg_depth:5.073 router_objective:-0.2538 router_entropy:0.9604
+step:5270/20000 router_matrix
+step:5270/20000 train_loss:2.2932 train_time:18007298ms step_avg:3416.94ms router_forward:1 router_objective:-0.2867 router_entropy:0.9483
+step:5280/20000 router_probe window_steps:10 avg_depth:5.421 router_objective:-0.2215 router_entropy:0.9864
+step:5280/20000 router_matrix
+step:5280/20000 train_loss:2.2342 train_time:18040513ms step_avg:3416.76ms router_forward:1 router_objective:-0.1522 router_entropy:0.9918
+step:5290/20000 router_probe window_steps:10 avg_depth:5.255 router_objective:-0.2397 router_entropy:0.9691
+step:5290/20000 router_matrix
+step:5290/20000 train_loss:2.2879 train_time:18072763ms step_avg:3416.40ms router_forward:1 router_objective:-0.2441 router_entropy:0.9673
+step:5300/20000 router_probe window_steps:10 avg_depth:5.730 router_objective:-0.2433 router_entropy:0.9950
+step:5300/20000 router_matrix
+step:5300/20000 train_loss:2.2683 train_time:18107407ms step_avg:3416.49ms router_forward:1 router_objective:-0.3425 router_entropy:0.9972
+step:5310/20000 router_probe window_steps:10 avg_depth:5.144 router_objective:-0.2175 router_entropy:0.9782
+step:5310/20000 router_matrix
+step:5310/20000 train_loss:2.3135 train_time:18139013ms step_avg:3416.01ms router_forward:1 router_objective:-0.1049 router_entropy:0.9672
+step:5320/20000 router_probe window_steps:10 avg_depth:5.299 router_objective:-0.2328 router_entropy:0.9805
+step:5320/20000 router_matrix
+step:5320/20000 train_loss:2.2675 train_time:18171681ms step_avg:3415.73ms router_forward:1 router_objective:-0.2375 router_entropy:0.9956
+step:5330/20000 router_probe window_steps:10 avg_depth:5.396 router_objective:-0.2364 router_entropy:0.9803
+step:5330/20000 router_matrix
+step:5330/20000 train_loss:2.2331 train_time:18204523ms step_avg:3415.48ms router_forward:1 router_objective:-0.3536 router_entropy:0.9933
+step:5340/20000 router_probe window_steps:10 avg_depth:5.536 router_objective:-0.2846 router_entropy:0.9907
+step:5340/20000 router_matrix
+step:5340/20000 train_loss:2.3538 train_time:18238168ms step_avg:3415.39ms router_forward:1 router_objective:-0.2799 router_entropy:0.9912
+step:5350/20000 router_probe window_steps:10 avg_depth:5.073 router_objective:-0.1555 router_entropy:0.9646
+step:5350/20000 router_matrix
+step:5350/20000 train_loss:2.2434 train_time:18273040ms step_avg:3415.52ms router_forward:1 router_objective:-0.2309 router_entropy:0.9749
+step:5360/20000 router_probe window_steps:10 avg_depth:5.487 router_objective:-0.2370 router_entropy:0.9703
+step:5360/20000 router_matrix
+step:5360/20000 train_loss:2.3411 train_time:18307134ms step_avg:3415.51ms router_forward:1 router_objective:-0.2056 router_entropy:0.9635
+step:5370/20000 router_probe window_steps:10 avg_depth:5.316 router_objective:-0.2678 router_entropy:0.9818
+step:5370/20000 router_matrix
+step:5370/20000 train_loss:2.2584 train_time:18339970ms step_avg:3415.26ms router_forward:1 router_objective:-0.2594 router_entropy:0.9902
+step:5380/20000 router_probe window_steps:10 avg_depth:5.222 router_objective:-0.2407 router_entropy:0.9508
+step:5380/20000 router_matrix
+step:5380/20000 train_loss:2.2877 train_time:18372557ms step_avg:3414.97ms router_forward:1 router_objective:-0.2752 router_entropy:0.9440
+step:5390/20000 router_probe window_steps:10 avg_depth:6.098 router_objective:-0.2740 router_entropy:0.9874
+step:5390/20000 router_matrix
+step:5390/20000 train_loss:2.3223 train_time:18409070ms step_avg:3415.41ms router_forward:1 router_objective:-0.2025 router_entropy:0.9907
+step:5400/20000 router_probe window_steps:10 avg_depth:5.834 router_objective:-0.2237 router_entropy:0.9671
+step:5400/20000 router_matrix
+step:5400/20000 train_loss:2.2823 train_time:18444446ms step_avg:3415.64ms router_forward:1 router_objective:-0.2740 router_entropy:0.9719
+step:5410/20000 router_probe window_steps:10 avg_depth:5.465 router_objective:-0.2503 router_entropy:0.9832
+step:5410/20000 router_matrix
+step:5410/20000 train_loss:2.3316 train_time:18477839ms step_avg:3415.50ms router_forward:1 router_objective:-0.2718 router_entropy:0.9862
+step:5420/20000 router_probe window_steps:10 avg_depth:5.054 router_objective:-0.2249 router_entropy:0.9674
+step:5420/20000 router_matrix
+step:5420/20000 train_loss:2.2900 train_time:18509171ms step_avg:3414.98ms router_forward:1 router_objective:-0.2121 router_entropy:0.9638
+step:5430/20000 router_probe window_steps:10 avg_depth:5.265 router_objective:-0.2412 router_entropy:0.9767
+step:5430/20000 router_matrix
+step:5430/20000 train_loss:2.3199 train_time:18541744ms step_avg:3414.69ms router_forward:1 router_objective:-0.1969 router_entropy:0.9793
+step:5440/20000 router_probe window_steps:10 avg_depth:5.550 router_objective:-0.2535 router_entropy:0.9836
+step:5440/20000 router_matrix
+step:5440/20000 train_loss:2.3312 train_time:18575596ms step_avg:3414.63ms router_forward:1 router_objective:-0.2718 router_entropy:0.9796
+step:5450/20000 router_probe window_steps:10 avg_depth:5.643 router_objective:-0.0946 router_entropy:0.9816
+step:5450/20000 router_matrix
+step:5450/20000 train_loss:2.2994 train_time:18609935ms step_avg:3414.67ms router_forward:1 router_objective:-0.0494 router_entropy:0.9911
+step:5460/20000 router_probe window_steps:10 avg_depth:5.104 router_objective:-0.1882 router_entropy:0.9765
+step:5460/20000 router_matrix
+step:5460/20000 train_loss:2.3082 train_time:18641618ms step_avg:3414.22ms router_forward:1 router_objective:-0.3290 router_entropy:0.9874
+step:5470/20000 router_probe window_steps:10 avg_depth:5.910 router_objective:-0.2109 router_entropy:0.9606
+step:5470/20000 router_matrix
+step:5470/20000 train_loss:2.3064 train_time:18681757ms step_avg:3415.31ms router_forward:1 router_objective:-0.2049 router_entropy:0.9766
+step:5480/20000 router_probe window_steps:10 avg_depth:5.245 router_objective:-0.2546 router_entropy:0.9846
+step:5480/20000 router_matrix
+step:5480/20000 train_loss:2.3530 train_time:18714141ms step_avg:3414.99ms router_forward:1 router_objective:-0.2261 router_entropy:0.9958
+step:5490/20000 router_probe window_steps:10 avg_depth:5.408 router_objective:-0.2043 router_entropy:0.9859
+step:5490/20000 router_matrix
+step:5490/20000 train_loss:2.3635 train_time:18747198ms step_avg:3414.79ms router_forward:1 router_objective:-0.2058 router_entropy:0.9721
+step:5500/20000 router_probe window_steps:10 avg_depth:5.254 router_objective:-0.2459 router_entropy:0.9707
+step:5500/20000 router_matrix
+step:5500/20000 train_loss:2.3111 train_time:18779702ms step_avg:3414.49ms router_forward:1 router_objective:-0.1889 router_entropy:0.9936
+step:5510/20000 router_probe window_steps:10 avg_depth:5.324 router_objective:-0.2487 router_entropy:0.9911
+step:5510/20000 router_matrix
+step:5510/20000 train_loss:2.2313 train_time:18812588ms step_avg:3414.26ms router_forward:1 router_objective:-0.2500 router_entropy:0.9887
+step:5520/20000 router_probe window_steps:10 avg_depth:5.566 router_objective:-0.1857 router_entropy:0.9942
+step:5520/20000 router_matrix
+step:5520/20000 train_loss:2.2464 train_time:18846824ms step_avg:3414.28ms router_forward:1 router_objective:-0.1975 router_entropy:0.9831
+step:5530/20000 router_probe window_steps:10 avg_depth:5.336 router_objective:-0.2316 router_entropy:0.9645
+step:5530/20000 router_matrix
+step:5530/20000 train_loss:2.2229 train_time:18879489ms step_avg:3414.01ms router_forward:1 router_objective:-0.2329 router_entropy:0.9601
+step:5540/20000 router_probe window_steps:10 avg_depth:5.112 router_objective:-0.2152 router_entropy:0.9803
+step:5540/20000 router_matrix
+step:5540/20000 train_loss:2.3123 train_time:18911096ms step_avg:3413.56ms router_forward:1 router_objective:-0.2263 router_entropy:0.9853
+step:5550/20000 router_probe window_steps:10 avg_depth:5.327 router_objective:-0.2409 router_entropy:0.9805
+step:5550/20000 router_matrix
+step:5550/20000 train_loss:2.2516 train_time:18943829ms step_avg:3413.30ms router_forward:1 router_objective:-0.2991 router_entropy:0.9876
+step:5560/20000 router_probe window_steps:10 avg_depth:5.448 router_objective:-0.2325 router_entropy:0.9878
+step:5560/20000 router_matrix
+step:5560/20000 train_loss:2.2585 train_time:18976999ms step_avg:3413.13ms router_forward:1 router_objective:-0.2312 router_entropy:0.9674
+step:5570/20000 router_probe window_steps:10 avg_depth:5.301 router_objective:-0.2401 router_entropy:0.9783
+step:5570/20000 router_matrix
+step:5570/20000 train_loss:2.2426 train_time:19010017ms step_avg:3412.93ms router_forward:1 router_objective:-0.2412 router_entropy:0.9899
+step:5580/20000 router_probe window_steps:10 avg_depth:5.477 router_objective:-0.2524 router_entropy:0.9907
+step:5580/20000 router_matrix
+step:5580/20000 train_loss:2.2585 train_time:19043941ms step_avg:3412.89ms router_forward:1 router_objective:-0.2522 router_entropy:0.9752
+step:5590/20000 router_probe window_steps:10 avg_depth:5.519 router_objective:-0.2312 router_entropy:0.9818
+step:5590/20000 router_matrix
+step:5590/20000 train_loss:2.2519 train_time:19078238ms step_avg:3412.92ms router_forward:1 router_objective:-0.2841 router_entropy:0.9931
+step:5600/20000 router_probe window_steps:10 avg_depth:5.607 router_objective:-0.2451 router_entropy:0.9883
+step:5600/20000 router_matrix
+step:5600/20000 train_loss:2.2383 train_time:19115377ms step_avg:3413.46ms router_forward:1 router_objective:-0.3168 router_entropy:0.9830
+step:5610/20000 router_probe window_steps:10 avg_depth:5.480 router_objective:-0.2132 router_entropy:0.9726
+step:5610/20000 router_matrix
+step:5610/20000 train_loss:2.3342 train_time:19149128ms step_avg:3413.39ms router_forward:1 router_objective:-0.2261 router_entropy:0.9877
+step:5620/20000 router_probe window_steps:10 avg_depth:5.355 router_objective:-0.2659 router_entropy:0.9660
+step:5620/20000 router_matrix
+step:5620/20000 train_loss:2.2713 train_time:19182205ms step_avg:3413.20ms router_forward:1 router_objective:-0.2477 router_entropy:0.9373
+step:5630/20000 router_probe window_steps:10 avg_depth:5.516 router_objective:-0.2594 router_entropy:0.9648
+step:5630/20000 router_matrix
+step:5630/20000 train_loss:2.3469 train_time:19216115ms step_avg:3413.16ms router_forward:1 router_objective:-0.1064 router_entropy:0.9890
+step:5640/20000 router_probe window_steps:10 avg_depth:5.152 router_objective:-0.2380 router_entropy:0.9784
+step:5640/20000 router_matrix
+step:5640/20000 train_loss:2.2990 train_time:19248616ms step_avg:3412.88ms router_forward:1 router_objective:-0.2305 router_entropy:0.9733
+step:5650/20000 router_probe window_steps:10 avg_depth:5.613 router_objective:-0.2984 router_entropy:0.9981
+step:5650/20000 router_matrix
+step:5650/20000 train_loss:2.2416 train_time:19282815ms step_avg:3412.89ms router_forward:1 router_objective:-0.1808 router_entropy:0.9992
+step:5660/20000 router_probe window_steps:10 avg_depth:5.187 router_objective:-0.2502 router_entropy:0.9768
+step:5660/20000 router_matrix
+step:5660/20000 train_loss:2.2415 train_time:19314823ms step_avg:3412.51ms router_forward:1 router_objective:-0.2113 router_entropy:0.9580
+step:5670/20000 router_probe window_steps:10 avg_depth:5.272 router_objective:-0.2396 router_entropy:0.9733
+step:5670/20000 router_matrix
+step:5670/20000 train_loss:2.2477 train_time:19347421ms step_avg:3412.24ms router_forward:1 router_objective:-0.2611 router_entropy:0.9884
+step:5680/20000 router_probe window_steps:10 avg_depth:5.162 router_objective:-0.2310 router_entropy:0.9756
+step:5680/20000 router_matrix
+step:5680/20000 train_loss:2.3075 train_time:19379693ms step_avg:3411.92ms router_forward:1 router_objective:-0.2410 router_entropy:0.9473
+step:5690/20000 router_probe window_steps:10 avg_depth:4.996 router_objective:-0.2224 router_entropy:0.9482
+step:5690/20000 router_matrix
+step:5690/20000 train_loss:2.2405 train_time:19410654ms step_avg:3411.36ms router_forward:1 router_objective:-0.2813 router_entropy:0.9646
+step:5700/20000 router_probe window_steps:10 avg_depth:5.960 router_objective:-0.3139 router_entropy:0.9896
+step:5700/20000 router_matrix
+step:5700/20000 train_loss:2.3118 train_time:19446765ms step_avg:3411.71ms router_forward:1 router_objective:-0.3354 router_entropy:0.9987
+step:5710/20000 router_probe window_steps:10 avg_depth:5.183 router_objective:-0.1912 router_entropy:0.9792
+step:5710/20000 router_matrix
+step:5710/20000 train_loss:2.2935 train_time:19478480ms step_avg:3411.29ms router_forward:1 router_objective:-0.2676 router_entropy:0.9706
+step:5720/20000 router_probe window_steps:10 avg_depth:5.508 router_objective:-0.2446 router_entropy:0.9805
+step:5720/20000 router_matrix
+step:5720/20000 train_loss:2.2463 train_time:19512214ms step_avg:3411.23ms router_forward:1 router_objective:-0.1782 router_entropy:0.9691
+step:5730/20000 router_probe window_steps:10 avg_depth:5.509 router_objective:-0.2330 router_entropy:0.9811
+step:5730/20000 router_matrix
+step:5730/20000 train_loss:2.2517 train_time:19547314ms step_avg:3411.40ms router_forward:1 router_objective:-0.1538 router_entropy:0.9520
+step:5740/20000 router_probe window_steps:10 avg_depth:4.870 router_objective:-0.2039 router_entropy:0.9614
+step:5740/20000 router_matrix
+step:5740/20000 train_loss:2.2347 train_time:19577701ms step_avg:3410.75ms router_forward:1 router_objective:-0.3009 router_entropy:0.9854
+step:5750/20000 router_probe window_steps:10 avg_depth:5.596 router_objective:-0.2518 router_entropy:0.9878
+step:5750/20000 router_matrix
+step:5750/20000 train_loss:2.2990 train_time:19611534ms step_avg:3410.70ms router_forward:1 router_objective:-0.2035 router_entropy:0.9748
+step:5760/20000 router_probe window_steps:10 avg_depth:5.259 router_objective:-0.2280 router_entropy:0.9829
+step:5760/20000 router_matrix
+step:5760/20000 train_loss:2.2372 train_time:19643882ms step_avg:3410.40ms router_forward:1 router_objective:-0.2598 router_entropy:0.9960
+step:5770/20000 router_probe window_steps:10 avg_depth:5.369 router_objective:-0.2339 router_entropy:0.9762
+step:5770/20000 router_matrix
+step:5770/20000 train_loss:2.3021 train_time:19677003ms step_avg:3410.23ms router_forward:1 router_objective:-0.1625 router_entropy:0.9823
+step:5780/20000 router_probe window_steps:10 avg_depth:5.526 router_objective:-0.2436 router_entropy:0.9875
+step:5780/20000 router_matrix
+step:5780/20000 train_loss:2.2824 train_time:19710423ms step_avg:3410.11ms router_forward:1 router_objective:-0.1780 router_entropy:0.9684
+step:5790/20000 router_probe window_steps:10 avg_depth:5.512 router_objective:-0.2298 router_entropy:0.9804
+step:5790/20000 router_matrix
+step:5790/20000 train_loss:2.2600 train_time:19744016ms step_avg:3410.02ms router_forward:1 router_objective:-0.2068 router_entropy:0.9857
+step:5800/20000 router_probe window_steps:10 avg_depth:5.430 router_objective:-0.2380 router_entropy:0.9766
+step:5800/20000 router_matrix
+step:5800/20000 train_loss:2.2428 train_time:19777540ms step_avg:3409.92ms router_forward:1 router_objective:-0.2045 router_entropy:0.9584
+step:5810/20000 router_probe window_steps:10 avg_depth:5.501 router_objective:-0.2265 router_entropy:0.9812
+step:5810/20000 router_matrix
+step:5810/20000 train_loss:2.2677 train_time:19810701ms step_avg:3409.76ms router_forward:1 router_objective:-0.2508 router_entropy:0.9964
+step:5820/20000 router_probe window_steps:10 avg_depth:5.618 router_objective:-0.2355 router_entropy:0.9895
+step:5820/20000 router_matrix
+step:5820/20000 train_loss:2.2603 train_time:19844496ms step_avg:3409.71ms router_forward:1 router_objective:-0.2706 router_entropy:0.9919
+step:5830/20000 router_probe window_steps:10 avg_depth:5.243 router_objective:-0.2513 router_entropy:0.9702
+step:5830/20000 router_matrix
+step:5830/20000 train_loss:2.2980 train_time:19876215ms step_avg:3409.30ms router_forward:1 router_objective:-0.1835 router_entropy:0.9500
+step:5840/20000 router_probe window_steps:10 avg_depth:5.572 router_objective:-0.2472 router_entropy:0.9840
+step:5840/20000 router_matrix
+step:5840/20000 train_loss:2.2754 train_time:19909613ms step_avg:3409.18ms router_forward:1 router_objective:-0.2037 router_entropy:0.9661
+step:5850/20000 router_probe window_steps:10 avg_depth:5.133 router_objective:-0.2295 router_entropy:0.9732
+step:5850/20000 router_matrix
+step:5850/20000 train_loss:2.2406 train_time:19949375ms step_avg:3410.15ms router_forward:1 router_objective:-0.2021 router_entropy:0.9717
+step:5860/20000 router_probe window_steps:10 avg_depth:5.791 router_objective:-0.2438 router_entropy:0.9857
+step:5860/20000 router_matrix
+step:5860/20000 train_loss:2.2896 train_time:19984323ms step_avg:3410.29ms router_forward:1 router_objective:-0.2673 router_entropy:0.9882
+step:5870/20000 router_probe window_steps:10 avg_depth:5.322 router_objective:-0.2323 router_entropy:0.9785
+step:5870/20000 router_matrix
+step:5870/20000 train_loss:2.2560 train_time:20016371ms step_avg:3409.94ms router_forward:1 router_objective:-0.3018 router_entropy:0.9772
+step:5880/20000 router_probe window_steps:10 avg_depth:5.420 router_objective:-0.2583 router_entropy:0.9853
+step:5880/20000 router_matrix
+step:5880/20000 train_loss:2.2658 train_time:20049029ms step_avg:3409.70ms router_forward:1 router_objective:-0.3311 router_entropy:0.9880
+step:5890/20000 router_probe window_steps:10 avg_depth:5.200 router_objective:-0.2420 router_entropy:0.9720
+step:5890/20000 router_matrix
+step:5890/20000 train_loss:2.2489 train_time:20080631ms step_avg:3409.28ms router_forward:1 router_objective:-0.2128 router_entropy:0.9501
+step:5900/20000 router_probe window_steps:10 avg_depth:5.731 router_objective:-0.2442 router_entropy:0.9830
+step:5900/20000 router_matrix
+step:5900/20000 train_loss:2.2610 train_time:20114836ms step_avg:3409.29ms router_forward:1 router_objective:-0.2747 router_entropy:0.9893
+step:5910/20000 router_probe window_steps:10 avg_depth:5.488 router_objective:-0.2340 router_entropy:0.9789
+step:5910/20000 router_matrix
+step:5910/20000 train_loss:2.2520 train_time:20147616ms step_avg:3409.07ms router_forward:1 router_objective:-0.1629 router_entropy:0.9753
+step:5920/20000 router_probe window_steps:10 avg_depth:5.325 router_objective:-0.2415 router_entropy:0.9777
+step:5920/20000 router_matrix
+step:5920/20000 train_loss:2.2730 train_time:20179634ms step_avg:3408.72ms router_forward:1 router_objective:-0.2527 router_entropy:0.9893
+step:5930/20000 router_probe window_steps:10 avg_depth:5.607 router_objective:-0.2538 router_entropy:0.9927
+step:5930/20000 router_matrix
+step:5930/20000 train_loss:2.2423 train_time:20213561ms step_avg:3408.69ms router_forward:1 router_objective:-0.3180 router_entropy:0.9870
+step:5940/20000 router_probe window_steps:10 avg_depth:5.598 router_objective:-0.2345 router_entropy:0.9729
+step:5940/20000 router_matrix
+step:5940/20000 train_loss:2.2366 train_time:20247321ms step_avg:3408.64ms router_forward:1 router_objective:-0.2348 router_entropy:0.9695
+step:5950/20000 router_probe window_steps:10 avg_depth:5.261 router_objective:-0.2489 router_entropy:0.9731
+step:5950/20000 router_matrix
+step:5950/20000 train_loss:2.2543 train_time:20279209ms step_avg:3408.27ms router_forward:1 router_objective:-0.2666 router_entropy:0.9666
+step:5960/20000 router_probe window_steps:10 avg_depth:5.347 router_objective:-0.1983 router_entropy:0.9756
+step:5960/20000 router_matrix
+step:5960/20000 train_loss:2.2116 train_time:20311582ms step_avg:3407.98ms router_forward:1 router_objective:-0.1867 router_entropy:0.9880
+step:5970/20000 router_probe window_steps:10 avg_depth:5.265 router_objective:-0.1639 router_entropy:0.9847
+step:5970/20000 router_matrix
+step:5970/20000 train_loss:2.2882 train_time:20343591ms step_avg:3407.64ms router_forward:1 router_objective:-0.2137 router_entropy:0.9867
+step:5980/20000 router_probe window_steps:10 avg_depth:5.341 router_objective:-0.2427 router_entropy:0.9644
+step:5980/20000 router_matrix
+step:5980/20000 train_loss:2.2302 train_time:20377301ms step_avg:3407.58ms router_forward:1 router_objective:-0.2673 router_entropy:0.9716
+step:5990/20000 router_probe window_steps:10 avg_depth:5.469 router_objective:-0.2560 router_entropy:0.9757
+step:5990/20000 router_matrix
+step:5990/20000 train_loss:2.2450 train_time:20410350ms step_avg:3407.40ms router_forward:1 router_objective:-0.2075 router_entropy:0.9709
+step:6000/20000 router_probe window_steps:10 avg_depth:5.586 router_objective:-0.2460 router_entropy:0.9865
+step:6000/20000 router_matrix
+step:6000/20000 train_loss:2.2078 train_time:20444062ms step_avg:3407.34ms router_forward:1 router_objective:-0.2064 router_entropy:0.9847
+step:6010/20000 router_probe window_steps:10 avg_depth:5.266 router_objective:-0.2475 router_entropy:0.9802
+step:6010/20000 router_matrix
+step:6010/20000 train_loss:2.3500 train_time:20476427ms step_avg:3407.06ms router_forward:1 router_objective:-0.3018 router_entropy:0.9801
+step:6020/20000 router_probe window_steps:10 avg_depth:5.484 router_objective:-0.2371 router_entropy:0.9749
+step:6020/20000 router_matrix
+step:6020/20000 train_loss:2.1627 train_time:20509996ms step_avg:3406.98ms router_forward:1 router_objective:-0.2978 router_entropy:0.9921
+step:6030/20000 router_probe window_steps:10 avg_depth:5.427 router_objective:-0.2401 router_entropy:0.9810
+step:6030/20000 router_matrix
+step:6030/20000 train_loss:2.2596 train_time:20542908ms step_avg:3406.78ms router_forward:1 router_objective:-0.2334 router_entropy:0.9711
+step:6040/20000 router_probe window_steps:10 avg_depth:5.327 router_objective:-0.2344 router_entropy:0.9809
+step:6040/20000 router_matrix
+step:6040/20000 train_loss:2.2173 train_time:20575354ms step_avg:3406.52ms router_forward:1 router_objective:-0.2222 router_entropy:0.9735
+step:6050/20000 router_probe window_steps:10 avg_depth:5.385 router_objective:-0.2319 router_entropy:0.9804
+step:6050/20000 router_matrix
+step:6050/20000 train_loss:2.2695 train_time:20607938ms step_avg:3406.27ms router_forward:1 router_objective:-0.2254 router_entropy:0.9834
+step:6060/20000 router_probe window_steps:10 avg_depth:5.459 router_objective:-0.2280 router_entropy:0.9819
+step:6060/20000 router_matrix
+step:6060/20000 train_loss:2.1946 train_time:20641030ms step_avg:3406.11ms router_forward:1 router_objective:-0.1828 router_entropy:0.9887
+step:6070/20000 router_probe window_steps:10 avg_depth:5.427 router_objective:-0.2257 router_entropy:0.9865
+step:6070/20000 router_matrix
+step:6070/20000 train_loss:2.2922 train_time:20673603ms step_avg:3405.87ms router_forward:1 router_objective:-0.1961 router_entropy:0.9667
+step:6080/20000 router_probe window_steps:10 avg_depth:5.595 router_objective:-0.2739 router_entropy:0.9803
+step:6080/20000 router_matrix
+step:6080/20000 train_loss:2.2180 train_time:20707180ms step_avg:3405.79ms router_forward:1 router_objective:-0.3506 router_entropy:0.9918
+step:6090/20000 router_probe window_steps:10 avg_depth:5.441 router_objective:-0.2344 router_entropy:0.9821
+step:6090/20000 router_matrix
+step:6090/20000 train_loss:2.2494 train_time:20740012ms step_avg:3405.58ms router_forward:1 router_objective:-0.2502 router_entropy:0.9815
+step:6100/20000 router_probe window_steps:10 avg_depth:5.597 router_objective:-0.2299 router_entropy:0.9891
+step:6100/20000 router_matrix
+step:6100/20000 train_loss:2.2191 train_time:20773607ms step_avg:3405.51ms router_forward:1 router_objective:-0.3161 router_entropy:1.0038
+step:6110/20000 router_probe window_steps:10 avg_depth:5.367 router_objective:-0.2431 router_entropy:0.9790
+step:6110/20000 router_matrix
+step:6110/20000 train_loss:2.2684 train_time:20807229ms step_avg:3405.44ms router_forward:1 router_objective:-0.2727 router_entropy:0.9764
+step:6120/20000 router_probe window_steps:10 avg_depth:5.396 router_objective:-0.2243 router_entropy:0.9701
+step:6120/20000 router_matrix
+step:6120/20000 train_loss:2.1974 train_time:20839742ms step_avg:3405.19ms router_forward:1 router_objective:-0.2477 router_entropy:0.9709
+step:6130/20000 router_probe window_steps:10 avg_depth:5.740 router_objective:-0.2979 router_entropy:0.9920
+step:6130/20000 router_matrix
+step:6130/20000 train_loss:2.2629 train_time:20874093ms step_avg:3405.24ms router_forward:1 router_objective:-0.2179 router_entropy:1.0007
+step:6140/20000 router_probe window_steps:10 avg_depth:4.895 router_objective:-0.2494 router_entropy:0.9612
+step:6140/20000 router_matrix
+step:6140/20000 train_loss:2.1539 train_time:20904010ms step_avg:3404.56ms router_forward:1 router_objective:-0.2527 router_entropy:0.9534
+step:6150/20000 router_probe window_steps:10 avg_depth:5.593 router_objective:-0.2340 router_entropy:0.9578
+step:6150/20000 router_matrix
+step:6150/20000 train_loss:2.2476 train_time:20937779ms step_avg:3404.52ms router_forward:1 router_objective:-0.1898 router_entropy:0.9743
+step:6160/20000 router_probe window_steps:10 avg_depth:5.537 router_objective:-0.2535 router_entropy:0.9717
+step:6160/20000 router_matrix
+step:6160/20000 train_loss:2.1952 train_time:20971551ms step_avg:3404.47ms router_forward:1 router_objective:-0.3342 router_entropy:0.9673
+step:6170/20000 router_probe window_steps:10 avg_depth:5.619 router_objective:-0.2200 router_entropy:0.9672
+step:6170/20000 router_matrix
+step:6170/20000 train_loss:2.2683 train_time:21006219ms step_avg:3404.57ms router_forward:1 router_objective:-0.0958 router_entropy:0.9884
+step:6180/20000 router_probe window_steps:10 avg_depth:5.357 router_objective:-0.2336 router_entropy:0.9876
+step:6180/20000 router_matrix
+step:6180/20000 train_loss:2.2544 train_time:21038481ms step_avg:3404.28ms router_forward:1 router_objective:-0.1881 router_entropy:0.9863
+step:6190/20000 router_probe window_steps:10 avg_depth:5.538 router_objective:-0.2468 router_entropy:0.9584
+step:6190/20000 router_matrix
+step:6190/20000 train_loss:2.2119 train_time:21071552ms step_avg:3404.13ms router_forward:1 router_objective:-0.2617 router_entropy:0.9633
+step:6200/20000 router_probe window_steps:10 avg_depth:5.434 router_objective:-0.2173 router_entropy:0.9841
+step:6200/20000 router_matrix
+step:6200/20000 train_loss:2.3185 train_time:21104280ms step_avg:3403.92ms router_forward:1 router_objective:-0.1871 router_entropy:0.9904
+step:6210/20000 router_probe window_steps:10 avg_depth:5.564 router_objective:-0.2217 router_entropy:0.9818
+step:6210/20000 router_matrix
+step:6210/20000 train_loss:2.1899 train_time:21137773ms step_avg:3403.83ms router_forward:1 router_objective:-0.2079 router_entropy:0.9735
+step:6220/20000 router_probe window_steps:10 avg_depth:5.214 router_objective:-0.2229 router_entropy:0.9802
+step:6220/20000 router_matrix
+step:6220/20000 train_loss:2.2520 train_time:21169381ms step_avg:3403.44ms router_forward:1 router_objective:-0.2106 router_entropy:0.9822
+step:6230/20000 router_probe window_steps:10 avg_depth:5.777 router_objective:-0.2349 router_entropy:0.9734
+step:6230/20000 router_matrix
+step:6230/20000 train_loss:2.2496 train_time:21203960ms step_avg:3403.52ms router_forward:1 router_objective:-0.2065 router_entropy:0.9568
+step:6240/20000 router_probe window_steps:10 avg_depth:5.269 router_objective:-0.2403 router_entropy:0.9674
+step:6240/20000 router_matrix
+step:6240/20000 train_loss:2.2465 train_time:21237975ms step_avg:3403.52ms router_forward:1 router_objective:-0.2314 router_entropy:0.9896
+step:6250/20000 router_probe window_steps:10 avg_depth:5.559 router_objective:-0.2351 router_entropy:0.9840
+step:6250/20000 router_matrix
+step:6250/20000 train_loss:2.1991 train_time:21271426ms step_avg:3403.43ms router_forward:1 router_objective:-0.1739 router_entropy:0.9942
+step:6260/20000 router_probe window_steps:10 avg_depth:5.656 router_objective:-0.2273 router_entropy:0.9816
+step:6260/20000 router_matrix
+step:6260/20000 train_loss:2.2188 train_time:21305407ms step_avg:3403.42ms router_forward:1 router_objective:-0.2631 router_entropy:0.9817
+step:6270/20000 router_probe window_steps:10 avg_depth:5.308 router_objective:-0.2104 router_entropy:0.9789
+step:6270/20000 router_matrix
+step:6270/20000 train_loss:2.2891 train_time:21338410ms step_avg:3403.26ms router_forward:1 router_objective:-0.1815 router_entropy:0.9689
+step:6280/20000 router_probe window_steps:10 avg_depth:5.501 router_objective:-0.2157 router_entropy:0.9857
+step:6280/20000 router_matrix
+step:6280/20000 train_loss:2.2100 train_time:21372187ms step_avg:3403.21ms router_forward:1 router_objective:-0.2221 router_entropy:0.9946
+step:6290/20000 router_probe window_steps:10 avg_depth:5.585 router_objective:-0.2334 router_entropy:0.9759
+step:6290/20000 router_matrix
+step:6290/20000 train_loss:2.2794 train_time:21406152ms step_avg:3403.20ms router_forward:1 router_objective:-0.2032 router_entropy:0.9589
+step:6300/20000 router_probe window_steps:10 avg_depth:5.371 router_objective:-0.2259 router_entropy:0.9643
+step:6300/20000 router_matrix
+step:6300/20000 train_loss:2.2064 train_time:21438974ms step_avg:3403.01ms router_forward:1 router_objective:-0.2921 router_entropy:0.9904
+step:6310/20000 router_probe window_steps:10 avg_depth:5.637 router_objective:-0.2441 router_entropy:0.9862
+step:6310/20000 router_matrix
+step:6310/20000 train_loss:2.2684 train_time:21473225ms step_avg:3403.05ms router_forward:1 router_objective:-0.2930 router_entropy:0.9798
+step:6320/20000 router_probe window_steps:10 avg_depth:5.193 router_objective:-0.2224 router_entropy:0.9736
+step:6320/20000 router_matrix
+step:6320/20000 train_loss:2.1793 train_time:21505132ms step_avg:3402.71ms router_forward:1 router_objective:-0.2278 router_entropy:0.9651
+step:6330/20000 router_probe window_steps:10 avg_depth:5.513 router_objective:-0.2264 router_entropy:0.9618
+step:6330/20000 router_matrix
+step:6330/20000 train_loss:2.2463 train_time:21538185ms step_avg:3402.56ms router_forward:1 router_objective:-0.2115 router_entropy:0.9781
+step:6340/20000 router_probe window_steps:10 avg_depth:5.411 router_objective:-0.2022 router_entropy:0.9861
+step:6340/20000 router_matrix
+step:6340/20000 train_loss:2.2505 train_time:21570878ms step_avg:3402.35ms router_forward:1 router_objective:-0.2037 router_entropy:0.9862
+step:6350/20000 router_probe window_steps:10 avg_depth:5.585 router_objective:-0.2373 router_entropy:0.9752
+step:6350/20000 router_matrix
+step:6350/20000 train_loss:2.1942 train_time:21604999ms step_avg:3402.36ms router_forward:1 router_objective:-0.1920 router_entropy:0.9455
+step:6360/20000 router_probe window_steps:10 avg_depth:5.513 router_objective:-0.2103 router_entropy:0.9400
+step:6360/20000 router_matrix
+step:6360/20000 train_loss:2.2152 train_time:21645645ms step_avg:3403.40ms router_forward:1 router_objective:-0.1955 router_entropy:0.9391
+step:6370/20000 router_probe window_steps:10 avg_depth:5.541 router_objective:-0.2283 router_entropy:0.9764
+step:6370/20000 router_matrix
+step:6370/20000 train_loss:2.2374 train_time:21679142ms step_avg:3403.32ms router_forward:1 router_objective:-0.2143 router_entropy:0.9956
+step:6380/20000 router_probe window_steps:10 avg_depth:5.385 router_objective:-0.2456 router_entropy:0.9746
+step:6380/20000 router_matrix
+step:6380/20000 train_loss:2.1674 train_time:21711695ms step_avg:3403.09ms router_forward:1 router_objective:-0.3006 router_entropy:0.9619
+step:6390/20000 router_probe window_steps:10 avg_depth:5.418 router_objective:-0.2212 router_entropy:0.9609
+step:6390/20000 router_matrix
+step:6390/20000 train_loss:2.1615 train_time:21744477ms step_avg:3402.89ms router_forward:1 router_objective:-0.2259 router_entropy:0.9579
+step:6400/20000 router_probe window_steps:10 avg_depth:5.559 router_objective:-0.2253 router_entropy:0.9779
+step:6400/20000 router_matrix
+step:6400/20000 train_loss:2.2675 train_time:21778106ms step_avg:3402.83ms router_forward:1 router_objective:-0.3786 router_entropy:1.0030
+step:6410/20000 router_probe window_steps:10 avg_depth:5.505 router_objective:-0.2311 router_entropy:0.9821
+step:6410/20000 router_matrix
+step:6410/20000 train_loss:2.1974 train_time:21811300ms step_avg:3402.70ms router_forward:1 router_objective:-0.2390 router_entropy:0.9670
+step:6420/20000 router_probe window_steps:10 avg_depth:5.334 router_objective:-0.2223 router_entropy:0.9743
+step:6420/20000 router_matrix
+step:6420/20000 train_loss:2.2162 train_time:21843805ms step_avg:3402.46ms router_forward:1 router_objective:-0.2192 router_entropy:0.9680
+step:6430/20000 router_probe window_steps:10 avg_depth:5.640 router_objective:-0.2345 router_entropy:0.9825
+step:6430/20000 router_matrix
+step:6430/20000 train_loss:2.2179 train_time:21877601ms step_avg:3402.43ms router_forward:1 router_objective:-0.2207 router_entropy:0.9848
+step:6440/20000 router_probe window_steps:10 avg_depth:5.411 router_objective:-0.2212 router_entropy:0.9783
+step:6440/20000 router_matrix
+step:6440/20000 train_loss:2.2250 train_time:21910248ms step_avg:3402.21ms router_forward:1 router_objective:-0.2095 router_entropy:0.9707
+step:6450/20000 router_probe window_steps:10 avg_depth:5.659 router_objective:-0.2449 router_entropy:0.9892
+step:6450/20000 router_matrix
+step:6450/20000 train_loss:2.2215 train_time:21944088ms step_avg:3402.18ms router_forward:1 router_objective:-0.3013 router_entropy:0.9897
+step:6460/20000 router_probe window_steps:10 avg_depth:5.381 router_objective:-0.1676 router_entropy:0.9755
+step:6460/20000 router_matrix
+step:6460/20000 train_loss:2.1834 train_time:21976479ms step_avg:3401.93ms router_forward:1 router_objective:-0.2076 router_entropy:0.9707
+step:6470/20000 router_probe window_steps:10 avg_depth:5.468 router_objective:-0.2506 router_entropy:0.9694
+step:6470/20000 router_matrix
+step:6470/20000 train_loss:2.3065 train_time:22009349ms step_avg:3401.75ms router_forward:1 router_objective:-0.3386 router_entropy:0.9777
+step:6480/20000 router_probe window_steps:10 avg_depth:5.723 router_objective:-0.2054 router_entropy:0.9831
+step:6480/20000 router_matrix
+step:6480/20000 train_loss:2.1881 train_time:22043481ms step_avg:3401.77ms router_forward:1 router_objective:-0.1860 router_entropy:0.9882
+step:6490/20000 router_probe window_steps:10 avg_depth:5.533 router_objective:-0.2245 router_entropy:0.9773
+step:6490/20000 router_matrix
+step:6490/20000 train_loss:2.2162 train_time:22080242ms step_avg:3402.19ms router_forward:1 router_objective:-0.2141 router_entropy:0.9648
+step:6500/20000 router_probe window_steps:10 avg_depth:9.544 router_objective:-0.1816 router_entropy:0.9863
+step:6500/20000 router_matrix
+step:6500/20000 train_loss:2.3301 train_time:22133088ms step_avg:3405.09ms router_forward:1 router_objective:-0.2279 router_entropy:1.0001
+step:6510/20000 router_probe window_steps:10 avg_depth:11.440 router_objective:-0.1999 router_entropy:0.9951
+step:6510/20000 router_matrix
+step:6510/20000 train_loss:2.1422 train_time:22194791ms step_avg:3409.34ms router_forward:1 router_objective:-0.1857 router_entropy:0.9905
+step:6520/20000 router_probe window_steps:10 avg_depth:6.959 router_objective:-0.2416 router_entropy:0.9870
+step:6520/20000 router_matrix
+step:6520/20000 train_loss:2.2584 train_time:22235436ms step_avg:3410.34ms router_forward:1 router_objective:-0.2563 router_entropy:0.9841
+step:6530/20000 router_probe window_steps:10 avg_depth:5.842 router_objective:-0.2359 router_entropy:0.9622
+step:6530/20000 router_matrix
+step:6530/20000 train_loss:2.3013 train_time:22270802ms step_avg:3410.54ms router_forward:1 router_objective:-0.2122 router_entropy:0.9221
+step:6540/20000 router_probe window_steps:10 avg_depth:5.948 router_objective:-0.2241 router_entropy:0.9362
+step:6540/20000 router_matrix
+step:6540/20000 train_loss:2.2097 train_time:22306118ms step_avg:3410.72ms router_forward:1 router_objective:-0.2139 router_entropy:0.9309
+step:6550/20000 router_probe window_steps:10 avg_depth:5.927 router_objective:-0.2297 router_entropy:0.9622
+step:6550/20000 router_matrix
+step:6550/20000 train_loss:2.3335 train_time:22341444ms step_avg:3410.91ms router_forward:1 router_objective:-0.1664 router_entropy:0.9742
+step:6560/20000 router_probe window_steps:10 avg_depth:5.784 router_objective:-0.2510 router_entropy:0.9718
+step:6560/20000 router_matrix
+step:6560/20000 train_loss:2.2675 train_time:22375889ms step_avg:3410.96ms router_forward:1 router_objective:-0.2666 router_entropy:0.9681
+step:6570/20000 router_probe window_steps:10 avg_depth:5.914 router_objective:-0.2303 router_entropy:0.9227
+step:6570/20000 router_matrix
+step:6570/20000 train_loss:2.2474 train_time:22410927ms step_avg:3411.10ms router_forward:1 router_objective:-0.2514 router_entropy:0.9062
+step:6580/20000 router_probe window_steps:10 avg_depth:5.775 router_objective:-0.2328 router_entropy:0.9414
+step:6580/20000 router_matrix
+step:6580/20000 train_loss:2.1230 train_time:22445547ms step_avg:3411.18ms router_forward:1 router_objective:-0.2342 router_entropy:0.9564
+step:6590/20000 router_probe window_steps:10 avg_depth:6.129 router_objective:-0.2406 router_entropy:0.9261
+step:6590/20000 router_matrix
+step:6590/20000 train_loss:2.1895 train_time:22481649ms step_avg:3411.48ms router_forward:1 router_objective:-0.2113 router_entropy:0.8865
+step:6600/20000 router_probe window_steps:10 avg_depth:6.299 router_objective:-0.2396 router_entropy:0.9302
+step:6600/20000 router_matrix
+step:6600/20000 train_loss:2.1744 train_time:22518990ms step_avg:3411.97ms router_forward:1 router_objective:-0.1785 router_entropy:0.9305
+step:6610/20000 router_probe window_steps:10 avg_depth:6.167 router_objective:-0.2418 router_entropy:0.9249
+step:6610/20000 router_matrix
+step:6610/20000 train_loss:2.1393 train_time:22555434ms step_avg:3412.32ms router_forward:1 router_objective:-0.2439 router_entropy:0.9318
+step:6620/20000 router_probe window_steps:10 avg_depth:6.056 router_objective:-0.2448 router_entropy:0.9321
+step:6620/20000 router_matrix
+step:6620/20000 train_loss:2.1691 train_time:22592623ms step_avg:3412.78ms router_forward:1 router_objective:-0.2057 router_entropy:0.9566
+step:6630/20000 router_probe window_steps:10 avg_depth:6.051 router_objective:-0.2295 router_entropy:0.9591
+step:6630/20000 router_matrix
+step:6630/20000 train_loss:2.1921 train_time:22628603ms step_avg:3413.06ms router_forward:1 router_objective:-0.2028 router_entropy:0.9439
+step:6640/20000 router_probe window_steps:10 avg_depth:6.504 router_objective:-0.2408 router_entropy:0.9467
+step:6640/20000 router_matrix
+step:6640/20000 train_loss:2.2016 train_time:22667267ms step_avg:3413.75ms router_forward:1 router_objective:-0.2597 router_entropy:0.9360
+step:6650/20000 router_probe window_steps:10 avg_depth:6.153 router_objective:-0.2351 router_entropy:0.9181
+step:6650/20000 router_matrix
+step:6650/20000 train_loss:2.0464 train_time:22703749ms step_avg:3414.10ms router_forward:1 router_objective:-0.2424 router_entropy:0.9078
+step:6660/20000 router_probe window_steps:10 avg_depth:6.502 router_objective:-0.2206 router_entropy:0.9221
+step:6660/20000 router_matrix
+step:6660/20000 train_loss:2.1776 train_time:22741804ms step_avg:3414.69ms router_forward:1 router_objective:-0.1592 router_entropy:0.9310
+step:6670/20000 router_probe window_steps:10 avg_depth:6.446 router_objective:-0.2454 router_entropy:0.9373
+step:6670/20000 router_matrix
+step:6670/20000 train_loss:2.1952 train_time:22779410ms step_avg:3415.20ms router_forward:1 router_objective:-0.2364 router_entropy:0.9399
+step:6680/20000 router_probe window_steps:10 avg_depth:6.348 router_objective:-0.2427 router_entropy:0.9384
+step:6680/20000 router_matrix
+step:6680/20000 train_loss:2.1692 train_time:22817422ms step_avg:3415.78ms router_forward:1 router_objective:-0.2644 router_entropy:0.9164
+step:6690/20000 router_probe window_steps:10 avg_depth:5.893 router_objective:-0.2631 router_entropy:0.9021
+step:6690/20000 router_matrix
+step:6690/20000 train_loss:2.2127 train_time:22852567ms step_avg:3415.93ms router_forward:1 router_objective:-0.2708 router_entropy:0.8960
+step:6700/20000 router_probe window_steps:10 avg_depth:6.377 router_objective:-0.2621 router_entropy:0.9204
+step:6700/20000 router_matrix
+step:6700/20000 train_loss:2.0952 train_time:22890980ms step_avg:3416.56ms router_forward:1 router_objective:-0.3175 router_entropy:0.9172
+step:6710/20000 router_probe window_steps:10 avg_depth:6.607 router_objective:-0.2351 router_entropy:0.9241
+step:6710/20000 router_matrix
+step:6710/20000 train_loss:2.2040 train_time:22930413ms step_avg:3417.35ms router_forward:1 router_objective:-0.2292 router_entropy:0.9538
+step:6720/20000 router_probe window_steps:10 avg_depth:6.330 router_objective:-0.2490 router_entropy:0.9440
+step:6720/20000 router_matrix
+step:6720/20000 train_loss:2.1151 train_time:22968214ms step_avg:3417.89ms router_forward:1 router_objective:-0.2347 router_entropy:0.9070
+step:6730/20000 router_probe window_steps:10 avg_depth:6.478 router_objective:-0.2285 router_entropy:0.9107
+step:6730/20000 router_matrix
+step:6730/20000 train_loss:2.1368 train_time:23006715ms step_avg:3418.53ms router_forward:1 router_objective:-0.2638 router_entropy:0.9269
+step:6740/20000 router_probe window_steps:10 avg_depth:6.556 router_objective:-0.2569 router_entropy:0.9332
+step:6740/20000 router_matrix
+step:6740/20000 train_loss:2.1955 train_time:23047811ms step_avg:3419.56ms router_forward:1 router_objective:-0.2130 router_entropy:0.9063
+step:6750/20000 router_probe window_steps:10 avg_depth:6.527 router_objective:-0.2253 router_entropy:0.9102
+step:6750/20000 router_matrix
+step:6750/20000 train_loss:2.1805 train_time:23085963ms step_avg:3420.14ms router_forward:1 router_objective:-0.3219 router_entropy:0.9149
+step:6760/20000 router_probe window_steps:10 avg_depth:6.407 router_objective:-0.2408 router_entropy:0.9164
+step:6760/20000 router_matrix
+step:6760/20000 train_loss:2.1531 train_time:23123410ms step_avg:3420.62ms router_forward:1 router_objective:-0.2409 router_entropy:0.9077
+step:6770/20000 router_probe window_steps:10 avg_depth:6.375 router_objective:-0.2426 router_entropy:0.9068
+step:6770/20000 router_matrix
+step:6770/20000 train_loss:2.1960 train_time:23160896ms step_avg:3421.11ms router_forward:1 router_objective:-0.2235 router_entropy:0.9061
+step:6780/20000 router_probe window_steps:10 avg_depth:6.704 router_objective:-0.2429 router_entropy:0.9118
+step:6780/20000 router_matrix
+step:6780/20000 train_loss:2.0990 train_time:23199900ms step_avg:3421.81ms router_forward:1 router_objective:-0.2063 router_entropy:0.9198
+step:6790/20000 router_probe window_steps:10 avg_depth:6.693 router_objective:-0.2298 router_entropy:0.9229
+step:6790/20000 router_matrix
+step:6790/20000 train_loss:2.1098 train_time:23238873ms step_avg:3422.51ms router_forward:1 router_objective:-0.2852 router_entropy:0.9224
+step:6800/20000 router_probe window_steps:10 avg_depth:6.461 router_objective:-0.2420 router_entropy:0.9366
+step:6800/20000 router_matrix
+step:6800/20000 train_loss:2.2032 train_time:23276734ms step_avg:3423.05ms router_forward:1 router_objective:-0.2233 router_entropy:0.9315
+step:6810/20000 router_probe window_steps:10 avg_depth:6.519 router_objective:-0.2274 router_entropy:0.9299
+step:6810/20000 router_matrix
+step:6810/20000 train_loss:2.1519 train_time:23315410ms step_avg:3423.70ms router_forward:1 router_objective:-0.2009 router_entropy:0.9253
+step:6820/20000 router_probe window_steps:10 avg_depth:6.287 router_objective:-0.2238 router_entropy:0.9233
+step:6820/20000 router_matrix
+step:6820/20000 train_loss:2.1442 train_time:23352513ms step_avg:3424.12ms router_forward:1 router_objective:-0.2036 router_entropy:0.9237
+step:6830/20000 router_probe window_steps:10 avg_depth:6.558 router_objective:-0.2319 router_entropy:0.9257
+step:6830/20000 router_matrix
+step:6830/20000 train_loss:2.1602 train_time:23390982ms step_avg:3424.74ms router_forward:1 router_objective:-0.1828 router_entropy:0.9186
+step:6840/20000 router_probe window_steps:10 avg_depth:6.385 router_objective:-0.2263 router_entropy:0.9218
+step:6840/20000 router_matrix
+step:6840/20000 train_loss:2.1237 train_time:23428341ms step_avg:3425.20ms router_forward:1 router_objective:-0.2195 router_entropy:0.9249
+step:6850/20000 router_probe window_steps:10 avg_depth:6.141 router_objective:-0.2649 router_entropy:0.9392
+step:6850/20000 router_matrix
+step:6850/20000 train_loss:2.0967 train_time:23464405ms step_avg:3425.46ms router_forward:1 router_objective:-0.2179 router_entropy:0.9366
+step:6860/20000 router_probe window_steps:10 avg_depth:5.898 router_objective:-0.2374 router_entropy:0.9221
+step:6860/20000 router_matrix
+step:6860/20000 train_loss:2.1403 train_time:23499606ms step_avg:3425.60ms router_forward:1 router_objective:-0.2137 router_entropy:0.9228
+step:6870/20000 router_probe window_steps:10 avg_depth:6.043 router_objective:-0.2278 router_entropy:0.9204
+step:6870/20000 router_matrix
+step:6870/20000 train_loss:2.1325 train_time:23537318ms step_avg:3426.10ms router_forward:1 router_objective:-0.2474 router_entropy:0.9281
+step:6880/20000 router_probe window_steps:10 avg_depth:6.602 router_objective:-0.2602 router_entropy:0.9273
+step:6880/20000 router_matrix
+step:6880/20000 train_loss:2.1465 train_time:23575788ms step_avg:3426.71ms router_forward:1 router_objective:-0.2227 router_entropy:0.9237
+step:6890/20000 router_probe window_steps:10 avg_depth:6.288 router_objective:-0.2237 router_entropy:0.9218
+step:6890/20000 router_matrix
+step:6890/20000 train_loss:2.1344 train_time:23612835ms step_avg:3427.12ms router_forward:1 router_objective:-0.2239 router_entropy:0.9201
+step:6900/20000 router_probe window_steps:10 avg_depth:6.288 router_objective:-0.2579 router_entropy:0.9130
+step:6900/20000 router_matrix
+step:6900/20000 train_loss:2.0511 train_time:23649640ms step_avg:3427.48ms router_forward:1 router_objective:-0.2309 router_entropy:0.9105
+step:6910/20000 router_probe window_steps:10 avg_depth:6.447 router_objective:-0.2557 router_entropy:0.9103
+step:6910/20000 router_matrix
+step:6910/20000 train_loss:2.0956 train_time:23687157ms step_avg:3427.95ms router_forward:1 router_objective:-0.2738 router_entropy:0.9128
+step:6920/20000 router_probe window_steps:10 avg_depth:6.591 router_objective:-0.2733 router_entropy:0.9160
+step:6920/20000 router_matrix
+step:6920/20000 train_loss:2.1536 train_time:23725634ms step_avg:3428.56ms router_forward:1 router_objective:-0.2796 router_entropy:0.9232
+step:6930/20000 router_probe window_steps:10 avg_depth:6.797 router_objective:-0.2311 router_entropy:0.9271
+step:6930/20000 router_matrix
+step:6930/20000 train_loss:1.9576 train_time:23765453ms step_avg:3429.36ms router_forward:1 router_objective:-0.2305 router_entropy:0.9316
+step:6940/20000 router_probe window_steps:10 avg_depth:6.357 router_objective:-0.2633 router_entropy:0.9182
+step:6940/20000 router_matrix
+step:6940/20000 train_loss:2.1337 train_time:23802758ms step_avg:3429.79ms router_forward:1 router_objective:-0.1924 router_entropy:0.9064
+step:6950/20000 router_probe window_steps:10 avg_depth:6.268 router_objective:-0.2550 router_entropy:0.8969
+step:6950/20000 router_matrix
+step:6950/20000 train_loss:2.1389 train_time:23839623ms step_avg:3430.16ms router_forward:1 router_objective:-0.3145 router_entropy:0.9039
+step:6960/20000 router_probe window_steps:10 avg_depth:6.401 router_objective:-0.2527 router_entropy:0.9088
+step:6960/20000 router_matrix
+step:6960/20000 train_loss:2.0888 train_time:23876975ms step_avg:3430.60ms router_forward:1 router_objective:-0.1968 router_entropy:0.9216
+step:6970/20000 router_probe window_steps:10 avg_depth:6.630 router_objective:-0.2763 router_entropy:0.9244
+step:6970/20000 router_matrix
+step:6970/20000 train_loss:2.1934 train_time:23915440ms step_avg:3431.20ms router_forward:1 router_objective:-0.2062 router_entropy:0.9171
+step:6980/20000 router_probe window_steps:10 avg_depth:6.485 router_objective:-0.2556 router_entropy:0.9157
+step:6980/20000 router_matrix
+step:6980/20000 train_loss:2.0267 train_time:23953248ms step_avg:3431.70ms router_forward:1 router_objective:-0.2129 router_entropy:0.9089
+step:6990/20000 router_probe window_steps:10 avg_depth:6.403 router_objective:-0.2300 router_entropy:0.9127
+step:6990/20000 router_matrix
+step:6990/20000 train_loss:2.1044 train_time:23990548ms step_avg:3432.12ms router_forward:1 router_objective:-0.2517 router_entropy:0.9107
+step:7000/20000 router_probe window_steps:10 avg_depth:6.503 router_objective:-0.2293 router_entropy:0.9157
+step:7000/20000 router_matrix
+step:7000/20000 train_loss:2.0148 train_time:24038485ms step_avg:3434.07ms router_forward:1 router_objective:-0.2806 router_entropy:0.9169
+step:7010/20000 router_probe window_steps:10 avg_depth:6.630 router_objective:-0.2429 router_entropy:0.9229
+step:7010/20000 router_matrix
+step:7010/20000 train_loss:2.1059 train_time:24077791ms step_avg:3434.78ms router_forward:1 router_objective:-0.2501 router_entropy:0.9221
+step:7020/20000 router_probe window_steps:10 avg_depth:6.770 router_objective:-0.2552 router_entropy:0.9268
+step:7020/20000 router_matrix
+step:7020/20000 train_loss:2.0858 train_time:24117594ms step_avg:3435.55ms router_forward:1 router_objective:-0.3026 router_entropy:0.9282
+step:7030/20000 router_probe window_steps:10 avg_depth:6.541 router_objective:-0.2605 router_entropy:0.9355
+step:7030/20000 router_matrix
+step:7030/20000 train_loss:2.1004 train_time:24156180ms step_avg:3436.16ms router_forward:1 router_objective:-0.2214 router_entropy:0.9249
+step:7040/20000 router_probe window_steps:10 avg_depth:6.446 router_objective:-0.2342 router_entropy:0.9209
+step:7040/20000 router_matrix
+step:7040/20000 train_loss:2.1220 train_time:24194089ms step_avg:3436.66ms router_forward:1 router_objective:-0.2590 router_entropy:0.9286
+step:7050/20000 router_probe window_steps:10 avg_depth:6.387 router_objective:-0.2421 router_entropy:0.9095
+step:7050/20000 router_matrix
+step:7050/20000 train_loss:2.0322 train_time:24231589ms step_avg:3437.10ms router_forward:1 router_objective:-0.2534 router_entropy:0.9074
+step:7060/20000 router_probe window_steps:10 avg_depth:6.483 router_objective:-0.2299 router_entropy:0.9105
+step:7060/20000 router_matrix
+step:7060/20000 train_loss:2.0908 train_time:24269694ms step_avg:3437.63ms router_forward:1 router_objective:-0.2450 router_entropy:0.9104
+step:7070/20000 router_probe window_steps:10 avg_depth:6.748 router_objective:-0.2458 router_entropy:0.9253
+step:7070/20000 router_matrix
+step:7070/20000 train_loss:2.1359 train_time:24309087ms step_avg:3438.34ms router_forward:1 router_objective:-0.3129 router_entropy:0.9359
+step:7080/20000 router_probe window_steps:10 avg_depth:6.759 router_objective:-0.2535 router_entropy:0.9292
+step:7080/20000 router_matrix
+step:7080/20000 train_loss:2.1063 train_time:24348261ms step_avg:3439.02ms router_forward:1 router_objective:-0.2285 router_entropy:0.9267
+step:7090/20000 router_probe window_steps:10 avg_depth:6.473 router_objective:-0.2483 router_entropy:0.9152
+step:7090/20000 router_matrix
+step:7090/20000 train_loss:1.9374 train_time:24386275ms step_avg:3439.53ms router_forward:1 router_objective:-0.2718 router_entropy:0.9016
+step:7100/20000 router_probe window_steps:10 avg_depth:6.361 router_objective:-0.2345 router_entropy:0.9088
+step:7100/20000 router_matrix
+step:7100/20000 train_loss:2.0558 train_time:24423487ms step_avg:3439.93ms router_forward:1 router_objective:-0.1788 router_entropy:0.9061
+step:7110/20000 router_probe window_steps:10 avg_depth:6.550 router_objective:-0.2519 router_entropy:0.9125
+step:7110/20000 router_matrix
+step:7110/20000 train_loss:2.0669 train_time:24462256ms step_avg:3440.54ms router_forward:1 router_objective:-0.2230 router_entropy:0.9135
+step:7120/20000 router_probe window_steps:10 avg_depth:6.564 router_objective:-0.2502 router_entropy:0.9154
+step:7120/20000 router_matrix
+step:7120/20000 train_loss:2.0917 train_time:24501317ms step_avg:3441.20ms router_forward:1 router_objective:-0.1225 router_entropy:0.9145
+step:7130/20000 router_probe window_steps:10 avg_depth:6.575 router_objective:-0.2410 router_entropy:0.9201
+step:7130/20000 router_matrix
+step:7130/20000 train_loss:2.0684 train_time:24541722ms step_avg:3442.04ms router_forward:1 router_objective:-0.2688 router_entropy:0.9182
+step:7140/20000 router_probe window_steps:10 avg_depth:6.536 router_objective:-0.2432 router_entropy:0.9146
+step:7140/20000 router_matrix
+step:7140/20000 train_loss:2.0630 train_time:24579822ms step_avg:3442.55ms router_forward:1 router_objective:-0.2125 router_entropy:0.9218
+step:7150/20000 router_probe window_steps:10 avg_depth:6.477 router_objective:-0.2247 router_entropy:0.9166
+step:7150/20000 router_matrix
+step:7150/20000 train_loss:2.0799 train_time:24617699ms step_avg:3443.03ms router_forward:1 router_objective:-0.1999 router_entropy:0.9213
+step:7160/20000 router_probe window_steps:10 avg_depth:6.417 router_objective:-0.2411 router_entropy:0.9167
+step:7160/20000 router_matrix
+step:7160/20000 train_loss:2.0338 train_time:24655609ms step_avg:3443.52ms router_forward:1 router_objective:-0.2196 router_entropy:0.9238
+step:7170/20000 router_probe window_steps:10 avg_depth:6.488 router_objective:-0.2603 router_entropy:0.9166
+step:7170/20000 router_matrix
+step:7170/20000 train_loss:2.0818 train_time:24693878ms step_avg:3444.06ms router_forward:1 router_objective:-0.2577 router_entropy:0.9174
+step:7180/20000 router_probe window_steps:10 avg_depth:6.546 router_objective:-0.2305 router_entropy:0.9184
+step:7180/20000 router_matrix
+step:7180/20000 train_loss:2.0208 train_time:24732263ms step_avg:3444.60ms router_forward:1 router_objective:-0.1623 router_entropy:0.9237
+step:7190/20000 router_probe window_steps:10 avg_depth:6.493 router_objective:-0.2376 router_entropy:0.9171
+step:7190/20000 router_matrix
+step:7190/20000 train_loss:2.1041 train_time:24770490ms step_avg:3445.13ms router_forward:1 router_objective:-0.2076 router_entropy:0.9162
+step:7200/20000 router_probe window_steps:10 avg_depth:6.521 router_objective:-0.2555 router_entropy:0.9184
+step:7200/20000 router_matrix
+step:7200/20000 train_loss:2.0993 train_time:24809153ms step_avg:3445.72ms router_forward:1 router_objective:-0.2786 router_entropy:0.9176
+step:7210/20000 router_probe window_steps:10 avg_depth:6.597 router_objective:-0.2678 router_entropy:0.9216
+step:7210/20000 router_matrix
+step:7210/20000 train_loss:2.0743 train_time:24848550ms step_avg:3446.40ms router_forward:1 router_objective:-0.2794 router_entropy:0.9254
+step:7220/20000 router_probe window_steps:10 avg_depth:6.487 router_objective:-0.2572 router_entropy:0.9186
+step:7220/20000 router_matrix
+step:7220/20000 train_loss:2.1786 train_time:24886908ms step_avg:3446.94ms router_forward:1 router_objective:-0.2811 router_entropy:0.9163
+step:7230/20000 router_probe window_steps:10 avg_depth:6.459 router_objective:-0.2427 router_entropy:0.9198
+step:7230/20000 router_matrix
+step:7230/20000 train_loss:2.0685 train_time:24924612ms step_avg:3447.39ms router_forward:1 router_objective:-0.2346 router_entropy:0.9175
+step:7240/20000 router_probe window_steps:10 avg_depth:6.455 router_objective:-0.2347 router_entropy:0.9162
+step:7240/20000 router_matrix
+step:7240/20000 train_loss:2.0699 train_time:24962274ms step_avg:3447.83ms router_forward:1 router_objective:-0.2373 router_entropy:0.9162
+step:7250/20000 router_probe window_steps:10 avg_depth:6.545 router_objective:-0.2332 router_entropy:0.9176
+step:7250/20000 router_matrix
+step:7250/20000 train_loss:1.9847 train_time:25002396ms step_avg:3448.61ms router_forward:1 router_objective:-0.2467 router_entropy:0.9063
+stopping_early: wallclock_cap train_time:25002590ms step:7250/20000
+peak memory allocated: 17727 MiB reserved: 79714 MiB
+Serialized model: 168838041 bytes
+Serialized model int6+zlib: 22243730 bytes
+final_int6_roundtrip val_loss:2.2592 val_bpb:1.3380 eval_time:39077ms
+final_int6_roundtrip_exact val_loss:2.25922084 val_bpb:1.33803783
+final_int6_sliding_window val_loss:2.2234 val_bpb:1.3168 stride:64 eval_time:1315898ms
+final_int6_sliding_window_exact val_loss:2.22341991 val_bpb:1.31683800

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_2_5_dashboard_20260420_004715_e49b5f70.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_2_5_dashboard_20260420_004715_e49b5f70.stdout.log
@@ -1,0 +1,490 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260420_004715_e49b5f70.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+model_params:19680769
+router_params:344837
+unique_blocks:4 recurrent_steps:12
+world_size:8 grad_accum_steps:1
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 warmdown_frac:0.72 min_lr:0.0000 val_loss_every:0 num_recurrent_steps:12 max_wallclock_seconds:600.000
+router_actions:5 eval_recurrent_steps:12
+router_input_dim:2688 router_hidden_dim:128 mlp_router_hidden_dim:128 mlp_num_experts:4 mlp_expert_top_k:2 mlp_expert_mult:1.25 router_lr:0.001 router_wd:0.01 router_entropy_bonus_start:0.2 router_entropy_bonus_end:0.02 router_step_penalty:0.02 compiled_routed_experts:0 activation_checkpointing:0 ema_decay:0.9965 muon_momentum_warmup_steps:1500
+warmup_step:1/20
+warmup_step:10/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9560 train_time:412ms step_avg:411.65ms router_forward:1 router_objective:-0.7005 router_entropy:1.5540 router_entropy_bonus:0.2000
+step:2/20000 train_loss:11.6036 train_time:799ms step_avg:399.63ms router_forward:1 router_objective:1.7215 router_entropy:1.5513 router_entropy_bonus:0.1999
+step:3/20000 train_loss:9.7005 train_time:1213ms step_avg:404.50ms router_forward:1 router_objective:2.5055 router_entropy:1.5566 router_entropy_bonus:0.1998
+step:4/20000 train_loss:7.5979 train_time:1856ms step_avg:463.94ms router_forward:1 router_objective:1.0217 router_entropy:1.5487 router_entropy_bonus:0.1996
+step:5/20000 train_loss:6.5493 train_time:2593ms step_avg:518.61ms router_forward:1 router_objective:-0.2817 router_entropy:1.4922 router_entropy_bonus:0.1994
+step:6/20000 train_loss:6.1693 train_time:3248ms step_avg:541.28ms router_forward:1 router_objective:-0.5019 router_entropy:1.4387 router_entropy_bonus:0.1992
+step:7/20000 train_loss:6.1438 train_time:3900ms step_avg:557.16ms router_forward:1 router_objective:-0.5284 router_entropy:1.4021 router_entropy_bonus:0.1990
+step:8/20000 train_loss:6.1264 train_time:4532ms step_avg:566.54ms router_forward:1 router_objective:-0.4863 router_entropy:1.4083 router_entropy_bonus:0.1988
+step:9/20000 train_loss:6.0125 train_time:5148ms step_avg:571.99ms router_forward:1 router_objective:-0.4488 router_entropy:1.4573 router_entropy_bonus:0.1986
+step:10/20000 router_probe window_steps:10 avg_depth:7.896 router_objective:0.1865 router_entropy:1.4908
+step:10/20000 router_matrix
+step:10/20000 train_loss:5.8740 train_time:5710ms step_avg:571.01ms router_forward:1 router_objective:-0.4359 router_entropy:1.4991 router_entropy_bonus:0.1985
+step:20/20000 router_probe window_steps:10 avg_depth:4.983 router_objective:-0.2228 router_entropy:1.5333
+step:20/20000 router_matrix
+step:20/20000 train_loss:5.2409 train_time:9679ms step_avg:483.96ms router_forward:1 router_objective:-0.1378 router_entropy:1.5267 router_entropy_bonus:0.1972
+step:30/20000 router_probe window_steps:10 avg_depth:3.473 router_objective:-0.1699 router_entropy:1.5051
+step:30/20000 router_matrix
+step:30/20000 train_loss:4.4544 train_time:12414ms step_avg:413.79ms router_forward:1 router_objective:-0.1989 router_entropy:1.4843 router_entropy_bonus:0.1964
+step:40/20000 router_probe window_steps:10 avg_depth:3.815 router_objective:-0.2695 router_entropy:1.4783
+step:40/20000 router_matrix
+step:40/20000 train_loss:3.9383 train_time:15240ms step_avg:381.01ms router_forward:1 router_objective:-0.3426 router_entropy:1.4709 router_entropy_bonus:0.1955
+step:50/20000 router_probe window_steps:10 avg_depth:3.886 router_objective:-0.3078 router_entropy:1.4320
+step:50/20000 router_matrix
+step:50/20000 train_loss:3.7056 train_time:18074ms step_avg:361.49ms router_forward:1 router_objective:-0.2907 router_entropy:1.4149 router_entropy_bonus:0.1947
+step:60/20000 router_probe window_steps:10 avg_depth:3.820 router_objective:-0.3210 router_entropy:1.3885
+step:60/20000 router_matrix
+step:60/20000 train_loss:3.5875 train_time:20840ms step_avg:347.34ms router_forward:1 router_objective:-0.3309 router_entropy:1.4066 router_entropy_bonus:0.1938
+step:70/20000 router_probe window_steps:10 avg_depth:3.778 router_objective:-0.3124 router_entropy:1.4027
+step:70/20000 router_matrix
+step:70/20000 train_loss:3.4779 train_time:23578ms step_avg:336.83ms router_forward:1 router_objective:-0.2960 router_entropy:1.4247 router_entropy_bonus:0.1930
+step:80/20000 router_probe window_steps:10 avg_depth:4.434 router_objective:-0.3587 router_entropy:1.4052
+step:80/20000 router_matrix
+step:80/20000 train_loss:3.4494 train_time:26760ms step_avg:334.49ms router_forward:1 router_objective:-0.3926 router_entropy:1.4458 router_entropy_bonus:0.1921
+step:90/20000 router_probe window_steps:10 avg_depth:4.252 router_objective:-0.3422 router_entropy:1.4141
+step:90/20000 router_matrix
+step:90/20000 train_loss:3.3508 train_time:29991ms step_avg:333.24ms router_forward:1 router_objective:-0.2812 router_entropy:1.3998 router_entropy_bonus:0.1911
+step:100/20000 router_probe window_steps:10 avg_depth:4.130 router_objective:-0.3078 router_entropy:1.4233
+step:100/20000 router_matrix
+step:100/20000 train_loss:3.3106 train_time:32955ms step_avg:329.55ms router_forward:1 router_objective:-0.2820 router_entropy:1.4089 router_entropy_bonus:0.1902
+step:110/20000 router_probe window_steps:10 avg_depth:4.307 router_objective:-0.3292 router_entropy:1.4322
+step:110/20000 router_matrix
+step:110/20000 train_loss:3.3338 train_time:36114ms step_avg:328.31ms router_forward:1 router_objective:-0.2953 router_entropy:1.3944 router_entropy_bonus:0.1892
+step:120/20000 router_probe window_steps:10 avg_depth:4.104 router_objective:-0.3273 router_entropy:1.4224
+step:120/20000 router_matrix
+step:120/20000 train_loss:3.2497 train_time:39125ms step_avg:326.04ms router_forward:1 router_objective:-0.2836 router_entropy:1.3989 router_entropy_bonus:0.1883
+step:130/20000 router_probe window_steps:10 avg_depth:4.139 router_objective:-0.3135 router_entropy:1.4473
+step:130/20000 router_matrix
+step:130/20000 train_loss:3.2432 train_time:42140ms step_avg:324.16ms router_forward:1 router_objective:-0.3110 router_entropy:1.4256 router_entropy_bonus:0.1874
+step:140/20000 router_probe window_steps:10 avg_depth:4.176 router_objective:-0.3178 router_entropy:1.4411
+step:140/20000 router_matrix
+step:140/20000 train_loss:3.1791 train_time:45233ms step_avg:323.09ms router_forward:1 router_objective:-0.4143 router_entropy:1.4866 router_entropy_bonus:0.1866
+step:150/20000 router_probe window_steps:10 avg_depth:4.297 router_objective:-0.3193 router_entropy:1.4632
+step:150/20000 router_matrix
+step:150/20000 train_loss:3.1459 train_time:48412ms step_avg:322.75ms router_forward:1 router_objective:-0.3399 router_entropy:1.4659 router_entropy_bonus:0.1856
+step:160/20000 router_probe window_steps:10 avg_depth:4.170 router_objective:-0.3290 router_entropy:1.4457
+step:160/20000 router_matrix
+step:160/20000 train_loss:3.1095 train_time:51717ms step_avg:323.23ms router_forward:1 router_objective:-0.2854 router_entropy:1.4237 router_entropy_bonus:0.1846
+step:170/20000 router_probe window_steps:10 avg_depth:4.369 router_objective:-0.3269 router_entropy:1.4434
+step:170/20000 router_matrix
+step:170/20000 train_loss:3.0618 train_time:54890ms step_avg:322.88ms router_forward:1 router_objective:-0.3167 router_entropy:1.4755 router_entropy_bonus:0.1836
+step:180/20000 router_probe window_steps:10 avg_depth:4.378 router_objective:-0.3560 router_entropy:1.4693
+step:180/20000 router_matrix
+step:180/20000 train_loss:3.0385 train_time:58177ms step_avg:323.21ms router_forward:1 router_objective:-0.2676 router_entropy:1.4533 router_entropy_bonus:0.1826
+step:190/20000 router_probe window_steps:10 avg_depth:4.311 router_objective:-0.3443 router_entropy:1.4615
+step:190/20000 router_matrix
+step:190/20000 train_loss:3.0264 train_time:61411ms step_avg:323.22ms router_forward:1 router_objective:-0.3581 router_entropy:1.4754 router_entropy_bonus:0.1817
+step:200/20000 router_probe window_steps:10 avg_depth:4.510 router_objective:-0.3158 router_entropy:1.4409
+step:200/20000 router_matrix
+step:200/20000 train_loss:2.9727 train_time:64679ms step_avg:323.39ms router_forward:1 router_objective:-0.3175 router_entropy:1.4220 router_entropy_bonus:0.1807
+step:210/20000 router_probe window_steps:10 avg_depth:4.773 router_objective:-0.2876 router_entropy:1.4111
+step:210/20000 router_matrix
+step:210/20000 train_loss:2.9837 train_time:68445ms step_avg:325.93ms router_forward:1 router_objective:-0.2555 router_entropy:1.4305 router_entropy_bonus:0.1796
+step:220/20000 router_probe window_steps:10 avg_depth:4.242 router_objective:-0.3064 router_entropy:1.4362
+step:220/20000 router_matrix
+step:220/20000 train_loss:2.9230 train_time:71556ms step_avg:325.26ms router_forward:1 router_objective:-0.3264 router_entropy:1.4312 router_entropy_bonus:0.1786
+step:230/20000 router_probe window_steps:10 avg_depth:4.416 router_objective:-0.3118 router_entropy:1.4297
+step:230/20000 router_matrix
+step:230/20000 train_loss:2.9080 train_time:74756ms step_avg:325.02ms router_forward:1 router_objective:-0.2949 router_entropy:1.4330 router_entropy_bonus:0.1777
+step:240/20000 router_probe window_steps:10 avg_depth:4.801 router_objective:-0.3023 router_entropy:1.4659
+step:240/20000 router_matrix
+step:240/20000 train_loss:2.8787 train_time:78530ms step_avg:327.21ms router_forward:1 router_objective:-0.2604 router_entropy:1.4583 router_entropy_bonus:0.1765
+step:250/20000 router_probe window_steps:10 avg_depth:4.658 router_objective:-0.2898 router_entropy:1.4177
+step:250/20000 router_matrix
+step:250/20000 train_loss:2.8637 train_time:81828ms step_avg:327.31ms router_forward:1 router_objective:-0.2983 router_entropy:1.4127 router_entropy_bonus:0.1756
+step:260/20000 router_probe window_steps:10 avg_depth:4.864 router_objective:-0.2933 router_entropy:1.4400
+step:260/20000 router_matrix
+step:260/20000 train_loss:2.8435 train_time:85304ms step_avg:328.09ms router_forward:1 router_objective:-0.3004 router_entropy:1.4641 router_entropy_bonus:0.1745
+step:270/20000 router_probe window_steps:10 avg_depth:4.790 router_objective:-0.2980 router_entropy:1.4415
+step:270/20000 router_matrix
+step:270/20000 train_loss:2.7581 train_time:88776ms step_avg:328.80ms router_forward:1 router_objective:-0.2853 router_entropy:1.4464 router_entropy_bonus:0.1735
+step:280/20000 router_probe window_steps:10 avg_depth:4.860 router_objective:-0.3069 router_entropy:1.4393
+step:280/20000 router_matrix
+step:280/20000 train_loss:2.7840 train_time:92252ms step_avg:329.47ms router_forward:1 router_objective:-0.2716 router_entropy:1.4493 router_entropy_bonus:0.1724
+step:290/20000 router_probe window_steps:10 avg_depth:4.813 router_objective:-0.2933 router_entropy:1.4400
+step:290/20000 router_matrix
+step:290/20000 train_loss:2.7807 train_time:95804ms step_avg:330.36ms router_forward:1 router_objective:-0.2051 router_entropy:1.4131 router_entropy_bonus:0.1714
+step:300/20000 router_probe window_steps:10 avg_depth:4.781 router_objective:-0.2943 router_entropy:1.4434
+step:300/20000 router_matrix
+step:300/20000 train_loss:2.7788 train_time:99265ms step_avg:330.88ms router_forward:1 router_objective:-0.2939 router_entropy:1.4281 router_entropy_bonus:0.1703
+step:310/20000 router_probe window_steps:10 avg_depth:4.586 router_objective:-0.2788 router_entropy:1.4391
+step:310/20000 router_matrix
+step:310/20000 train_loss:2.7311 train_time:102599ms step_avg:330.97ms router_forward:1 router_objective:-0.2533 router_entropy:1.4080 router_entropy_bonus:0.1693
+step:320/20000 router_probe window_steps:10 avg_depth:4.827 router_objective:-0.2751 router_entropy:1.4209
+step:320/20000 router_matrix
+step:320/20000 train_loss:2.7733 train_time:106202ms step_avg:331.88ms router_forward:1 router_objective:-0.2265 router_entropy:1.4170 router_entropy_bonus:0.1682
+step:330/20000 router_probe window_steps:10 avg_depth:4.728 router_objective:-0.2969 router_entropy:1.4456
+step:330/20000 router_matrix
+step:330/20000 train_loss:2.7148 train_time:109648ms step_avg:332.27ms router_forward:1 router_objective:-0.2709 router_entropy:1.4349 router_entropy_bonus:0.1672
+step:340/20000 router_probe window_steps:10 avg_depth:4.778 router_objective:-0.2610 router_entropy:1.4270
+step:340/20000 router_matrix
+step:340/20000 train_loss:2.7625 train_time:113134ms step_avg:332.75ms router_forward:1 router_objective:-0.2835 router_entropy:1.4388 router_entropy_bonus:0.1662
+step:350/20000 router_probe window_steps:10 avg_depth:4.914 router_objective:-0.2623 router_entropy:1.4529
+step:350/20000 router_matrix
+step:350/20000 train_loss:2.7663 train_time:116755ms step_avg:333.59ms router_forward:1 router_objective:-0.2441 router_entropy:1.4414 router_entropy_bonus:0.1651
+step:360/20000 router_probe window_steps:10 avg_depth:5.157 router_objective:-0.2550 router_entropy:1.4348
+step:360/20000 router_matrix
+step:360/20000 train_loss:2.7316 train_time:120519ms step_avg:334.77ms router_forward:1 router_objective:-0.2620 router_entropy:1.4319 router_entropy_bonus:0.1640
+step:370/20000 router_probe window_steps:10 avg_depth:5.253 router_objective:-0.2620 router_entropy:1.4178
+step:370/20000 router_matrix
+step:370/20000 train_loss:2.7364 train_time:124432ms step_avg:336.30ms router_forward:1 router_objective:-0.2679 router_entropy:1.4358 router_entropy_bonus:0.1628
+step:380/20000 router_probe window_steps:10 avg_depth:5.335 router_objective:-0.2729 router_entropy:1.4267
+step:380/20000 router_matrix
+step:380/20000 train_loss:2.6378 train_time:128154ms step_avg:337.25ms router_forward:1 router_objective:-0.3721 router_entropy:1.4428 router_entropy_bonus:0.1617
+step:390/20000 router_probe window_steps:10 avg_depth:5.370 router_objective:-0.2688 router_entropy:1.4160
+step:390/20000 router_matrix
+step:390/20000 train_loss:2.6505 train_time:131892ms step_avg:338.19ms router_forward:1 router_objective:-0.2468 router_entropy:1.3968 router_entropy_bonus:0.1605
+step:400/20000 router_probe window_steps:10 avg_depth:5.295 router_objective:-0.2327 router_entropy:1.4170
+step:400/20000 router_matrix
+step:400/20000 train_loss:2.6892 train_time:135619ms step_avg:339.05ms router_forward:1 router_objective:-0.2681 router_entropy:1.4072 router_entropy_bonus:0.1594
+step:410/20000 router_probe window_steps:10 avg_depth:5.397 router_objective:-0.2191 router_entropy:1.4097
+step:410/20000 router_matrix
+step:410/20000 train_loss:2.7217 train_time:139443ms step_avg:340.11ms router_forward:1 router_objective:-0.2332 router_entropy:1.4354 router_entropy_bonus:0.1583
+step:420/20000 router_probe window_steps:10 avg_depth:5.440 router_objective:-0.2160 router_entropy:1.4450
+step:420/20000 router_matrix
+step:420/20000 train_loss:2.6739 train_time:143291ms step_avg:341.17ms router_forward:1 router_objective:-0.3049 router_entropy:1.4413 router_entropy_bonus:0.1571
+step:430/20000 router_probe window_steps:10 avg_depth:5.630 router_objective:-0.2175 router_entropy:1.4283
+step:430/20000 router_matrix
+step:430/20000 train_loss:2.6718 train_time:147153ms step_avg:342.22ms router_forward:1 router_objective:-0.2280 router_entropy:1.4489 router_entropy_bonus:0.1560
+step:440/20000 router_probe window_steps:10 avg_depth:5.540 router_objective:-0.2149 router_entropy:1.4249
+step:440/20000 router_matrix
+step:440/20000 train_loss:2.6486 train_time:151106ms step_avg:343.42ms router_forward:1 router_objective:-0.1381 router_entropy:1.4078 router_entropy_bonus:0.1548
+step:450/20000 router_probe window_steps:10 avg_depth:5.146 router_objective:-0.2213 router_entropy:1.4396
+step:450/20000 router_matrix
+step:450/20000 train_loss:2.7058 train_time:154725ms step_avg:343.83ms router_forward:1 router_objective:-0.2137 router_entropy:1.4266 router_entropy_bonus:0.1537
+step:460/20000 router_probe window_steps:10 avg_depth:5.496 router_objective:-0.2256 router_entropy:1.4302
+step:460/20000 router_matrix
+step:460/20000 train_loss:2.6848 train_time:158550ms step_avg:344.67ms router_forward:1 router_objective:-0.2623 router_entropy:1.4543 router_entropy_bonus:0.1526
+step:470/20000 router_probe window_steps:10 avg_depth:5.746 router_objective:-0.2468 router_entropy:1.4437
+step:470/20000 router_matrix
+step:470/20000 train_loss:2.6221 train_time:162599ms step_avg:345.95ms router_forward:1 router_objective:-0.2394 router_entropy:1.4317 router_entropy_bonus:0.1513
+step:480/20000 router_probe window_steps:10 avg_depth:5.305 router_objective:-0.2052 router_entropy:1.3959
+step:480/20000 router_matrix
+step:480/20000 train_loss:2.7174 train_time:166304ms step_avg:346.47ms router_forward:1 router_objective:-0.2292 router_entropy:1.3850 router_entropy_bonus:0.1502
+step:490/20000 router_probe window_steps:10 avg_depth:5.516 router_objective:-0.1954 router_entropy:1.3959
+step:490/20000 router_matrix
+step:490/20000 train_loss:2.7020 train_time:170070ms step_avg:347.08ms router_forward:1 router_objective:-0.2132 router_entropy:1.4236 router_entropy_bonus:0.1491
+step:500/20000 router_probe window_steps:10 avg_depth:5.912 router_objective:-0.2142 router_entropy:1.4368
+step:500/20000 router_matrix
+step:500/20000 train_loss:2.6841 train_time:174159ms step_avg:348.32ms router_forward:1 router_objective:-0.2180 router_entropy:1.4317 router_entropy_bonus:0.1479
+step:510/20000 router_probe window_steps:10 avg_depth:5.597 router_objective:-0.2189 router_entropy:1.4302
+step:510/20000 router_matrix
+step:510/20000 train_loss:2.7381 train_time:178054ms step_avg:349.13ms router_forward:1 router_objective:-0.2076 router_entropy:1.4252 router_entropy_bonus:0.1467
+step:520/20000 router_probe window_steps:10 avg_depth:5.555 router_objective:-0.1894 router_entropy:1.4056
+step:520/20000 router_matrix
+step:520/20000 train_loss:2.5934 train_time:181916ms step_avg:349.84ms router_forward:1 router_objective:-0.1382 router_entropy:1.3834 router_entropy_bonus:0.1455
+step:530/20000 router_probe window_steps:10 avg_depth:6.150 router_objective:-0.2070 router_entropy:1.4157
+step:530/20000 router_matrix
+step:530/20000 train_loss:2.6097 train_time:186051ms step_avg:351.04ms router_forward:1 router_objective:-0.3022 router_entropy:1.4202 router_entropy_bonus:0.1443
+step:540/20000 router_probe window_steps:10 avg_depth:5.640 router_objective:-0.1941 router_entropy:1.3913
+step:540/20000 router_matrix
+step:540/20000 train_loss:2.6735 train_time:189826ms step_avg:351.53ms router_forward:1 router_objective:-0.2279 router_entropy:1.4143 router_entropy_bonus:0.1432
+step:550/20000 router_probe window_steps:10 avg_depth:5.823 router_objective:-0.2114 router_entropy:1.4032
+step:550/20000 router_matrix
+step:550/20000 train_loss:2.6235 train_time:193930ms step_avg:352.60ms router_forward:1 router_objective:-0.1774 router_entropy:1.4070 router_entropy_bonus:0.1419
+step:560/20000 router_probe window_steps:10 avg_depth:5.773 router_objective:-0.2238 router_entropy:1.4310
+step:560/20000 router_matrix
+step:560/20000 train_loss:2.5895 train_time:197910ms step_avg:353.41ms router_forward:1 router_objective:-0.1755 router_entropy:1.4167 router_entropy_bonus:0.1407
+step:570/20000 router_probe window_steps:10 avg_depth:6.303 router_objective:-0.2156 router_entropy:1.4201
+step:570/20000 router_matrix
+step:570/20000 train_loss:2.5994 train_time:202169ms step_avg:354.68ms router_forward:1 router_objective:-0.1864 router_entropy:1.4146 router_entropy_bonus:0.1395
+step:580/20000 router_probe window_steps:10 avg_depth:6.074 router_objective:-0.2153 router_entropy:1.4085
+step:580/20000 router_matrix
+step:580/20000 train_loss:2.5678 train_time:206301ms step_avg:355.69ms router_forward:1 router_objective:-0.2464 router_entropy:1.3879 router_entropy_bonus:0.1382
+step:590/20000 router_probe window_steps:10 avg_depth:6.664 router_objective:-0.2184 router_entropy:1.3921
+step:590/20000 router_matrix
+step:590/20000 train_loss:2.6410 train_time:210750ms step_avg:357.20ms router_forward:1 router_objective:-0.1916 router_entropy:1.4271 router_entropy_bonus:0.1369
+step:600/20000 router_probe window_steps:10 avg_depth:5.967 router_objective:-0.2363 router_entropy:1.4136
+step:600/20000 router_matrix
+step:600/20000 train_loss:2.6996 train_time:214835ms step_avg:358.06ms router_forward:1 router_objective:-0.2364 router_entropy:1.3893 router_entropy_bonus:0.1357
+step:610/20000 router_probe window_steps:10 avg_depth:6.009 router_objective:-0.1983 router_entropy:1.4003
+step:610/20000 router_matrix
+step:610/20000 train_loss:2.6004 train_time:218941ms step_avg:358.92ms router_forward:1 router_objective:-0.1543 router_entropy:1.4106 router_entropy_bonus:0.1344
+step:620/20000 router_probe window_steps:10 avg_depth:6.449 router_objective:-0.2184 router_entropy:1.4239
+step:620/20000 router_matrix
+step:620/20000 train_loss:2.6038 train_time:223371ms step_avg:360.28ms router_forward:1 router_objective:-0.1841 router_entropy:1.4284 router_entropy_bonus:0.1331
+step:630/20000 router_probe window_steps:10 avg_depth:6.372 router_objective:-0.2076 router_entropy:1.3887
+step:630/20000 router_matrix
+step:630/20000 train_loss:2.6643 train_time:227718ms step_avg:361.46ms router_forward:1 router_objective:-0.1964 router_entropy:1.3552 router_entropy_bonus:0.1318
+step:640/20000 router_probe window_steps:10 avg_depth:5.655 router_objective:-0.1735 router_entropy:1.3628
+step:640/20000 router_matrix
+step:640/20000 train_loss:2.5699 train_time:231665ms step_avg:361.98ms router_forward:1 router_objective:-0.1565 router_entropy:1.3944 router_entropy_bonus:0.1306
+step:650/20000 router_probe window_steps:10 avg_depth:6.253 router_objective:-0.2000 router_entropy:1.4360
+step:650/20000 router_matrix
+step:650/20000 train_loss:2.6870 train_time:235988ms step_avg:363.06ms router_forward:1 router_objective:-0.2485 router_entropy:1.4326 router_entropy_bonus:0.1293
+step:660/20000 router_probe window_steps:10 avg_depth:5.367 router_objective:-0.1714 router_entropy:1.3816
+step:660/20000 router_matrix
+step:660/20000 train_loss:2.6197 train_time:239712ms step_avg:363.20ms router_forward:1 router_objective:-0.1671 router_entropy:1.3838 router_entropy_bonus:0.1282
+step:670/20000 router_probe window_steps:10 avg_depth:6.409 router_objective:-0.2035 router_entropy:1.4162
+step:670/20000 router_matrix
+step:670/20000 train_loss:2.6610 train_time:244078ms step_avg:364.30ms router_forward:1 router_objective:-0.2005 router_entropy:1.4239 router_entropy_bonus:0.1269
+step:680/20000 router_probe window_steps:10 avg_depth:6.342 router_objective:-0.2305 router_entropy:1.4074
+step:680/20000 router_matrix
+step:680/20000 train_loss:2.5553 train_time:248340ms step_avg:365.21ms router_forward:1 router_objective:-0.2382 router_entropy:1.3810 router_entropy_bonus:0.1256
+step:690/20000 router_probe window_steps:10 avg_depth:6.859 router_objective:-0.2042 router_entropy:1.3806
+step:690/20000 router_matrix
+step:690/20000 train_loss:2.6095 train_time:252875ms step_avg:366.49ms router_forward:1 router_objective:-0.2600 router_entropy:1.3903 router_entropy_bonus:0.1243
+step:700/20000 router_probe window_steps:10 avg_depth:6.097 router_objective:-0.1769 router_entropy:1.3969
+step:700/20000 router_matrix
+step:700/20000 train_loss:2.5449 train_time:256991ms step_avg:367.13ms router_forward:1 router_objective:-0.1897 router_entropy:1.4291 router_entropy_bonus:0.1230
+step:710/20000 router_probe window_steps:10 avg_depth:6.152 router_objective:-0.1946 router_entropy:1.4315
+step:710/20000 router_matrix
+step:710/20000 train_loss:2.6295 train_time:261134ms step_avg:367.79ms router_forward:1 router_objective:-0.2263 router_entropy:1.4085 router_entropy_bonus:0.1218
+step:720/20000 router_probe window_steps:10 avg_depth:5.478 router_objective:-0.1828 router_entropy:1.3667
+step:720/20000 router_matrix
+step:720/20000 train_loss:2.5007 train_time:264746ms step_avg:367.70ms router_forward:1 router_objective:-0.1959 router_entropy:1.3690 router_entropy_bonus:0.1207
+step:730/20000 router_probe window_steps:10 avg_depth:7.072 router_objective:-0.1977 router_entropy:1.3526
+step:730/20000 router_matrix
+step:730/20000 train_loss:2.5676 train_time:269258ms step_avg:368.85ms router_forward:1 router_objective:-0.2031 router_entropy:1.3422 router_entropy_bonus:0.1194
+step:740/20000 router_probe window_steps:10 avg_depth:6.776 router_objective:-0.1958 router_entropy:1.3527
+step:740/20000 router_matrix
+step:740/20000 train_loss:2.5909 train_time:273667ms step_avg:369.82ms router_forward:1 router_objective:-0.1869 router_entropy:1.3821 router_entropy_bonus:0.1180
+step:750/20000 router_probe window_steps:10 avg_depth:6.267 router_objective:-0.1960 router_entropy:1.4316
+step:750/20000 router_matrix
+step:750/20000 train_loss:2.5990 train_time:277965ms step_avg:370.62ms router_forward:1 router_objective:-0.2422 router_entropy:1.4448 router_entropy_bonus:0.1167
+step:760/20000 router_probe window_steps:10 avg_depth:5.759 router_objective:-0.1847 router_entropy:1.3965
+step:760/20000 router_matrix
+step:760/20000 train_loss:2.5490 train_time:281848ms step_avg:370.85ms router_forward:1 router_objective:-0.2078 router_entropy:1.3756 router_entropy_bonus:0.1156
+step:770/20000 router_probe window_steps:10 avg_depth:6.747 router_objective:-0.2166 router_entropy:1.3882
+step:770/20000 router_matrix
+step:770/20000 train_loss:2.5796 train_time:286312ms step_avg:371.83ms router_forward:1 router_objective:-0.1817 router_entropy:1.3835 router_entropy_bonus:0.1142
+step:780/20000 router_probe window_steps:10 avg_depth:5.958 router_objective:-0.1953 router_entropy:1.3912
+step:780/20000 router_matrix
+step:780/20000 train_loss:2.5771 train_time:290496ms step_avg:372.43ms router_forward:1 router_objective:-0.2092 router_entropy:1.3928 router_entropy_bonus:0.1130
+step:790/20000 router_probe window_steps:10 avg_depth:6.610 router_objective:-0.2013 router_entropy:1.3641
+step:790/20000 router_matrix
+step:790/20000 train_loss:2.5016 train_time:294883ms step_avg:373.27ms router_forward:1 router_objective:-0.2057 router_entropy:1.3562 router_entropy_bonus:0.1117
+step:800/20000 router_probe window_steps:10 avg_depth:7.427 router_objective:-0.1633 router_entropy:1.3572
+step:800/20000 router_matrix
+step:800/20000 train_loss:2.5732 train_time:299675ms step_avg:374.59ms router_forward:1 router_objective:-0.1648 router_entropy:1.3548 router_entropy_bonus:0.1103
+step:810/20000 router_probe window_steps:10 avg_depth:8.263 router_objective:-0.1703 router_entropy:1.3729
+step:810/20000 router_matrix
+step:810/20000 train_loss:2.5679 train_time:305000ms step_avg:376.54ms router_forward:1 router_objective:-0.1115 router_entropy:1.3718 router_entropy_bonus:0.1086
+step:820/20000 router_probe window_steps:10 avg_depth:5.528 router_objective:-0.1412 router_entropy:1.3576
+step:820/20000 router_matrix
+step:820/20000 train_loss:2.5387 train_time:308652ms step_avg:376.40ms router_forward:1 router_objective:-0.1396 router_entropy:1.3512 router_entropy_bonus:0.1075
+step:830/20000 router_probe window_steps:10 avg_depth:6.582 router_objective:-0.1539 router_entropy:1.3745
+step:830/20000 router_matrix
+step:830/20000 train_loss:2.5770 train_time:312995ms step_avg:377.10ms router_forward:1 router_objective:-0.1516 router_entropy:1.3771 router_entropy_bonus:0.1062
+step:840/20000 router_probe window_steps:10 avg_depth:6.847 router_objective:-0.1244 router_entropy:1.3573
+step:840/20000 router_matrix
+step:840/20000 train_loss:2.5518 train_time:317456ms step_avg:377.92ms router_forward:1 router_objective:-0.1225 router_entropy:1.3685 router_entropy_bonus:0.1049
+step:850/20000 router_probe window_steps:10 avg_depth:7.006 router_objective:-0.1230 router_entropy:1.3840
+step:850/20000 router_matrix
+step:850/20000 train_loss:2.6068 train_time:322027ms step_avg:378.86ms router_forward:1 router_objective:-0.1080 router_entropy:1.3960 router_entropy_bonus:0.1035
+step:860/20000 router_probe window_steps:10 avg_depth:6.258 router_objective:-0.1328 router_entropy:1.4127
+step:860/20000 router_matrix
+step:860/20000 train_loss:2.5265 train_time:326219ms step_avg:379.32ms router_forward:1 router_objective:-0.1316 router_entropy:1.4158 router_entropy_bonus:0.1022
+step:870/20000 router_probe window_steps:10 avg_depth:5.835 router_objective:-0.1342 router_entropy:1.4044
+step:870/20000 router_matrix
+step:870/20000 train_loss:2.5481 train_time:330089ms step_avg:379.41ms router_forward:1 router_objective:-0.1787 router_entropy:1.4022 router_entropy_bonus:0.1011
+step:880/20000 router_probe window_steps:10 avg_depth:5.845 router_objective:-0.1381 router_entropy:1.3811
+step:880/20000 router_matrix
+step:880/20000 train_loss:2.4972 train_time:333955ms step_avg:379.49ms router_forward:1 router_objective:-0.1708 router_entropy:1.3801 router_entropy_bonus:0.0999
+step:890/20000 router_probe window_steps:10 avg_depth:5.435 router_objective:-0.1534 router_entropy:1.3898
+step:890/20000 router_matrix
+step:890/20000 train_loss:2.5210 train_time:337606ms step_avg:379.33ms router_forward:1 router_objective:-0.1398 router_entropy:1.3796 router_entropy_bonus:0.0988
+step:900/20000 router_probe window_steps:10 avg_depth:6.859 router_objective:-0.1822 router_entropy:1.3758
+step:900/20000 router_matrix
+step:900/20000 train_loss:2.4869 train_time:342041ms step_avg:380.05ms router_forward:1 router_objective:-0.2312 router_entropy:1.3767 router_entropy_bonus:0.0975
+step:910/20000 router_probe window_steps:10 avg_depth:6.613 router_objective:-0.1618 router_entropy:1.3675
+step:910/20000 router_matrix
+step:910/20000 train_loss:2.4868 train_time:346472ms step_avg:380.74ms router_forward:1 router_objective:-0.1818 router_entropy:1.3580 router_entropy_bonus:0.0962
+step:920/20000 router_probe window_steps:10 avg_depth:5.491 router_objective:-0.1350 router_entropy:1.3823
+step:920/20000 router_matrix
+step:920/20000 train_loss:2.5526 train_time:350107ms step_avg:380.55ms router_forward:1 router_objective:-0.1887 router_entropy:1.4255 router_entropy_bonus:0.0951
+step:930/20000 router_probe window_steps:10 avg_depth:6.142 router_objective:-0.1371 router_entropy:1.4269
+step:930/20000 router_matrix
+step:930/20000 train_loss:2.4709 train_time:354273ms step_avg:380.94ms router_forward:1 router_objective:-0.1073 router_entropy:1.4072 router_entropy_bonus:0.0938
+step:940/20000 router_probe window_steps:10 avg_depth:6.091 router_objective:-0.1350 router_entropy:1.3941
+step:940/20000 router_matrix
+step:940/20000 train_loss:2.5263 train_time:358629ms step_avg:381.52ms router_forward:1 router_objective:-0.0903 router_entropy:1.3733 router_entropy_bonus:0.0925
+step:950/20000 router_probe window_steps:10 avg_depth:5.809 router_objective:-0.1106 router_entropy:1.4093
+step:950/20000 router_matrix
+step:950/20000 train_loss:2.4818 train_time:362516ms step_avg:381.60ms router_forward:1 router_objective:-0.1552 router_entropy:1.4290 router_entropy_bonus:0.0914
+step:960/20000 router_probe window_steps:10 avg_depth:6.114 router_objective:-0.1165 router_entropy:1.4192
+step:960/20000 router_matrix
+step:960/20000 train_loss:2.4286 train_time:366648ms step_avg:381.92ms router_forward:1 router_objective:-0.1492 router_entropy:1.3969 router_entropy_bonus:0.0901
+step:970/20000 router_probe window_steps:10 avg_depth:6.152 router_objective:-0.1274 router_entropy:1.3516
+step:970/20000 router_matrix
+step:970/20000 train_loss:2.4720 train_time:370642ms step_avg:382.10ms router_forward:1 router_objective:-0.1175 router_entropy:1.3249 router_entropy_bonus:0.0889
+step:980/20000 router_probe window_steps:10 avg_depth:8.804 router_objective:-0.1402 router_entropy:1.3156
+step:980/20000 router_matrix
+step:980/20000 train_loss:2.4786 train_time:376116ms step_avg:383.79ms router_forward:1 router_objective:-0.1642 router_entropy:1.3079 router_entropy_bonus:0.0873
+step:990/20000 router_probe window_steps:10 avg_depth:8.614 router_objective:-0.1141 router_entropy:1.3048
+step:990/20000 router_matrix
+step:990/20000 train_loss:2.5620 train_time:381515ms step_avg:385.37ms router_forward:1 router_objective:-0.0904 router_entropy:1.3180 router_entropy_bonus:0.0857
+step:1000/20000 router_probe window_steps:10 avg_depth:7.197 router_objective:-0.1349 router_entropy:1.3773
+step:1000/20000 router_matrix
+step:1000/20000 train_loss:2.4169 train_time:386170ms step_avg:386.17ms router_forward:1 router_objective:-0.1578 router_entropy:1.4094 router_entropy_bonus:0.0843
+step:1010/20000 router_probe window_steps:10 avg_depth:6.708 router_objective:-0.1411 router_entropy:1.4014
+step:1010/20000 router_matrix
+step:1010/20000 train_loss:2.5597 train_time:390725ms step_avg:386.86ms router_forward:1 router_objective:-0.1076 router_entropy:1.3751 router_entropy_bonus:0.0829
+step:1020/20000 router_probe window_steps:10 avg_depth:6.535 router_objective:-0.1096 router_entropy:1.3584
+step:1020/20000 router_matrix
+step:1020/20000 train_loss:2.5291 train_time:395126ms step_avg:387.38ms router_forward:1 router_objective:-0.1157 router_entropy:1.3493 router_entropy_bonus:0.0816
+step:1030/20000 router_probe window_steps:10 avg_depth:5.880 router_objective:-0.0928 router_entropy:1.3536
+step:1030/20000 router_matrix
+step:1030/20000 train_loss:2.4908 train_time:398909ms step_avg:387.29ms router_forward:1 router_objective:-0.1153 router_entropy:1.3698 router_entropy_bonus:0.0804
+step:1040/20000 router_probe window_steps:10 avg_depth:6.647 router_objective:-0.0960 router_entropy:1.3915
+step:1040/20000 router_matrix
+step:1040/20000 train_loss:2.4878 train_time:403218ms step_avg:387.71ms router_forward:1 router_objective:-0.0685 router_entropy:1.4048 router_entropy_bonus:0.0792
+step:1050/20000 router_probe window_steps:10 avg_depth:6.705 router_objective:-0.1048 router_entropy:1.4181
+step:1050/20000 router_matrix
+step:1050/20000 train_loss:2.5508 train_time:407656ms step_avg:388.24ms router_forward:1 router_objective:-0.1090 router_entropy:1.4040 router_entropy_bonus:0.0778
+step:1060/20000 router_probe window_steps:10 avg_depth:6.098 router_objective:-0.1085 router_entropy:1.3946
+step:1060/20000 router_matrix
+step:1060/20000 train_loss:2.4829 train_time:411653ms step_avg:388.35ms router_forward:1 router_objective:-0.1072 router_entropy:1.3809 router_entropy_bonus:0.0766
+step:1070/20000 router_probe window_steps:10 avg_depth:6.811 router_objective:-0.1264 router_entropy:1.3657
+step:1070/20000 router_matrix
+step:1070/20000 train_loss:2.4591 train_time:416024ms step_avg:388.81ms router_forward:1 router_objective:-0.1157 router_entropy:1.3604 router_entropy_bonus:0.0753
+step:1080/20000 router_probe window_steps:10 avg_depth:7.245 router_objective:-0.1458 router_entropy:1.3701
+step:1080/20000 router_matrix
+step:1080/20000 train_loss:2.4942 train_time:420684ms step_avg:389.52ms router_forward:1 router_objective:-0.1841 router_entropy:1.3805 router_entropy_bonus:0.0740
+step:1090/20000 router_probe window_steps:10 avg_depth:7.663 router_objective:-0.1728 router_entropy:1.3823
+step:1090/20000 router_matrix
+step:1090/20000 train_loss:2.5301 train_time:425581ms step_avg:390.44ms router_forward:1 router_objective:-0.1454 router_entropy:1.3734 router_entropy_bonus:0.0725
+step:1100/20000 router_probe window_steps:10 avg_depth:5.950 router_objective:-0.1151 router_entropy:1.3770
+step:1100/20000 router_matrix
+step:1100/20000 train_loss:2.4519 train_time:429476ms step_avg:390.43ms router_forward:1 router_objective:-0.1088 router_entropy:1.3938 router_entropy_bonus:0.0713
+step:1110/20000 router_probe window_steps:10 avg_depth:6.460 router_objective:-0.1511 router_entropy:1.3846
+step:1110/20000 router_matrix
+step:1110/20000 train_loss:2.4522 train_time:433712ms step_avg:390.73ms router_forward:1 router_objective:-0.1404 router_entropy:1.3667 router_entropy_bonus:0.0700
+step:1120/20000 router_probe window_steps:10 avg_depth:6.640 router_objective:-0.1459 router_entropy:1.3495
+step:1120/20000 router_matrix
+step:1120/20000 train_loss:2.5118 train_time:437969ms step_avg:391.04ms router_forward:1 router_objective:-0.1127 router_entropy:1.3367 router_entropy_bonus:0.0687
+step:1130/20000 router_probe window_steps:10 avg_depth:6.708 router_objective:-0.1335 router_entropy:1.3392
+step:1130/20000 router_matrix
+step:1130/20000 train_loss:2.4563 train_time:442483ms step_avg:391.58ms router_forward:1 router_objective:-0.2010 router_entropy:1.3387 router_entropy_bonus:0.0674
+step:1140/20000 router_probe window_steps:10 avg_depth:8.039 router_objective:-0.1320 router_entropy:1.3182
+step:1140/20000 router_matrix
+step:1140/20000 train_loss:2.4356 train_time:447573ms step_avg:392.61ms router_forward:1 router_objective:-0.1548 router_entropy:1.3101 router_entropy_bonus:0.0659
+step:1150/20000 router_probe window_steps:10 avg_depth:6.028 router_objective:-0.1031 router_entropy:1.3281
+step:1150/20000 router_matrix
+step:1150/20000 train_loss:2.5011 train_time:451505ms step_avg:392.61ms router_forward:1 router_objective:-0.1313 router_entropy:1.3473 router_entropy_bonus:0.0647
+step:1160/20000 router_probe window_steps:10 avg_depth:5.552 router_objective:-0.0893 router_entropy:1.3710
+step:1160/20000 router_matrix
+step:1160/20000 train_loss:2.5043 train_time:455177ms step_avg:392.39ms router_forward:1 router_objective:-0.0971 router_entropy:1.3856 router_entropy_bonus:0.0636
+step:1170/20000 router_probe window_steps:10 avg_depth:6.544 router_objective:-0.1170 router_entropy:1.3866
+step:1170/20000 router_matrix
+step:1170/20000 train_loss:2.4435 train_time:459603ms step_avg:392.82ms router_forward:1 router_objective:-0.1569 router_entropy:1.3828 router_entropy_bonus:0.0623
+step:1180/20000 router_probe window_steps:10 avg_depth:6.574 router_objective:-0.1189 router_entropy:1.3681
+step:1180/20000 router_matrix
+step:1180/20000 train_loss:2.4597 train_time:463838ms step_avg:393.08ms router_forward:1 router_objective:-0.1040 router_entropy:1.3576 router_entropy_bonus:0.0610
+step:1190/20000 router_probe window_steps:10 avg_depth:5.515 router_objective:-0.0814 router_entropy:1.3640
+step:1190/20000 router_matrix
+step:1190/20000 train_loss:2.4788 train_time:467463ms step_avg:392.83ms router_forward:1 router_objective:-0.0376 router_entropy:1.3729 router_entropy_bonus:0.0599
+step:1200/20000 router_probe window_steps:10 avg_depth:6.056 router_objective:-0.0890 router_entropy:1.3907
+step:1200/20000 router_matrix
+step:1200/20000 train_loss:2.4659 train_time:471416ms step_avg:392.85ms router_forward:1 router_objective:-0.0843 router_entropy:1.3952 router_entropy_bonus:0.0587
+step:1210/20000 router_probe window_steps:10 avg_depth:6.495 router_objective:-0.1008 router_entropy:1.4019
+step:1210/20000 router_matrix
+step:1210/20000 train_loss:2.4410 train_time:475644ms step_avg:393.09ms router_forward:1 router_objective:-0.0818 router_entropy:1.3964 router_entropy_bonus:0.0574
+step:1220/20000 router_probe window_steps:10 avg_depth:5.549 router_objective:-0.0832 router_entropy:1.3734
+step:1220/20000 router_matrix
+step:1220/20000 train_loss:2.4520 train_time:479292ms step_avg:392.86ms router_forward:1 router_objective:-0.0395 router_entropy:1.3556 router_entropy_bonus:0.0563
+step:1230/20000 router_probe window_steps:10 avg_depth:5.166 router_objective:-0.0648 router_entropy:1.3661
+step:1230/20000 router_matrix
+step:1230/20000 train_loss:2.4705 train_time:482653ms step_avg:392.40ms router_forward:1 router_objective:-0.0791 router_entropy:1.3817 router_entropy_bonus:0.0553
+step:1240/20000 router_probe window_steps:10 avg_depth:5.532 router_objective:-0.0775 router_entropy:1.3921
+step:1240/20000 router_matrix
+step:1240/20000 train_loss:2.4490 train_time:486299ms step_avg:392.18ms router_forward:1 router_objective:-0.1086 router_entropy:1.3920 router_entropy_bonus:0.0542
+step:1250/20000 router_probe window_steps:10 avg_depth:5.320 router_objective:-0.0830 router_entropy:1.3682
+step:1250/20000 router_matrix
+step:1250/20000 train_loss:2.4396 train_time:489806ms step_avg:391.84ms router_forward:1 router_objective:-0.0677 router_entropy:1.3593 router_entropy_bonus:0.0532
+step:1260/20000 router_probe window_steps:10 avg_depth:5.307 router_objective:-0.0602 router_entropy:1.3561
+step:1260/20000 router_matrix
+step:1260/20000 train_loss:2.5344 train_time:493281ms step_avg:391.49ms router_forward:1 router_objective:-0.0449 router_entropy:1.3590 router_entropy_bonus:0.0521
+step:1270/20000 router_probe window_steps:10 avg_depth:5.813 router_objective:-0.0522 router_entropy:1.3562
+step:1270/20000 router_matrix
+step:1270/20000 train_loss:2.4591 train_time:497036ms step_avg:391.37ms router_forward:1 router_objective:-0.0419 router_entropy:1.3616 router_entropy_bonus:0.0510
+step:1280/20000 router_probe window_steps:10 avg_depth:6.393 router_objective:-0.0609 router_entropy:1.3732
+step:1280/20000 router_matrix
+step:1280/20000 train_loss:2.4147 train_time:501157ms step_avg:391.53ms router_forward:1 router_objective:-0.0906 router_entropy:1.3794 router_entropy_bonus:0.0498
+step:1290/20000 router_probe window_steps:10 avg_depth:6.603 router_objective:-0.0551 router_entropy:1.3638
+step:1290/20000 router_matrix
+step:1290/20000 train_loss:2.3846 train_time:505426ms step_avg:391.80ms router_forward:1 router_objective:-0.0506 router_entropy:1.3506 router_entropy_bonus:0.0485
+step:1300/20000 router_probe window_steps:10 avg_depth:6.401 router_objective:-0.0587 router_entropy:1.3389
+step:1300/20000 router_matrix
+step:1300/20000 train_loss:2.4232 train_time:509556ms step_avg:391.97ms router_forward:1 router_objective:-0.0794 router_entropy:1.3417 router_entropy_bonus:0.0473
+step:1310/20000 router_probe window_steps:10 avg_depth:6.247 router_objective:-0.0491 router_entropy:1.3519
+step:1310/20000 router_matrix
+step:1310/20000 train_loss:2.3663 train_time:513611ms step_avg:392.07ms router_forward:1 router_objective:-0.0405 router_entropy:1.3653 router_entropy_bonus:0.0460
+step:1320/20000 router_probe window_steps:10 avg_depth:5.893 router_objective:-0.0696 router_entropy:1.3703
+step:1320/20000 router_matrix
+step:1320/20000 train_loss:2.3649 train_time:517430ms step_avg:391.99ms router_forward:1 router_objective:-0.0471 router_entropy:1.3691 router_entropy_bonus:0.0449
+step:1330/20000 router_probe window_steps:10 avg_depth:5.512 router_objective:-0.0517 router_entropy:1.3647
+step:1330/20000 router_matrix
+step:1330/20000 train_loss:2.3615 train_time:521009ms step_avg:391.74ms router_forward:1 router_objective:-0.0546 router_entropy:1.3613 router_entropy_bonus:0.0438
+step:1340/20000 router_probe window_steps:10 avg_depth:5.683 router_objective:-0.0668 router_entropy:1.3554
+step:1340/20000 router_matrix
+step:1340/20000 train_loss:2.4149 train_time:524685ms step_avg:391.56ms router_forward:1 router_objective:-0.0694 router_entropy:1.3463 router_entropy_bonus:0.0427
+step:1350/20000 router_probe window_steps:10 avg_depth:5.887 router_objective:-0.0524 router_entropy:1.3407
+step:1350/20000 router_matrix
+step:1350/20000 train_loss:2.3798 train_time:528451ms step_avg:391.45ms router_forward:1 router_objective:-0.0996 router_entropy:1.3352 router_entropy_bonus:0.0416
+step:1360/20000 router_probe window_steps:10 avg_depth:6.036 router_objective:-0.0667 router_entropy:1.3336
+step:1360/20000 router_matrix
+step:1360/20000 train_loss:2.3929 train_time:532293ms step_avg:391.39ms router_forward:1 router_objective:-0.0672 router_entropy:1.3325 router_entropy_bonus:0.0404
+step:1370/20000 router_probe window_steps:10 avg_depth:5.826 router_objective:-0.0642 router_entropy:1.3253
+step:1370/20000 router_matrix
+step:1370/20000 train_loss:2.3949 train_time:536004ms step_avg:391.24ms router_forward:1 router_objective:-0.0769 router_entropy:1.3231 router_entropy_bonus:0.0393
+step:1380/20000 router_probe window_steps:10 avg_depth:5.803 router_objective:-0.0509 router_entropy:1.3205
+step:1380/20000 router_matrix
+step:1380/20000 train_loss:2.3635 train_time:539727ms step_avg:391.11ms router_forward:1 router_objective:-0.0364 router_entropy:1.3134 router_entropy_bonus:0.0382
+step:1390/20000 router_probe window_steps:10 avg_depth:6.082 router_objective:-0.0569 router_entropy:1.3210
+step:1390/20000 router_matrix
+step:1390/20000 train_loss:2.3944 train_time:543576ms step_avg:391.06ms router_forward:1 router_objective:-0.0289 router_entropy:1.3193 router_entropy_bonus:0.0370
+step:1400/20000 router_probe window_steps:10 avg_depth:6.287 router_objective:-0.0472 router_entropy:1.3144
+step:1400/20000 router_matrix
+step:1400/20000 train_loss:2.3931 train_time:547566ms step_avg:391.12ms router_forward:1 router_objective:-0.0182 router_entropy:1.3212 router_entropy_bonus:0.0358
+step:1410/20000 router_probe window_steps:10 avg_depth:6.243 router_objective:-0.0539 router_entropy:1.3058
+step:1410/20000 router_matrix
+step:1410/20000 train_loss:2.3653 train_time:551498ms step_avg:391.13ms router_forward:1 router_objective:-0.0630 router_entropy:1.2927 router_entropy_bonus:0.0347
+step:1420/20000 router_probe window_steps:10 avg_depth:6.096 router_objective:-0.0354 router_entropy:1.2972
+step:1420/20000 router_matrix
+step:1420/20000 train_loss:2.3593 train_time:555321ms step_avg:391.07ms router_forward:1 router_objective:-0.0541 router_entropy:1.2923 router_entropy_bonus:0.0335
+step:1430/20000 router_probe window_steps:10 avg_depth:6.397 router_objective:-0.0544 router_entropy:1.2938
+step:1430/20000 router_matrix
+step:1430/20000 train_loss:2.3811 train_time:559370ms step_avg:391.17ms router_forward:1 router_objective:-0.0407 router_entropy:1.2895 router_entropy_bonus:0.0323
+step:1440/20000 router_probe window_steps:10 avg_depth:6.371 router_objective:-0.0287 router_entropy:1.2880
+step:1440/20000 router_matrix
+step:1440/20000 train_loss:2.3309 train_time:563358ms step_avg:391.22ms router_forward:1 router_objective:-0.0405 router_entropy:1.2966 router_entropy_bonus:0.0311
+step:1450/20000 router_probe window_steps:10 avg_depth:6.471 router_objective:-0.0481 router_entropy:1.2904
+step:1450/20000 router_matrix
+step:1450/20000 train_loss:2.3349 train_time:567410ms step_avg:391.32ms router_forward:1 router_objective:-0.0327 router_entropy:1.2832 router_entropy_bonus:0.0299
+step:1460/20000 router_probe window_steps:10 avg_depth:6.338 router_objective:-0.0436 router_entropy:1.2813
+step:1460/20000 router_matrix
+step:1460/20000 train_loss:2.4077 train_time:571371ms step_avg:391.35ms router_forward:1 router_objective:-0.0769 router_entropy:1.2822 router_entropy_bonus:0.0287
+step:1470/20000 router_probe window_steps:10 avg_depth:6.328 router_objective:-0.0424 router_entropy:1.2805
+step:1470/20000 router_matrix
+step:1470/20000 train_loss:2.3287 train_time:575314ms step_avg:391.37ms router_forward:1 router_objective:-0.0406 router_entropy:1.2840 router_entropy_bonus:0.0275
+step:1480/20000 router_probe window_steps:10 avg_depth:6.361 router_objective:-0.0371 router_entropy:1.2817
+step:1480/20000 router_matrix
+step:1480/20000 train_loss:2.3572 train_time:579307ms step_avg:391.42ms router_forward:1 router_objective:-0.0564 router_entropy:1.2826 router_entropy_bonus:0.0263
+step:1490/20000 router_probe window_steps:10 avg_depth:6.341 router_objective:-0.0436 router_entropy:1.2793
+step:1490/20000 router_matrix
+step:1490/20000 train_loss:2.3626 train_time:583262ms step_avg:391.45ms router_forward:1 router_objective:-0.0382 router_entropy:1.2857 router_entropy_bonus:0.0251
+step:1500/20000 router_probe window_steps:10 avg_depth:6.280 router_objective:-0.0351 router_entropy:1.2819
+step:1500/20000 router_matrix
+step:1500/20000 train_loss:2.3821 train_time:587172ms step_avg:391.45ms router_forward:1 router_objective:-0.0446 router_entropy:1.2839 router_entropy_bonus:0.0240
+step:1510/20000 router_probe window_steps:10 avg_depth:6.203 router_objective:-0.0332 router_entropy:1.2864
+step:1510/20000 router_matrix
+step:1510/20000 train_loss:2.3881 train_time:591058ms step_avg:391.43ms router_forward:1 router_objective:-0.0392 router_entropy:1.2923 router_entropy_bonus:0.0228
+step:1520/20000 router_probe window_steps:10 avg_depth:6.086 router_objective:-0.0371 router_entropy:1.2942
+step:1520/20000 router_matrix
+step:1520/20000 train_loss:2.3477 train_time:595199ms step_avg:391.58ms router_forward:1 router_objective:-0.0451 router_entropy:1.2910 router_entropy_bonus:0.0216
+step:1530/20000 router_probe window_steps:10 avg_depth:6.055 router_objective:-0.0321 router_entropy:1.2945
+step:1530/20000 router_matrix
+step:1530/20000 train_loss:2.3385 train_time:599027ms step_avg:391.52ms router_forward:1 router_objective:-0.0486 router_entropy:1.2863 router_entropy_bonus:0.0204
+stopping_early: wallclock_cap train_time:600173ms step:1533/20000
+peak memory allocated: 69699 MiB reserved: 76004 MiB
+ema:applying EMA weights
+Serialized model: 76314608 bytes
+Serialized model int6+zlib: 7896324 bytes
+final_int6_roundtrip val_loss:2.5808 val_bpb:1.5285 eval_time:7571ms
+final_int6_roundtrip_exact val_loss:2.58081454 val_bpb:1.52850374

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_2_dashboard_20260419_161439_9b946387.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_2_dashboard_20260419_161439_9b946387.stdout.log
@@ -1,0 +1,790 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260419_161439_9b946387.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+model_params:32867285
+router_params:344708
+unique_blocks:3 recurrent_steps:12
+world_size:8 grad_accum_steps:1
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 warmdown_frac:0.72 min_lr:0.0000 val_loss_every:0 num_recurrent_steps:12 max_wallclock_seconds:600.000
+router_actions:4 eval_recurrent_steps:12
+router_input_dim:2688 router_hidden_dim:128 router_lr:0.001 router_wd:0.01 router_entropy_bonus_start:0.2 router_entropy_bonus_end:0.02 router_step_penalty:0.02 compiled_routed_experts:0 activation_checkpointing:0 ema_decay:0.9965 muon_momentum_warmup_steps:1500
+warmup_step:1/20
+warmup_step:10/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9585 train_time:286ms step_avg:286.17ms router_forward:1 router_objective:-0.4410 router_entropy:1.3029 router_entropy_bonus:0.2000
+step:2/20000 train_loss:11.8491 train_time:531ms step_avg:265.60ms router_forward:1 router_objective:0.5696 router_entropy:1.3113 router_entropy_bonus:0.1999
+step:3/20000 train_loss:10.3601 train_time:820ms step_avg:273.42ms router_forward:1 router_objective:1.8584 router_entropy:1.3127 router_entropy_bonus:0.1998
+step:4/20000 train_loss:8.3221 train_time:1109ms step_avg:277.24ms router_forward:1 router_objective:1.0072 router_entropy:1.2945 router_entropy_bonus:0.1998
+step:5/20000 train_loss:6.8558 train_time:1481ms step_avg:296.10ms router_forward:1 router_objective:0.0838 router_entropy:1.2419 router_entropy_bonus:0.1997
+step:6/20000 train_loss:6.2043 train_time:1961ms step_avg:326.80ms router_forward:1 router_objective:-0.4083 router_entropy:1.1997 router_entropy_bonus:0.1996
+step:7/20000 train_loss:6.0230 train_time:2446ms step_avg:349.45ms router_forward:1 router_objective:-0.4680 router_entropy:1.2013 router_entropy_bonus:0.1994
+step:8/20000 train_loss:5.9743 train_time:2900ms step_avg:362.56ms router_forward:1 router_objective:-0.4853 router_entropy:1.2201 router_entropy_bonus:0.1993
+step:9/20000 train_loss:5.9639 train_time:3298ms step_avg:366.42ms router_forward:1 router_objective:-0.4847 router_entropy:1.2490 router_entropy_bonus:0.1991
+step:10/20000 router_probe window_steps:10 avg_depth:6.504 router_objective:0.0807 router_entropy:1.2608
+step:10/20000 router_matrix
+step:10/20000 train_loss:5.9040 train_time:3654ms step_avg:365.38ms router_forward:1 router_objective:-0.4247 router_entropy:1.2745 router_entropy_bonus:0.1990
+step:20/20000 router_probe window_steps:10 avg_depth:4.033 router_objective:-0.2495 router_entropy:1.2999
+step:20/20000 router_matrix
+step:20/20000 train_loss:5.2420 train_time:6150ms step_avg:307.50ms router_forward:1 router_objective:-0.2308 router_entropy:1.2942 router_entropy_bonus:0.1982
+step:30/20000 router_probe window_steps:10 avg_depth:3.107 router_objective:-0.2202 router_entropy:1.2767
+step:30/20000 router_matrix
+step:30/20000 train_loss:4.5055 train_time:8143ms step_avg:271.42ms router_forward:1 router_objective:-0.2612 router_entropy:1.2639 router_entropy_bonus:0.1976
+step:40/20000 router_probe window_steps:10 avg_depth:3.662 router_objective:-0.2838 router_entropy:1.2223
+step:40/20000 router_matrix
+step:40/20000 train_loss:3.9604 train_time:10343ms step_avg:258.57ms router_forward:1 router_objective:-0.2588 router_entropy:1.1803 router_entropy_bonus:0.1970
+step:50/20000 router_probe window_steps:10 avg_depth:3.596 router_objective:-0.3084 router_entropy:1.1414
+step:50/20000 router_matrix
+step:50/20000 train_loss:3.7186 train_time:12442ms step_avg:248.85ms router_forward:1 router_objective:-0.2839 router_entropy:1.1216 router_entropy_bonus:0.1963
+step:60/20000 router_probe window_steps:10 avg_depth:4.200 router_objective:-0.3277 router_entropy:1.1514
+step:60/20000 router_matrix
+step:60/20000 train_loss:3.5912 train_time:14923ms step_avg:248.71ms router_forward:1 router_objective:-0.4035 router_entropy:1.1625 router_entropy_bonus:0.1956
+step:70/20000 router_probe window_steps:10 avg_depth:4.025 router_objective:-0.2720 router_entropy:1.1580
+step:70/20000 router_matrix
+step:70/20000 train_loss:3.4986 train_time:17213ms step_avg:245.90ms router_forward:1 router_objective:-0.2592 router_entropy:1.1838 router_entropy_bonus:0.1949
+step:80/20000 router_probe window_steps:10 avg_depth:3.993 router_objective:-0.2594 router_entropy:1.1937
+step:80/20000 router_matrix
+step:80/20000 train_loss:3.4899 train_time:19531ms step_avg:244.13ms router_forward:1 router_objective:-0.2381 router_entropy:1.1904 router_entropy_bonus:0.1942
+step:90/20000 router_probe window_steps:10 avg_depth:3.924 router_objective:-0.2632 router_entropy:1.2121
+step:90/20000 router_matrix
+step:90/20000 train_loss:3.3573 train_time:21828ms step_avg:242.53ms router_forward:1 router_objective:-0.2509 router_entropy:1.2233 router_entropy_bonus:0.1935
+step:100/20000 router_probe window_steps:10 avg_depth:3.692 router_objective:-0.2747 router_entropy:1.2016
+step:100/20000 router_matrix
+step:100/20000 train_loss:3.2573 train_time:23981ms step_avg:239.81ms router_forward:1 router_objective:-0.2643 router_entropy:1.1886 router_entropy_bonus:0.1929
+step:110/20000 router_probe window_steps:10 avg_depth:4.067 router_objective:-0.2740 router_entropy:1.2109
+step:110/20000 router_matrix
+step:110/20000 train_loss:3.3010 train_time:26395ms step_avg:239.95ms router_forward:1 router_objective:-0.2454 router_entropy:1.2331 router_entropy_bonus:0.1922
+step:120/20000 router_probe window_steps:10 avg_depth:3.690 router_objective:-0.2850 router_entropy:1.2121
+step:120/20000 router_matrix
+step:120/20000 train_loss:3.2174 train_time:28624ms step_avg:238.54ms router_forward:1 router_objective:-0.2781 router_entropy:1.2009 router_entropy_bonus:0.1915
+step:130/20000 router_probe window_steps:10 avg_depth:3.666 router_objective:-0.2789 router_entropy:1.2224
+step:130/20000 router_matrix
+step:130/20000 train_loss:3.2066 train_time:30854ms step_avg:237.34ms router_forward:1 router_objective:-0.3573 router_entropy:1.2450 router_entropy_bonus:0.1908
+step:140/20000 router_probe window_steps:10 avg_depth:3.838 router_objective:-0.2748 router_entropy:1.2024
+step:140/20000 router_matrix
+step:140/20000 train_loss:3.1199 train_time:33134ms step_avg:236.67ms router_forward:1 router_objective:-0.2696 router_entropy:1.1975 router_entropy_bonus:0.1901
+step:150/20000 router_probe window_steps:10 avg_depth:4.096 router_objective:-0.2774 router_entropy:1.2190
+step:150/20000 router_matrix
+step:150/20000 train_loss:3.0909 train_time:35591ms step_avg:237.27ms router_forward:1 router_objective:-0.2918 router_entropy:1.2026 router_entropy_bonus:0.1894
+step:160/20000 router_probe window_steps:10 avg_depth:3.876 router_objective:-0.2582 router_entropy:1.1740
+step:160/20000 router_matrix
+step:160/20000 train_loss:3.0514 train_time:37851ms step_avg:236.57ms router_forward:1 router_objective:-0.2072 router_entropy:1.1765 router_entropy_bonus:0.1887
+step:170/20000 router_probe window_steps:10 avg_depth:3.993 router_objective:-0.2707 router_entropy:1.2250
+step:170/20000 router_matrix
+step:170/20000 train_loss:2.9997 train_time:40239ms step_avg:236.70ms router_forward:1 router_objective:-0.2735 router_entropy:1.1961 router_entropy_bonus:0.1880
+step:180/20000 router_probe window_steps:10 avg_depth:4.083 router_objective:-0.2534 router_entropy:1.1823
+step:180/20000 router_matrix
+step:180/20000 train_loss:2.9479 train_time:42544ms step_avg:236.35ms router_forward:1 router_objective:-0.2786 router_entropy:1.1946 router_entropy_bonus:0.1873
+step:190/20000 router_probe window_steps:10 avg_depth:4.268 router_objective:-0.2627 router_entropy:1.1809
+step:190/20000 router_matrix
+step:190/20000 train_loss:2.9344 train_time:44995ms step_avg:236.81ms router_forward:1 router_objective:-0.2258 router_entropy:1.1609 router_entropy_bonus:0.1866
+step:200/20000 router_probe window_steps:10 avg_depth:4.634 router_objective:-0.2696 router_entropy:1.1703
+step:200/20000 router_matrix
+step:200/20000 train_loss:2.9259 train_time:47646ms step_avg:238.23ms router_forward:1 router_objective:-0.2479 router_entropy:1.1528 router_entropy_bonus:0.1858
+step:210/20000 router_probe window_steps:10 avg_depth:4.147 router_objective:-0.2589 router_entropy:1.1836
+step:210/20000 router_matrix
+step:210/20000 train_loss:2.8962 train_time:50120ms step_avg:238.67ms router_forward:1 router_objective:-0.2961 router_entropy:1.2030 router_entropy_bonus:0.1850
+step:220/20000 router_probe window_steps:10 avg_depth:4.047 router_objective:-0.2572 router_entropy:1.1495
+step:220/20000 router_matrix
+step:220/20000 train_loss:2.8746 train_time:52430ms step_avg:238.32ms router_forward:1 router_objective:-0.2549 router_entropy:1.1353 router_entropy_bonus:0.1843
+step:230/20000 router_probe window_steps:10 avg_depth:4.322 router_objective:-0.2632 router_entropy:1.1826
+step:230/20000 router_matrix
+step:230/20000 train_loss:2.8285 train_time:54957ms step_avg:238.95ms router_forward:1 router_objective:-0.2670 router_entropy:1.2021 router_entropy_bonus:0.1836
+step:240/20000 router_probe window_steps:10 avg_depth:4.165 router_objective:-0.2508 router_entropy:1.1820
+step:240/20000 router_matrix
+step:240/20000 train_loss:2.7868 train_time:57359ms step_avg:238.99ms router_forward:1 router_objective:-0.2825 router_entropy:1.1754 router_entropy_bonus:0.1829
+step:250/20000 router_probe window_steps:10 avg_depth:4.331 router_objective:-0.2705 router_entropy:1.1937
+step:250/20000 router_matrix
+step:250/20000 train_loss:2.8179 train_time:59870ms step_avg:239.48ms router_forward:1 router_objective:-0.2785 router_entropy:1.1941 router_entropy_bonus:0.1821
+step:260/20000 router_probe window_steps:10 avg_depth:4.386 router_objective:-0.2687 router_entropy:1.1806
+step:260/20000 router_matrix
+step:260/20000 train_loss:2.7979 train_time:62501ms step_avg:240.39ms router_forward:1 router_objective:-0.2623 router_entropy:1.1749 router_entropy_bonus:0.1813
+step:270/20000 router_probe window_steps:10 avg_depth:4.208 router_objective:-0.2436 router_entropy:1.1648
+step:270/20000 router_matrix
+step:270/20000 train_loss:2.7116 train_time:64925ms step_avg:240.46ms router_forward:1 router_objective:-0.2993 router_entropy:1.1754 router_entropy_bonus:0.1806
+step:280/20000 router_probe window_steps:10 avg_depth:4.265 router_objective:-0.2371 router_entropy:1.1358
+step:280/20000 router_matrix
+step:280/20000 train_loss:2.7325 train_time:67380ms step_avg:240.64ms router_forward:1 router_objective:-0.1873 router_entropy:1.1440 router_entropy_bonus:0.1799
+step:290/20000 router_probe window_steps:10 avg_depth:4.330 router_objective:-0.2465 router_entropy:1.1630
+step:290/20000 router_matrix
+step:290/20000 train_loss:2.7162 train_time:69881ms step_avg:240.97ms router_forward:1 router_objective:-0.2891 router_entropy:1.1680 router_entropy_bonus:0.1791
+step:300/20000 router_probe window_steps:10 avg_depth:4.612 router_objective:-0.2333 router_entropy:1.1247
+step:300/20000 router_matrix
+step:300/20000 train_loss:2.7278 train_time:72504ms step_avg:241.68ms router_forward:1 router_objective:-0.1918 router_entropy:1.0974 router_entropy_bonus:0.1783
+step:310/20000 router_probe window_steps:10 avg_depth:4.791 router_objective:-0.2436 router_entropy:1.1310
+step:310/20000 router_matrix
+step:310/20000 train_loss:2.6845 train_time:75252ms step_avg:242.75ms router_forward:1 router_objective:-0.2074 router_entropy:1.1607 router_entropy_bonus:0.1775
+step:320/20000 router_probe window_steps:10 avg_depth:4.890 router_objective:-0.2308 router_entropy:1.1585
+step:320/20000 router_matrix
+step:320/20000 train_loss:2.7367 train_time:78094ms step_avg:244.05ms router_forward:1 router_objective:-0.2318 router_entropy:1.1509 router_entropy_bonus:0.1767
+step:330/20000 router_probe window_steps:10 avg_depth:5.637 router_objective:-0.2635 router_entropy:1.1473
+step:330/20000 router_matrix
+step:330/20000 train_loss:2.6943 train_time:81252ms step_avg:246.22ms router_forward:1 router_objective:-0.2226 router_entropy:1.1500 router_entropy_bonus:0.1757
+step:340/20000 router_probe window_steps:10 avg_depth:4.684 router_objective:-0.2380 router_entropy:1.1475
+step:340/20000 router_matrix
+step:340/20000 train_loss:2.7419 train_time:83904ms step_avg:246.78ms router_forward:1 router_objective:-0.1843 router_entropy:1.1467 router_entropy_bonus:0.1749
+step:350/20000 router_probe window_steps:10 avg_depth:4.742 router_objective:-0.2491 router_entropy:1.1581
+step:350/20000 router_matrix
+step:350/20000 train_loss:2.7342 train_time:86723ms step_avg:247.78ms router_forward:1 router_objective:-0.2427 router_entropy:1.1205 router_entropy_bonus:0.1741
+step:360/20000 router_probe window_steps:10 avg_depth:4.830 router_objective:-0.2313 router_entropy:1.1034
+step:360/20000 router_matrix
+step:360/20000 train_loss:2.7081 train_time:89434ms step_avg:248.43ms router_forward:1 router_objective:-0.1965 router_entropy:1.1003 router_entropy_bonus:0.1733
+step:370/20000 router_probe window_steps:10 avg_depth:4.942 router_objective:-0.2600 router_entropy:1.1076
+step:370/20000 router_matrix
+step:370/20000 train_loss:2.7097 train_time:92267ms step_avg:249.37ms router_forward:1 router_objective:-0.2287 router_entropy:1.1059 router_entropy_bonus:0.1724
+step:380/20000 router_probe window_steps:10 avg_depth:4.938 router_objective:-0.2209 router_entropy:1.0894
+step:380/20000 router_matrix
+step:380/20000 train_loss:2.6266 train_time:95068ms step_avg:250.18ms router_forward:1 router_objective:-0.2608 router_entropy:1.1545 router_entropy_bonus:0.1716
+step:390/20000 router_probe window_steps:10 avg_depth:5.232 router_objective:-0.2554 router_entropy:1.1577
+step:390/20000 router_matrix
+step:390/20000 train_loss:2.6053 train_time:98113ms step_avg:251.57ms router_forward:1 router_objective:-0.1763 router_entropy:1.1335 router_entropy_bonus:0.1706
+step:400/20000 router_probe window_steps:10 avg_depth:4.926 router_objective:-0.2261 router_entropy:1.1152
+step:400/20000 router_matrix
+step:400/20000 train_loss:2.6790 train_time:100940ms step_avg:252.35ms router_forward:1 router_objective:-0.2043 router_entropy:1.0888 router_entropy_bonus:0.1698
+step:410/20000 router_probe window_steps:10 avg_depth:4.718 router_objective:-0.2228 router_entropy:1.1090
+step:410/20000 router_matrix
+step:410/20000 train_loss:2.6550 train_time:103631ms step_avg:252.76ms router_forward:1 router_objective:-0.2243 router_entropy:1.0995 router_entropy_bonus:0.1690
+step:420/20000 router_probe window_steps:10 avg_depth:5.349 router_objective:-0.2436 router_entropy:1.1390
+step:420/20000 router_matrix
+step:420/20000 train_loss:2.6293 train_time:106688ms step_avg:254.02ms router_forward:1 router_objective:-0.2860 router_entropy:1.1470 router_entropy_bonus:0.1681
+step:430/20000 router_probe window_steps:10 avg_depth:4.797 router_objective:-0.2312 router_entropy:1.1235
+step:430/20000 router_matrix
+step:430/20000 train_loss:2.6192 train_time:109474ms step_avg:254.59ms router_forward:1 router_objective:-0.1875 router_entropy:1.0999 router_entropy_bonus:0.1672
+step:440/20000 router_probe window_steps:10 avg_depth:5.329 router_objective:-0.2602 router_entropy:1.1218
+step:440/20000 router_matrix
+step:440/20000 train_loss:2.5842 train_time:112531ms step_avg:255.75ms router_forward:1 router_objective:-0.2506 router_entropy:1.0958 router_entropy_bonus:0.1663
+step:450/20000 router_probe window_steps:10 avg_depth:4.838 router_objective:-0.2362 router_entropy:1.0647
+step:450/20000 router_matrix
+step:450/20000 train_loss:2.6322 train_time:115341ms step_avg:256.31ms router_forward:1 router_objective:-0.2541 router_entropy:1.0968 router_entropy_bonus:0.1655
+step:460/20000 router_probe window_steps:10 avg_depth:5.469 router_objective:-0.2582 router_entropy:1.0523
+step:460/20000 router_matrix
+step:460/20000 train_loss:2.6528 train_time:118428ms step_avg:257.45ms router_forward:1 router_objective:-0.2096 router_entropy:1.0736 router_entropy_bonus:0.1646
+step:470/20000 router_probe window_steps:10 avg_depth:4.884 router_objective:-0.2414 router_entropy:1.0865
+step:470/20000 router_matrix
+step:470/20000 train_loss:2.6100 train_time:121231ms step_avg:257.94ms router_forward:1 router_objective:-0.2181 router_entropy:1.0807 router_entropy_bonus:0.1637
+step:480/20000 router_probe window_steps:10 avg_depth:4.885 router_objective:-0.2431 router_entropy:1.0453
+step:480/20000 router_matrix
+step:480/20000 train_loss:2.6598 train_time:123992ms step_avg:258.32ms router_forward:1 router_objective:-0.2080 router_entropy:1.0086 router_entropy_bonus:0.1629
+step:490/20000 router_probe window_steps:10 avg_depth:5.179 router_objective:-0.2176 router_entropy:1.0163
+step:490/20000 router_matrix
+step:490/20000 train_loss:2.6292 train_time:127082ms step_avg:259.35ms router_forward:1 router_objective:-0.1997 router_entropy:1.0462 router_entropy_bonus:0.1620
+step:500/20000 router_probe window_steps:10 avg_depth:5.236 router_objective:-0.2551 router_entropy:1.0643
+step:500/20000 router_matrix
+step:500/20000 train_loss:2.6090 train_time:130059ms step_avg:260.12ms router_forward:1 router_objective:-0.2418 router_entropy:1.0623 router_entropy_bonus:0.1611
+step:510/20000 router_probe window_steps:10 avg_depth:5.017 router_objective:-0.2332 router_entropy:1.0407
+step:510/20000 router_matrix
+step:510/20000 train_loss:2.6497 train_time:132938ms step_avg:260.66ms router_forward:1 router_objective:-0.2022 router_entropy:1.0319 router_entropy_bonus:0.1602
+step:520/20000 router_probe window_steps:10 avg_depth:4.852 router_objective:-0.2357 router_entropy:1.0042
+step:520/20000 router_matrix
+step:520/20000 train_loss:2.4820 train_time:135693ms step_avg:260.95ms router_forward:1 router_objective:-0.1643 router_entropy:0.9293 router_entropy_bonus:0.1594
+step:530/20000 router_probe window_steps:10 avg_depth:5.352 router_objective:-0.2580 router_entropy:1.0264
+step:530/20000 router_matrix
+step:530/20000 train_loss:2.5316 train_time:138712ms step_avg:261.72ms router_forward:1 router_objective:-0.2184 router_entropy:1.0590 router_entropy_bonus:0.1585
+step:540/20000 router_probe window_steps:10 avg_depth:4.777 router_objective:-0.2375 router_entropy:1.0229
+step:540/20000 router_matrix
+step:540/20000 train_loss:2.5929 train_time:141442ms step_avg:261.93ms router_forward:1 router_objective:-0.3378 router_entropy:1.0457 router_entropy_bonus:0.1577
+step:550/20000 router_probe window_steps:10 avg_depth:5.168 router_objective:-0.2519 router_entropy:0.9971
+step:550/20000 router_matrix
+step:550/20000 train_loss:2.5152 train_time:144395ms step_avg:262.54ms router_forward:1 router_objective:-0.2174 router_entropy:0.8918 router_entropy_bonus:0.1568
+step:560/20000 router_probe window_steps:10 avg_depth:4.830 router_objective:-0.2275 router_entropy:0.9274
+step:560/20000 router_matrix
+step:560/20000 train_loss:2.4891 train_time:147160ms step_avg:262.79ms router_forward:1 router_objective:-0.3063 router_entropy:1.0187 router_entropy_bonus:0.1559
+step:570/20000 router_probe window_steps:10 avg_depth:4.893 router_objective:-0.2238 router_entropy:0.9990
+step:570/20000 router_matrix
+step:570/20000 train_loss:2.5223 train_time:149944ms step_avg:263.06ms router_forward:1 router_objective:-0.1775 router_entropy:0.9761 router_entropy_bonus:0.1551
+step:580/20000 router_probe window_steps:10 avg_depth:4.872 router_objective:-0.2479 router_entropy:1.0227
+step:580/20000 router_matrix
+step:580/20000 train_loss:2.4945 train_time:152754ms step_avg:263.37ms router_forward:1 router_objective:-0.2267 router_entropy:1.0058 router_entropy_bonus:0.1543
+step:590/20000 router_probe window_steps:10 avg_depth:4.657 router_objective:-0.2230 router_entropy:0.9820
+step:590/20000 router_matrix
+step:590/20000 train_loss:2.5278 train_time:155415ms step_avg:263.41ms router_forward:1 router_objective:-0.2503 router_entropy:0.9732 router_entropy_bonus:0.1535
+step:600/20000 router_probe window_steps:10 avg_depth:4.918 router_objective:-0.2045 router_entropy:0.9812
+step:600/20000 router_matrix
+step:600/20000 train_loss:2.5685 train_time:158168ms step_avg:263.61ms router_forward:1 router_objective:-0.1814 router_entropy:1.0092 router_entropy_bonus:0.1526
+step:610/20000 router_probe window_steps:10 avg_depth:5.428 router_objective:-0.2219 router_entropy:1.0008
+step:610/20000 router_matrix
+step:610/20000 train_loss:2.4874 train_time:161210ms step_avg:264.28ms router_forward:1 router_objective:-0.1650 router_entropy:0.9712 router_entropy_bonus:0.1517
+step:620/20000 router_probe window_steps:10 avg_depth:4.530 router_objective:-0.2093 router_entropy:0.9852
+step:620/20000 router_matrix
+step:620/20000 train_loss:2.4863 train_time:163775ms step_avg:264.15ms router_forward:1 router_objective:-0.2588 router_entropy:1.0149 router_entropy_bonus:0.1510
+step:630/20000 router_probe window_steps:10 avg_depth:5.285 router_objective:-0.2132 router_entropy:1.0216
+step:630/20000 router_matrix
+step:630/20000 train_loss:2.5489 train_time:166750ms step_avg:264.68ms router_forward:1 router_objective:-0.2463 router_entropy:1.0007 router_entropy_bonus:0.1501
+step:640/20000 router_probe window_steps:10 avg_depth:5.196 router_objective:-0.2192 router_entropy:0.9595
+step:640/20000 router_matrix
+step:640/20000 train_loss:2.4008 train_time:169697ms step_avg:265.15ms router_forward:1 router_objective:-0.1710 router_entropy:0.9270 router_entropy_bonus:0.1492
+step:650/20000 router_probe window_steps:10 avg_depth:5.186 router_objective:-0.1926 router_entropy:0.8861
+step:650/20000 router_matrix
+step:650/20000 train_loss:2.5553 train_time:172591ms step_avg:265.52ms router_forward:1 router_objective:-0.1884 router_entropy:0.9204 router_entropy_bonus:0.1483
+step:660/20000 router_probe window_steps:10 avg_depth:4.816 router_objective:-0.1954 router_entropy:0.9568
+step:660/20000 router_matrix
+step:660/20000 train_loss:2.4916 train_time:175337ms step_avg:265.66ms router_forward:1 router_objective:-0.2012 router_entropy:1.0176 router_entropy_bonus:0.1475
+step:670/20000 router_probe window_steps:10 avg_depth:4.804 router_objective:-0.2043 router_entropy:0.9890
+step:670/20000 router_matrix
+step:670/20000 train_loss:2.5215 train_time:178048ms step_avg:265.74ms router_forward:1 router_objective:-0.1835 router_entropy:1.0107 router_entropy_bonus:0.1467
+step:680/20000 router_probe window_steps:10 avg_depth:5.259 router_objective:-0.2175 router_entropy:0.9820
+step:680/20000 router_matrix
+step:680/20000 train_loss:2.4285 train_time:181019ms step_avg:266.20ms router_forward:1 router_objective:-0.2102 router_entropy:0.9536 router_entropy_bonus:0.1458
+step:690/20000 router_probe window_steps:10 avg_depth:4.999 router_objective:-0.2095 router_entropy:0.9600
+step:690/20000 router_matrix
+step:690/20000 train_loss:2.4830 train_time:183854ms step_avg:266.46ms router_forward:1 router_objective:-0.2214 router_entropy:0.9465 router_entropy_bonus:0.1449
+step:700/20000 router_probe window_steps:10 avg_depth:4.947 router_objective:-0.1928 router_entropy:0.9004
+step:700/20000 router_matrix
+step:700/20000 train_loss:2.3775 train_time:186624ms step_avg:266.61ms router_forward:1 router_objective:-0.1883 router_entropy:0.8630 router_entropy_bonus:0.1441
+step:710/20000 router_probe window_steps:10 avg_depth:5.030 router_objective:-0.1882 router_entropy:0.9101
+step:710/20000 router_matrix
+step:710/20000 train_loss:2.4924 train_time:189421ms step_avg:266.79ms router_forward:1 router_objective:-0.1473 router_entropy:0.9383 router_entropy_bonus:0.1433
+step:720/20000 router_probe window_steps:10 avg_depth:5.152 router_objective:-0.2132 router_entropy:0.9793
+step:720/20000 router_matrix
+step:720/20000 train_loss:2.3749 train_time:192328ms step_avg:267.12ms router_forward:1 router_objective:-0.2106 router_entropy:0.9514 router_entropy_bonus:0.1424
+step:730/20000 router_probe window_steps:10 avg_depth:5.204 router_objective:-0.1870 router_entropy:0.9466
+step:730/20000 router_matrix
+step:730/20000 train_loss:2.4342 train_time:195228ms step_avg:267.44ms router_forward:1 router_objective:-0.2183 router_entropy:1.0085 router_entropy_bonus:0.1415
+step:740/20000 router_probe window_steps:10 avg_depth:5.392 router_objective:-0.2260 router_entropy:1.0084
+step:740/20000 router_matrix
+step:740/20000 train_loss:2.4664 train_time:198319ms step_avg:268.00ms router_forward:1 router_objective:-0.2332 router_entropy:0.9204 router_entropy_bonus:0.1406
+step:750/20000 router_probe window_steps:10 avg_depth:4.868 router_objective:-0.1908 router_entropy:0.9179
+step:750/20000 router_matrix
+step:750/20000 train_loss:2.4543 train_time:201117ms step_avg:268.16ms router_forward:1 router_objective:-0.2080 router_entropy:0.9938 router_entropy_bonus:0.1398
+step:760/20000 router_probe window_steps:10 avg_depth:4.953 router_objective:-0.2241 router_entropy:0.9322
+step:760/20000 router_matrix
+step:760/20000 train_loss:2.4340 train_time:203927ms step_avg:268.33ms router_forward:1 router_objective:-0.2664 router_entropy:0.9034 router_entropy_bonus:0.1389
+step:770/20000 router_probe window_steps:10 avg_depth:5.348 router_objective:-0.2147 router_entropy:0.9423
+step:770/20000 router_matrix
+step:770/20000 train_loss:2.4418 train_time:206951ms step_avg:268.77ms router_forward:1 router_objective:-0.2611 router_entropy:0.9786 router_entropy_bonus:0.1380
+step:780/20000 router_probe window_steps:10 avg_depth:5.209 router_objective:-0.2156 router_entropy:0.9099
+step:780/20000 router_matrix
+step:780/20000 train_loss:2.4459 train_time:209899ms step_avg:269.10ms router_forward:1 router_objective:-0.2139 router_entropy:0.8789 router_entropy_bonus:0.1371
+step:790/20000 router_probe window_steps:10 avg_depth:4.884 router_objective:-0.2083 router_entropy:0.8363
+step:790/20000 router_matrix
+step:790/20000 train_loss:2.3792 train_time:212679ms step_avg:269.21ms router_forward:1 router_objective:-0.1456 router_entropy:0.8165 router_entropy_bonus:0.1363
+step:800/20000 router_probe window_steps:10 avg_depth:5.623 router_objective:-0.2275 router_entropy:0.8917
+step:800/20000 router_matrix
+step:800/20000 train_loss:2.4375 train_time:215803ms step_avg:269.75ms router_forward:1 router_objective:-0.2099 router_entropy:0.8813 router_entropy_bonus:0.1354
+step:810/20000 router_probe window_steps:10 avg_depth:4.709 router_objective:-0.1981 router_entropy:0.7924
+step:810/20000 router_matrix
+step:810/20000 train_loss:2.3696 train_time:218438ms step_avg:269.68ms router_forward:1 router_objective:-0.1969 router_entropy:0.7643 router_entropy_bonus:0.1345
+step:820/20000 router_probe window_steps:10 avg_depth:5.075 router_objective:-0.1956 router_entropy:0.8071
+step:820/20000 router_matrix
+step:820/20000 train_loss:2.3768 train_time:221544ms step_avg:270.18ms router_forward:1 router_objective:-0.1657 router_entropy:0.8294 router_entropy_bonus:0.1336
+step:830/20000 router_probe window_steps:10 avg_depth:5.310 router_objective:-0.1958 router_entropy:0.8565
+step:830/20000 router_matrix
+step:830/20000 train_loss:2.4038 train_time:224603ms step_avg:270.61ms router_forward:1 router_objective:-0.1673 router_entropy:0.8149 router_entropy_bonus:0.1327
+step:840/20000 router_probe window_steps:10 avg_depth:5.227 router_objective:-0.1984 router_entropy:0.8691
+step:840/20000 router_matrix
+step:840/20000 train_loss:2.3877 train_time:227550ms step_avg:270.89ms router_forward:1 router_objective:-0.2241 router_entropy:0.9132 router_entropy_bonus:0.1318
+step:850/20000 router_probe window_steps:10 avg_depth:5.168 router_objective:-0.2281 router_entropy:0.8904
+step:850/20000 router_matrix
+step:850/20000 train_loss:2.4081 train_time:230438ms step_avg:271.10ms router_forward:1 router_objective:-0.2065 router_entropy:0.8504 router_entropy_bonus:0.1310
+step:860/20000 router_probe window_steps:10 avg_depth:4.815 router_objective:-0.1964 router_entropy:0.8274
+step:860/20000 router_matrix
+step:860/20000 train_loss:2.3402 train_time:233305ms step_avg:271.29ms router_forward:1 router_objective:-0.2193 router_entropy:0.9257 router_entropy_bonus:0.1301
+step:870/20000 router_probe window_steps:10 avg_depth:5.262 router_objective:-0.2457 router_entropy:0.9411
+step:870/20000 router_matrix
+step:870/20000 train_loss:2.3617 train_time:236303ms step_avg:271.61ms router_forward:1 router_objective:-0.2358 router_entropy:0.8804 router_entropy_bonus:0.1292
+step:880/20000 router_probe window_steps:10 avg_depth:4.904 router_objective:-0.1971 router_entropy:0.8076
+step:880/20000 router_matrix
+step:880/20000 train_loss:2.3200 train_time:239051ms step_avg:271.65ms router_forward:1 router_objective:-0.1511 router_entropy:0.7811 router_entropy_bonus:0.1284
+step:890/20000 router_probe window_steps:10 avg_depth:5.446 router_objective:-0.1999 router_entropy:0.8603
+step:890/20000 router_matrix
+step:890/20000 train_loss:2.3436 train_time:242175ms step_avg:272.11ms router_forward:1 router_objective:-0.2478 router_entropy:0.8904 router_entropy_bonus:0.1274
+step:900/20000 router_probe window_steps:10 avg_depth:4.870 router_objective:-0.1867 router_entropy:0.8369
+step:900/20000 router_matrix
+step:900/20000 train_loss:2.3337 train_time:244973ms step_avg:272.19ms router_forward:1 router_objective:-0.1969 router_entropy:0.8147 router_entropy_bonus:0.1266
+step:910/20000 router_probe window_steps:10 avg_depth:5.371 router_objective:-0.1906 router_entropy:0.8559
+step:910/20000 router_matrix
+step:910/20000 train_loss:2.2930 train_time:248075ms step_avg:272.61ms router_forward:1 router_objective:-0.2050 router_entropy:0.8596 router_entropy_bonus:0.1257
+step:920/20000 router_probe window_steps:10 avg_depth:5.136 router_objective:-0.1755 router_entropy:0.8307
+step:920/20000 router_matrix
+step:920/20000 train_loss:2.3579 train_time:250952ms step_avg:272.77ms router_forward:1 router_objective:-0.1388 router_entropy:0.8193 router_entropy_bonus:0.1248
+step:930/20000 router_probe window_steps:10 avg_depth:5.337 router_objective:-0.1844 router_entropy:0.8393
+step:930/20000 router_matrix
+step:930/20000 train_loss:2.3076 train_time:253929ms step_avg:273.04ms router_forward:1 router_objective:-0.1666 router_entropy:0.7693 router_entropy_bonus:0.1239
+step:940/20000 router_probe window_steps:10 avg_depth:5.178 router_objective:-0.1961 router_entropy:0.7679
+step:940/20000 router_matrix
+step:940/20000 train_loss:2.3567 train_time:257000ms step_avg:273.40ms router_forward:1 router_objective:-0.2126 router_entropy:0.7402 router_entropy_bonus:0.1230
+step:950/20000 router_probe window_steps:10 avg_depth:4.720 router_objective:-0.1839 router_entropy:0.7910
+step:950/20000 router_matrix
+step:950/20000 train_loss:2.3044 train_time:259913ms step_avg:273.59ms router_forward:1 router_objective:-0.3549 router_entropy:0.9186 router_entropy_bonus:0.1221
+step:960/20000 router_probe window_steps:10 avg_depth:5.165 router_objective:-0.1815 router_entropy:0.8577
+step:960/20000 router_matrix
+step:960/20000 train_loss:2.2713 train_time:262811ms step_avg:273.76ms router_forward:1 router_objective:-0.1384 router_entropy:0.8488 router_entropy_bonus:0.1212
+step:970/20000 router_probe window_steps:10 avg_depth:5.190 router_objective:-0.1948 router_entropy:0.8344
+step:970/20000 router_matrix
+step:970/20000 train_loss:2.3173 train_time:265728ms step_avg:273.95ms router_forward:1 router_objective:-0.1798 router_entropy:0.7540 router_entropy_bonus:0.1204
+step:980/20000 router_probe window_steps:10 avg_depth:4.638 router_objective:-0.1586 router_entropy:0.7613
+step:980/20000 router_matrix
+step:980/20000 train_loss:2.2960 train_time:268309ms step_avg:273.78ms router_forward:1 router_objective:-0.2010 router_entropy:0.8301 router_entropy_bonus:0.1196
+step:990/20000 router_probe window_steps:10 avg_depth:5.341 router_objective:-0.1753 router_entropy:0.8461
+step:990/20000 router_matrix
+step:990/20000 train_loss:2.3493 train_time:271296ms step_avg:274.04ms router_forward:1 router_objective:-0.1826 router_entropy:0.8731 router_entropy_bonus:0.1187
+step:1000/20000 router_probe window_steps:10 avg_depth:5.129 router_objective:-0.1776 router_entropy:0.8447
+step:1000/20000 router_matrix
+step:1000/20000 train_loss:2.2006 train_time:274129ms step_avg:274.13ms router_forward:1 router_objective:-0.2604 router_entropy:0.8556 router_entropy_bonus:0.1178
+step:1010/20000 router_probe window_steps:10 avg_depth:5.101 router_objective:-0.1469 router_entropy:0.7994
+step:1010/20000 router_matrix
+step:1010/20000 train_loss:2.3519 train_time:277016ms step_avg:274.27ms router_forward:1 router_objective:-0.1702 router_entropy:0.7776 router_entropy_bonus:0.1170
+step:1020/20000 router_probe window_steps:10 avg_depth:5.209 router_objective:-0.1548 router_entropy:0.8156
+step:1020/20000 router_matrix
+step:1020/20000 train_loss:2.3422 train_time:279884ms step_avg:274.40ms router_forward:1 router_objective:-0.2510 router_entropy:0.8466 router_entropy_bonus:0.1161
+step:1030/20000 router_probe window_steps:10 avg_depth:5.015 router_objective:-0.1503 router_entropy:0.7911
+step:1030/20000 router_matrix
+step:1030/20000 train_loss:2.2942 train_time:282807ms step_avg:274.57ms router_forward:1 router_objective:-0.1726 router_entropy:0.8151 router_entropy_bonus:0.1152
+step:1040/20000 router_probe window_steps:10 avg_depth:5.160 router_objective:-0.1791 router_entropy:0.8056
+step:1040/20000 router_matrix
+step:1040/20000 train_loss:2.3212 train_time:285786ms step_avg:274.79ms router_forward:1 router_objective:-0.1788 router_entropy:0.6989 router_entropy_bonus:0.1143
+step:1050/20000 router_probe window_steps:10 avg_depth:4.520 router_objective:-0.1556 router_entropy:0.7551
+step:1050/20000 router_matrix
+step:1050/20000 train_loss:2.3744 train_time:288756ms step_avg:275.01ms router_forward:1 router_objective:-0.1603 router_entropy:0.8436 router_entropy_bonus:0.1135
+step:1060/20000 router_probe window_steps:10 avg_depth:4.988 router_objective:-0.1964 router_entropy:0.8154
+step:1060/20000 router_matrix
+step:1060/20000 train_loss:2.3097 train_time:292474ms step_avg:275.92ms router_forward:1 router_objective:-0.2029 router_entropy:0.7722 router_entropy_bonus:0.1123
+step:1070/20000 router_probe window_steps:10 avg_depth:4.331 router_objective:-0.1563 router_entropy:0.6701
+step:1070/20000 router_matrix
+step:1070/20000 train_loss:2.2928 train_time:295424ms step_avg:276.10ms router_forward:1 router_objective:-0.1990 router_entropy:0.6535 router_entropy_bonus:0.1114
+step:1080/20000 router_probe window_steps:10 avg_depth:4.708 router_objective:-0.1777 router_entropy:0.7527
+step:1080/20000 router_matrix
+step:1080/20000 train_loss:2.3289 train_time:298125ms step_avg:276.04ms router_forward:1 router_objective:-0.1522 router_entropy:0.7534 router_entropy_bonus:0.1106
+step:1090/20000 router_probe window_steps:10 avg_depth:4.548 router_objective:-0.1527 router_entropy:0.7292
+step:1090/20000 router_matrix
+step:1090/20000 train_loss:2.3496 train_time:300716ms step_avg:275.89ms router_forward:1 router_objective:-0.1117 router_entropy:0.7622 router_entropy_bonus:0.1099
+step:1100/20000 router_probe window_steps:10 avg_depth:4.652 router_objective:-0.1863 router_entropy:0.7263
+step:1100/20000 router_matrix
+step:1100/20000 train_loss:2.2561 train_time:303322ms step_avg:275.75ms router_forward:1 router_objective:-0.1465 router_entropy:0.5952 router_entropy_bonus:0.1091
+step:1110/20000 router_probe window_steps:10 avg_depth:4.053 router_objective:-0.1272 router_entropy:0.5921
+step:1110/20000 router_matrix
+step:1110/20000 train_loss:2.2734 train_time:305561ms step_avg:275.28ms router_forward:1 router_objective:-0.1745 router_entropy:0.7149 router_entropy_bonus:0.1084
+step:1120/20000 router_probe window_steps:10 avg_depth:4.830 router_objective:-0.1719 router_entropy:0.7477
+step:1120/20000 router_matrix
+step:1120/20000 train_loss:2.3420 train_time:308257ms step_avg:275.23ms router_forward:1 router_objective:-0.1843 router_entropy:0.7188 router_entropy_bonus:0.1076
+step:1130/20000 router_probe window_steps:10 avg_depth:4.608 router_objective:-0.1454 router_entropy:0.7291
+step:1130/20000 router_matrix
+step:1130/20000 train_loss:2.2895 train_time:310859ms step_avg:275.10ms router_forward:1 router_objective:-0.1432 router_entropy:0.7653 router_entropy_bonus:0.1068
+step:1140/20000 router_probe window_steps:10 avg_depth:4.622 router_objective:-0.1747 router_entropy:0.7393
+step:1140/20000 router_matrix
+step:1140/20000 train_loss:2.2628 train_time:313479ms step_avg:274.98ms router_forward:1 router_objective:-0.1710 router_entropy:0.6933 router_entropy_bonus:0.1060
+step:1150/20000 router_probe window_steps:10 avg_depth:4.505 router_objective:-0.1713 router_entropy:0.7054
+step:1150/20000 router_matrix
+step:1150/20000 train_loss:2.2877 train_time:315994ms step_avg:274.78ms router_forward:1 router_objective:-0.1482 router_entropy:0.6839 router_entropy_bonus:0.1053
+step:1160/20000 router_probe window_steps:10 avg_depth:4.161 router_objective:-0.1240 router_entropy:0.5812
+step:1160/20000 router_matrix
+step:1160/20000 train_loss:2.3057 train_time:318296ms step_avg:274.39ms router_forward:1 router_objective:-0.0935 router_entropy:0.5661 router_entropy_bonus:0.1046
+step:1170/20000 router_probe window_steps:10 avg_depth:4.381 router_objective:-0.1205 router_entropy:0.6496
+step:1170/20000 router_matrix
+step:1170/20000 train_loss:2.2712 train_time:320695ms step_avg:274.10ms router_forward:1 router_objective:-0.1106 router_entropy:0.7153 router_entropy_bonus:0.1039
+step:1180/20000 router_probe window_steps:10 avg_depth:5.295 router_objective:-0.1519 router_entropy:0.8045
+step:1180/20000 router_matrix
+step:1180/20000 train_loss:2.2735 train_time:323625ms step_avg:274.26ms router_forward:1 router_objective:-0.1116 router_entropy:0.8206 router_entropy_bonus:0.1030
+step:1190/20000 router_probe window_steps:10 avg_depth:4.542 router_objective:-0.1473 router_entropy:0.7417
+step:1190/20000 router_matrix
+step:1190/20000 train_loss:2.2677 train_time:326189ms step_avg:274.11ms router_forward:1 router_objective:-0.1286 router_entropy:0.6811 router_entropy_bonus:0.1022
+step:1200/20000 router_probe window_steps:10 avg_depth:4.301 router_objective:-0.1357 router_entropy:0.6938
+step:1200/20000 router_matrix
+step:1200/20000 train_loss:2.2916 train_time:328561ms step_avg:273.80ms router_forward:1 router_objective:-0.1020 router_entropy:0.7173 router_entropy_bonus:0.1015
+step:1210/20000 router_probe window_steps:10 avg_depth:4.649 router_objective:-0.1529 router_entropy:0.7548
+step:1210/20000 router_matrix
+step:1210/20000 train_loss:2.2554 train_time:331131ms step_avg:273.66ms router_forward:1 router_objective:-0.1092 router_entropy:0.7108 router_entropy_bonus:0.1007
+step:1220/20000 router_probe window_steps:10 avg_depth:4.626 router_objective:-0.1664 router_entropy:0.7550
+step:1220/20000 router_matrix
+step:1220/20000 train_loss:2.2571 train_time:333693ms step_avg:273.52ms router_forward:1 router_objective:-0.2076 router_entropy:0.8011 router_entropy_bonus:0.1000
+step:1230/20000 router_probe window_steps:10 avg_depth:4.410 router_objective:-0.1565 router_entropy:0.6869
+step:1230/20000 router_matrix
+step:1230/20000 train_loss:2.2926 train_time:336154ms step_avg:273.30ms router_forward:1 router_objective:-0.1351 router_entropy:0.5908 router_entropy_bonus:0.0992
+step:1240/20000 router_probe window_steps:10 avg_depth:4.210 router_objective:-0.1277 router_entropy:0.6343
+step:1240/20000 router_matrix
+step:1240/20000 train_loss:2.2725 train_time:338529ms step_avg:273.01ms router_forward:1 router_objective:-0.1668 router_entropy:0.6788 router_entropy_bonus:0.0985
+step:1250/20000 router_probe window_steps:10 avg_depth:4.363 router_objective:-0.1685 router_entropy:0.6690
+step:1250/20000 router_matrix
+step:1250/20000 train_loss:2.2641 train_time:341054ms step_avg:272.84ms router_forward:1 router_objective:-0.1569 router_entropy:0.6175 router_entropy_bonus:0.0978
+step:1260/20000 router_probe window_steps:10 avg_depth:4.173 router_objective:-0.1151 router_entropy:0.6141
+step:1260/20000 router_matrix
+step:1260/20000 train_loss:2.3737 train_time:343366ms step_avg:272.51ms router_forward:1 router_objective:-0.1141 router_entropy:0.6630 router_entropy_bonus:0.0971
+step:1270/20000 router_probe window_steps:10 avg_depth:4.851 router_objective:-0.1413 router_entropy:0.7610
+step:1270/20000 router_matrix
+step:1270/20000 train_loss:2.3083 train_time:346107ms step_avg:272.53ms router_forward:1 router_objective:-0.1166 router_entropy:0.7748 router_entropy_bonus:0.0962
+step:1280/20000 router_probe window_steps:10 avg_depth:4.937 router_objective:-0.1424 router_entropy:0.6590
+step:1280/20000 router_matrix
+step:1280/20000 train_loss:2.2803 train_time:348791ms step_avg:272.49ms router_forward:1 router_objective:-0.0936 router_entropy:0.5960 router_entropy_bonus:0.0954
+step:1290/20000 router_probe window_steps:10 avg_depth:4.065 router_objective:-0.1321 router_entropy:0.5731
+step:1290/20000 router_matrix
+step:1290/20000 train_loss:2.2482 train_time:351104ms step_avg:272.17ms router_forward:1 router_objective:-0.0959 router_entropy:0.6105 router_entropy_bonus:0.0947
+step:1300/20000 router_probe window_steps:10 avg_depth:4.497 router_objective:-0.1515 router_entropy:0.7081
+step:1300/20000 router_matrix
+step:1300/20000 train_loss:2.2958 train_time:353630ms step_avg:272.02ms router_forward:1 router_objective:-0.1879 router_entropy:0.7249 router_entropy_bonus:0.0940
+step:1310/20000 router_probe window_steps:10 avg_depth:4.294 router_objective:-0.1453 router_entropy:0.6733
+step:1310/20000 router_matrix
+step:1310/20000 train_loss:2.2280 train_time:356033ms step_avg:271.78ms router_forward:1 router_objective:-0.1515 router_entropy:0.6598 router_entropy_bonus:0.0933
+step:1320/20000 router_probe window_steps:10 avg_depth:4.212 router_objective:-0.1264 router_entropy:0.6291
+step:1320/20000 router_matrix
+step:1320/20000 train_loss:2.2165 train_time:358378ms step_avg:271.50ms router_forward:1 router_objective:-0.1735 router_entropy:0.6401 router_entropy_bonus:0.0926
+step:1330/20000 router_probe window_steps:10 avg_depth:4.242 router_objective:-0.1182 router_entropy:0.6415
+step:1330/20000 router_matrix
+step:1330/20000 train_loss:2.2193 train_time:360771ms step_avg:271.26ms router_forward:1 router_objective:-0.0629 router_entropy:0.7165 router_entropy_bonus:0.0918
+step:1340/20000 router_probe window_steps:10 avg_depth:5.083 router_objective:-0.1874 router_entropy:0.7746
+step:1340/20000 router_matrix
+step:1340/20000 train_loss:2.2827 train_time:363699ms step_avg:271.42ms router_forward:1 router_objective:-0.1844 router_entropy:0.7417 router_entropy_bonus:0.0910
+step:1350/20000 router_probe window_steps:10 avg_depth:4.237 router_objective:-0.1224 router_entropy:0.6489
+step:1350/20000 router_matrix
+step:1350/20000 train_loss:2.2564 train_time:366070ms step_avg:271.16ms router_forward:1 router_objective:-0.0818 router_entropy:0.6342 router_entropy_bonus:0.0902
+step:1360/20000 router_probe window_steps:10 avg_depth:4.497 router_objective:-0.1307 router_entropy:0.7154
+step:1360/20000 router_matrix
+step:1360/20000 train_loss:2.2620 train_time:368558ms step_avg:271.00ms router_forward:1 router_objective:-0.1835 router_entropy:0.7879 router_entropy_bonus:0.0895
+step:1370/20000 router_probe window_steps:10 avg_depth:4.367 router_objective:-0.1667 router_entropy:0.6710
+step:1370/20000 router_matrix
+step:1370/20000 train_loss:2.2641 train_time:371055ms step_avg:270.84ms router_forward:1 router_objective:-0.1301 router_entropy:0.5514 router_entropy_bonus:0.0888
+step:1380/20000 router_probe window_steps:10 avg_depth:3.755 router_objective:-0.1359 router_entropy:0.5099
+step:1380/20000 router_matrix
+step:1380/20000 train_loss:2.2253 train_time:373156ms step_avg:270.40ms router_forward:1 router_objective:-0.1121 router_entropy:0.5048 router_entropy_bonus:0.0881
+step:1390/20000 router_probe window_steps:10 avg_depth:3.863 router_objective:-0.1196 router_entropy:0.5178
+step:1390/20000 router_matrix
+step:1390/20000 train_loss:2.2667 train_time:375306ms step_avg:270.00ms router_forward:1 router_objective:-0.0999 router_entropy:0.5413 router_entropy_bonus:0.0875
+step:1400/20000 router_probe window_steps:10 avg_depth:4.296 router_objective:-0.1369 router_entropy:0.6333
+step:1400/20000 router_matrix
+step:1400/20000 train_loss:2.2691 train_time:377730ms step_avg:269.81ms router_forward:1 router_objective:-0.1836 router_entropy:0.6909 router_entropy_bonus:0.0868
+step:1410/20000 router_probe window_steps:10 avg_depth:4.411 router_objective:-0.1545 router_entropy:0.6751
+step:1410/20000 router_matrix
+step:1410/20000 train_loss:2.2422 train_time:380264ms step_avg:269.69ms router_forward:1 router_objective:-0.2790 router_entropy:0.6488 router_entropy_bonus:0.0860
+step:1420/20000 router_probe window_steps:10 avg_depth:4.102 router_objective:-0.1215 router_entropy:0.5987
+step:1420/20000 router_matrix
+step:1420/20000 train_loss:2.2343 train_time:382579ms step_avg:269.42ms router_forward:1 router_objective:-0.1121 router_entropy:0.6073 router_entropy_bonus:0.0853
+step:1430/20000 router_probe window_steps:10 avg_depth:4.409 router_objective:-0.1219 router_entropy:0.6703
+step:1430/20000 router_matrix
+step:1430/20000 train_loss:2.2556 train_time:385042ms step_avg:269.26ms router_forward:1 router_objective:-0.1629 router_entropy:0.7298 router_entropy_bonus:0.0846
+step:1440/20000 router_probe window_steps:10 avg_depth:4.602 router_objective:-0.1386 router_entropy:0.7048
+step:1440/20000 router_matrix
+step:1440/20000 train_loss:2.2105 train_time:387617ms step_avg:269.18ms router_forward:1 router_objective:-0.1210 router_entropy:0.6724 router_entropy_bonus:0.0838
+step:1450/20000 router_probe window_steps:10 avg_depth:4.194 router_objective:-0.1242 router_entropy:0.6165
+step:1450/20000 router_matrix
+step:1450/20000 train_loss:2.2096 train_time:389976ms step_avg:268.95ms router_forward:1 router_objective:-0.1158 router_entropy:0.5942 router_entropy_bonus:0.0831
+step:1460/20000 router_probe window_steps:10 avg_depth:4.056 router_objective:-0.1369 router_entropy:0.5976
+step:1460/20000 router_matrix
+step:1460/20000 train_loss:2.2896 train_time:392244ms step_avg:268.66ms router_forward:1 router_objective:-0.1602 router_entropy:0.5565 router_entropy_bonus:0.0824
+step:1470/20000 router_probe window_steps:10 avg_depth:4.092 router_objective:-0.1095 router_entropy:0.5715
+step:1470/20000 router_matrix
+step:1470/20000 train_loss:2.2053 train_time:394475ms step_avg:268.35ms router_forward:1 router_objective:-0.1564 router_entropy:0.6409 router_entropy_bonus:0.0817
+step:1480/20000 router_probe window_steps:10 avg_depth:4.474 router_objective:-0.1361 router_entropy:0.6604
+step:1480/20000 router_matrix
+step:1480/20000 train_loss:2.2347 train_time:396931ms step_avg:268.20ms router_forward:1 router_objective:-0.1600 router_entropy:0.6775 router_entropy_bonus:0.0810
+step:1490/20000 router_probe window_steps:10 avg_depth:4.357 router_objective:-0.1498 router_entropy:0.6656
+step:1490/20000 router_matrix
+step:1490/20000 train_loss:2.2460 train_time:399349ms step_avg:268.02ms router_forward:1 router_objective:-0.1652 router_entropy:0.6504 router_entropy_bonus:0.0803
+step:1500/20000 router_probe window_steps:10 avg_depth:4.211 router_objective:-0.1443 router_entropy:0.5800
+step:1500/20000 router_matrix
+step:1500/20000 train_loss:2.2574 train_time:401677ms step_avg:267.78ms router_forward:1 router_objective:-0.4522 router_entropy:0.5523 router_entropy_bonus:0.0796
+step:1510/20000 router_probe window_steps:10 avg_depth:3.980 router_objective:-0.0970 router_entropy:0.5509
+step:1510/20000 router_matrix
+step:1510/20000 train_loss:2.2722 train_time:403885ms step_avg:267.47ms router_forward:1 router_objective:-0.1270 router_entropy:0.5970 router_entropy_bonus:0.0789
+step:1520/20000 router_probe window_steps:10 avg_depth:4.192 router_objective:-0.1227 router_entropy:0.6411
+step:1520/20000 router_matrix
+step:1520/20000 train_loss:2.2220 train_time:406272ms step_avg:267.28ms router_forward:1 router_objective:-0.1031 router_entropy:0.6374 router_entropy_bonus:0.0782
+step:1530/20000 router_probe window_steps:10 avg_depth:4.281 router_objective:-0.1477 router_entropy:0.6526
+step:1530/20000 router_matrix
+step:1530/20000 train_loss:2.2089 train_time:408672ms step_avg:267.11ms router_forward:1 router_objective:-0.1344 router_entropy:0.6356 router_entropy_bonus:0.0775
+step:1540/20000 router_probe window_steps:10 avg_depth:3.988 router_objective:-0.1014 router_entropy:0.5303
+step:1540/20000 router_matrix
+step:1540/20000 train_loss:2.2300 train_time:410874ms step_avg:266.80ms router_forward:1 router_objective:-0.0698 router_entropy:0.4876 router_entropy_bonus:0.0768
+step:1550/20000 router_probe window_steps:10 avg_depth:4.070 router_objective:-0.1150 router_entropy:0.5791
+step:1550/20000 router_matrix
+step:1550/20000 train_loss:2.2273 train_time:413159ms step_avg:266.55ms router_forward:1 router_objective:-0.1970 router_entropy:0.6542 router_entropy_bonus:0.0761
+step:1560/20000 router_probe window_steps:10 avg_depth:4.275 router_objective:-0.1192 router_entropy:0.6482
+step:1560/20000 router_matrix
+step:1560/20000 train_loss:2.1774 train_time:415556ms step_avg:266.38ms router_forward:1 router_objective:-0.1945 router_entropy:0.6816 router_entropy_bonus:0.0754
+step:1570/20000 router_probe window_steps:10 avg_depth:4.169 router_objective:-0.1452 router_entropy:0.5949
+step:1570/20000 router_matrix
+step:1570/20000 train_loss:2.2264 train_time:417897ms step_avg:266.18ms router_forward:1 router_objective:-0.1177 router_entropy:0.5046 router_entropy_bonus:0.0747
+step:1580/20000 router_probe window_steps:10 avg_depth:3.783 router_objective:-0.0812 router_entropy:0.5000
+step:1580/20000 router_matrix
+step:1580/20000 train_loss:2.2822 train_time:419956ms step_avg:265.80ms router_forward:1 router_objective:-0.0873 router_entropy:0.5449 router_entropy_bonus:0.0741
+step:1590/20000 router_probe window_steps:10 avg_depth:3.821 router_objective:-0.1180 router_entropy:0.5430
+step:1590/20000 router_matrix
+step:1590/20000 train_loss:2.2550 train_time:422089ms step_avg:265.46ms router_forward:1 router_objective:-0.1280 router_entropy:0.5098 router_entropy_bonus:0.0734
+step:1600/20000 router_probe window_steps:10 avg_depth:3.867 router_objective:-0.1183 router_entropy:0.5353
+step:1600/20000 router_matrix
+step:1600/20000 train_loss:2.2955 train_time:424257ms step_avg:265.16ms router_forward:1 router_objective:-0.2068 router_entropy:0.5719 router_entropy_bonus:0.0728
+step:1610/20000 router_probe window_steps:10 avg_depth:3.842 router_objective:-0.1273 router_entropy:0.5040
+step:1610/20000 router_matrix
+step:1610/20000 train_loss:2.2410 train_time:426412ms step_avg:264.85ms router_forward:1 router_objective:-0.0743 router_entropy:0.4171 router_entropy_bonus:0.0721
+step:1620/20000 router_probe window_steps:10 avg_depth:3.628 router_objective:-0.0703 router_entropy:0.4185
+step:1620/20000 router_matrix
+step:1620/20000 train_loss:2.2166 train_time:428392ms step_avg:264.44ms router_forward:1 router_objective:-0.0868 router_entropy:0.5022 router_entropy_bonus:0.0715
+step:1630/20000 router_probe window_steps:10 avg_depth:4.313 router_objective:-0.1297 router_entropy:0.6456
+step:1630/20000 router_matrix
+step:1630/20000 train_loss:2.2209 train_time:430843ms step_avg:264.32ms router_forward:1 router_objective:-0.1959 router_entropy:0.6806 router_entropy_bonus:0.0708
+step:1640/20000 router_probe window_steps:10 avg_depth:4.341 router_objective:-0.1223 router_entropy:0.6694
+step:1640/20000 router_matrix
+step:1640/20000 train_loss:2.2021 train_time:433235ms step_avg:264.17ms router_forward:1 router_objective:-0.1220 router_entropy:0.6426 router_entropy_bonus:0.0701
+step:1650/20000 router_probe window_steps:10 avg_depth:3.992 router_objective:-0.1186 router_entropy:0.5757
+step:1650/20000 router_matrix
+step:1650/20000 train_loss:2.2892 train_time:435425ms step_avg:263.89ms router_forward:1 router_objective:-0.0660 router_entropy:0.5146 router_entropy_bonus:0.0694
+step:1660/20000 router_probe window_steps:10 avg_depth:3.961 router_objective:-0.1052 router_entropy:0.5449
+step:1660/20000 router_matrix
+step:1660/20000 train_loss:2.1886 train_time:437613ms step_avg:263.62ms router_forward:1 router_objective:-0.1398 router_entropy:0.5790 router_entropy_bonus:0.0688
+step:1670/20000 router_probe window_steps:10 avg_depth:3.924 router_objective:-0.0971 router_entropy:0.5558
+step:1670/20000 router_matrix
+step:1670/20000 train_loss:2.2574 train_time:439783ms step_avg:263.34ms router_forward:1 router_objective:-0.1557 router_entropy:0.5852 router_entropy_bonus:0.0681
+step:1680/20000 router_probe window_steps:10 avg_depth:4.093 router_objective:-0.1045 router_entropy:0.5804
+step:1680/20000 router_matrix
+step:1680/20000 train_loss:2.2362 train_time:442027ms step_avg:263.11ms router_forward:1 router_objective:-0.0660 router_entropy:0.5531 router_entropy_bonus:0.0675
+step:1690/20000 router_probe window_steps:10 avg_depth:3.967 router_objective:-0.1051 router_entropy:0.5596
+step:1690/20000 router_matrix
+step:1690/20000 train_loss:2.2020 train_time:444208ms step_avg:262.85ms router_forward:1 router_objective:-0.1054 router_entropy:0.5633 router_entropy_bonus:0.0668
+step:1700/20000 router_probe window_steps:10 avg_depth:3.964 router_objective:-0.0987 router_entropy:0.5558
+step:1700/20000 router_matrix
+step:1700/20000 train_loss:2.1785 train_time:446397ms step_avg:262.59ms router_forward:1 router_objective:-0.0874 router_entropy:0.5427 router_entropy_bonus:0.0661
+step:1710/20000 router_probe window_steps:10 avg_depth:3.803 router_objective:-0.0850 router_entropy:0.5033
+step:1710/20000 router_matrix
+step:1710/20000 train_loss:2.2370 train_time:448481ms step_avg:262.27ms router_forward:1 router_objective:-0.0447 router_entropy:0.4877 router_entropy_bonus:0.0655
+step:1720/20000 router_probe window_steps:10 avg_depth:4.017 router_objective:-0.0985 router_entropy:0.5929
+step:1720/20000 router_matrix
+step:1720/20000 train_loss:2.2636 train_time:450694ms step_avg:262.03ms router_forward:1 router_objective:-0.1048 router_entropy:0.6112 router_entropy_bonus:0.0649
+step:1730/20000 router_probe window_steps:10 avg_depth:4.011 router_objective:-0.1062 router_entropy:0.5681
+step:1730/20000 router_matrix
+step:1730/20000 train_loss:2.2005 train_time:452929ms step_avg:261.81ms router_forward:1 router_objective:-0.1045 router_entropy:0.5229 router_entropy_bonus:0.0642
+step:1740/20000 router_probe window_steps:10 avg_depth:3.766 router_objective:-0.1023 router_entropy:0.4865
+step:1740/20000 router_matrix
+step:1740/20000 train_loss:2.1679 train_time:455042ms step_avg:261.52ms router_forward:1 router_objective:-0.0909 router_entropy:0.4868 router_entropy_bonus:0.0636
+step:1750/20000 router_probe window_steps:10 avg_depth:4.006 router_objective:-0.0839 router_entropy:0.5739
+step:1750/20000 router_matrix
+step:1750/20000 train_loss:2.2053 train_time:457281ms step_avg:261.30ms router_forward:1 router_objective:-0.1115 router_entropy:0.6543 router_entropy_bonus:0.0629
+step:1760/20000 router_probe window_steps:10 avg_depth:4.245 router_objective:-0.1073 router_entropy:0.6505
+step:1760/20000 router_matrix
+step:1760/20000 train_loss:2.2395 train_time:459614ms step_avg:261.14ms router_forward:1 router_objective:-0.0729 router_entropy:0.5982 router_entropy_bonus:0.0622
+step:1770/20000 router_probe window_steps:10 avg_depth:3.901 router_objective:-0.0826 router_entropy:0.5426
+step:1770/20000 router_matrix
+step:1770/20000 train_loss:2.2071 train_time:461801ms step_avg:260.90ms router_forward:1 router_objective:-0.0623 router_entropy:0.4856 router_entropy_bonus:0.0615
+step:1780/20000 router_probe window_steps:10 avg_depth:3.768 router_objective:-0.0829 router_entropy:0.4945
+step:1780/20000 router_matrix
+step:1780/20000 train_loss:2.1631 train_time:463909ms step_avg:260.62ms router_forward:1 router_objective:-0.0781 router_entropy:0.4966 router_entropy_bonus:0.0609
+step:1790/20000 router_probe window_steps:10 avg_depth:3.835 router_objective:-0.0778 router_entropy:0.4921
+step:1790/20000 router_matrix
+step:1790/20000 train_loss:2.2173 train_time:466091ms step_avg:260.39ms router_forward:1 router_objective:-0.0852 router_entropy:0.5148 router_entropy_bonus:0.0602
+step:1800/20000 router_probe window_steps:10 avg_depth:4.003 router_objective:-0.0992 router_entropy:0.5499
+step:1800/20000 router_matrix
+step:1800/20000 train_loss:2.1785 train_time:468331ms step_avg:260.18ms router_forward:1 router_objective:-0.1461 router_entropy:0.5525 router_entropy_bonus:0.0596
+step:1810/20000 router_probe window_steps:10 avg_depth:3.699 router_objective:-0.0919 router_entropy:0.4601
+step:1810/20000 router_matrix
+step:1810/20000 train_loss:2.1302 train_time:470420ms step_avg:259.90ms router_forward:1 router_objective:-0.1060 router_entropy:0.3968 router_entropy_bonus:0.0589
+step:1820/20000 router_probe window_steps:10 avg_depth:3.534 router_objective:-0.0680 router_entropy:0.3897
+step:1820/20000 router_matrix
+step:1820/20000 train_loss:2.2318 train_time:472352ms step_avg:259.53ms router_forward:1 router_objective:-0.0973 router_entropy:0.4020 router_entropy_bonus:0.0584
+step:1830/20000 router_probe window_steps:10 avg_depth:3.653 router_objective:-0.0569 router_entropy:0.4403
+step:1830/20000 router_matrix
+step:1830/20000 train_loss:2.1746 train_time:474379ms step_avg:259.22ms router_forward:1 router_objective:-0.0536 router_entropy:0.4771 router_entropy_bonus:0.0577
+step:1840/20000 router_probe window_steps:10 avg_depth:3.808 router_objective:-0.0724 router_entropy:0.4740
+step:1840/20000 router_matrix
+step:1840/20000 train_loss:2.2044 train_time:476508ms step_avg:258.97ms router_forward:1 router_objective:-0.0048 router_entropy:0.3844 router_entropy_bonus:0.0571
+step:1850/20000 router_probe window_steps:10 avg_depth:3.623 router_objective:-0.0516 router_entropy:0.3394
+step:1850/20000 router_matrix
+step:1850/20000 train_loss:2.2226 train_time:478527ms step_avg:258.66ms router_forward:1 router_objective:-0.0073 router_entropy:0.2666 router_entropy_bonus:0.0565
+step:1860/20000 router_probe window_steps:10 avg_depth:3.586 router_objective:-0.0277 router_entropy:0.2388
+step:1860/20000 router_matrix
+step:1860/20000 train_loss:2.1857 train_time:480440ms step_avg:258.30ms router_forward:1 router_objective:-0.0297 router_entropy:0.2526 router_entropy_bonus:0.0559
+step:1870/20000 router_probe window_steps:10 avg_depth:4.160 router_objective:-0.0198 router_entropy:0.2226
+step:1870/20000 router_matrix
+step:1870/20000 train_loss:2.2292 train_time:482638ms step_avg:258.09ms router_forward:1 router_objective:-0.0281 router_entropy:0.1991 router_entropy_bonus:0.0553
+step:1880/20000 router_probe window_steps:10 avg_depth:4.394 router_objective:-0.0345 router_entropy:0.2318
+step:1880/20000 router_matrix
+step:1880/20000 train_loss:2.1944 train_time:484926ms step_avg:257.94ms router_forward:1 router_objective:-0.0108 router_entropy:0.2486 router_entropy_bonus:0.0546
+step:1890/20000 router_probe window_steps:10 avg_depth:4.038 router_objective:-0.0369 router_entropy:0.2750
+step:1890/20000 router_matrix
+step:1890/20000 train_loss:2.2123 train_time:487060ms step_avg:257.70ms router_forward:1 router_objective:-0.0461 router_entropy:0.2951 router_entropy_bonus:0.0539
+step:1900/20000 router_probe window_steps:10 avg_depth:3.702 router_objective:-0.0413 router_entropy:0.2879
+step:1900/20000 router_matrix
+step:1900/20000 train_loss:2.1542 train_time:489095ms step_avg:257.42ms router_forward:1 router_objective:-0.0006 router_entropy:0.2906 router_entropy_bonus:0.0533
+step:1910/20000 router_probe window_steps:10 avg_depth:3.546 router_objective:-0.0286 router_entropy:0.3057
+step:1910/20000 router_matrix
+step:1910/20000 train_loss:2.1610 train_time:491033ms step_avg:257.09ms router_forward:1 router_objective:-0.0382 router_entropy:0.3180 router_entropy_bonus:0.0527
+step:1920/20000 router_probe window_steps:10 avg_depth:3.601 router_objective:-0.0373 router_entropy:0.3368
+step:1920/20000 router_matrix
+step:1920/20000 train_loss:2.1813 train_time:492988ms step_avg:256.76ms router_forward:1 router_objective:-0.0443 router_entropy:0.3516 router_entropy_bonus:0.0522
+step:1930/20000 router_probe window_steps:10 avg_depth:3.554 router_objective:-0.0391 router_entropy:0.3324
+step:1930/20000 router_matrix
+step:1930/20000 train_loss:2.2663 train_time:494940ms step_avg:256.45ms router_forward:1 router_objective:-0.0440 router_entropy:0.3244 router_entropy_bonus:0.0516
+step:1940/20000 router_probe window_steps:10 avg_depth:3.584 router_objective:-0.0299 router_entropy:0.3226
+step:1940/20000 router_matrix
+step:1940/20000 train_loss:2.1711 train_time:496905ms step_avg:256.14ms router_forward:1 router_objective:-0.0253 router_entropy:0.3203 router_entropy_bonus:0.0510
+step:1950/20000 router_probe window_steps:10 avg_depth:3.836 router_objective:-0.0454 router_entropy:0.3392
+step:1950/20000 router_matrix
+step:1950/20000 train_loss:2.1792 train_time:499027ms step_avg:255.91ms router_forward:1 router_objective:-0.0442 router_entropy:0.3179 router_entropy_bonus:0.0503
+step:1960/20000 router_probe window_steps:10 avg_depth:3.424 router_objective:-0.0702 router_entropy:0.2955
+step:1960/20000 router_matrix
+step:1960/20000 train_loss:2.1884 train_time:500929ms step_avg:255.58ms router_forward:1 router_objective:-0.1390 router_entropy:0.2706 router_entropy_bonus:0.0498
+step:1970/20000 router_probe window_steps:10 avg_depth:3.304 router_objective:-0.0382 router_entropy:0.2435
+step:1970/20000 router_matrix
+step:1970/20000 train_loss:2.2087 train_time:502707ms step_avg:255.18ms router_forward:1 router_objective:-0.0258 router_entropy:0.2227 router_entropy_bonus:0.0492
+step:1980/20000 router_probe window_steps:10 avg_depth:3.296 router_objective:-0.0657 router_entropy:0.2429
+step:1980/20000 router_matrix
+step:1980/20000 train_loss:2.2278 train_time:504512ms step_avg:254.80ms router_forward:1 router_objective:-0.0473 router_entropy:0.2606 router_entropy_bonus:0.0487
+step:1990/20000 router_probe window_steps:10 avg_depth:3.426 router_objective:-0.0357 router_entropy:0.2880
+step:1990/20000 router_matrix
+step:1990/20000 train_loss:2.1551 train_time:506369ms step_avg:254.46ms router_forward:1 router_objective:-0.0089 router_entropy:0.3052 router_entropy_bonus:0.0481
+step:2000/20000 router_probe window_steps:10 avg_depth:3.427 router_objective:-0.0429 router_entropy:0.2912
+step:2000/20000 router_matrix
+step:2000/20000 train_loss:2.2254 train_time:508230ms step_avg:254.11ms router_forward:1 router_objective:-0.0182 router_entropy:0.2760 router_entropy_bonus:0.0476
+step:2010/20000 router_probe window_steps:10 avg_depth:3.262 router_objective:-0.0313 router_entropy:0.2124
+step:2010/20000 router_matrix
+step:2010/20000 train_loss:2.1745 train_time:509977ms step_avg:253.72ms router_forward:1 router_objective:-0.0389 router_entropy:0.1831 router_entropy_bonus:0.0471
+step:2020/20000 router_probe window_steps:10 avg_depth:3.242 router_objective:-0.0229 router_entropy:0.2029
+step:2020/20000 router_matrix
+step:2020/20000 train_loss:2.1644 train_time:511711ms step_avg:253.32ms router_forward:1 router_objective:-0.0195 router_entropy:0.2186 router_entropy_bonus:0.0465
+step:2030/20000 router_probe window_steps:10 avg_depth:3.309 router_objective:-0.0304 router_entropy:0.2472
+step:2030/20000 router_matrix
+step:2030/20000 train_loss:2.1142 train_time:513483ms step_avg:252.95ms router_forward:1 router_objective:-0.0221 router_entropy:0.2599 router_entropy_bonus:0.0460
+step:2040/20000 router_probe window_steps:10 avg_depth:3.511 router_objective:-0.0361 router_entropy:0.3078
+step:2040/20000 router_matrix
+step:2040/20000 train_loss:2.0901 train_time:515393ms step_avg:252.64ms router_forward:1 router_objective:-0.1140 router_entropy:0.3420 router_entropy_bonus:0.0454
+step:2050/20000 router_probe window_steps:10 avg_depth:3.523 router_objective:-0.0487 router_entropy:0.3221
+step:2050/20000 router_matrix
+step:2050/20000 train_loss:2.1523 train_time:517337ms step_avg:252.36ms router_forward:1 router_objective:-0.0437 router_entropy:0.2883 router_entropy_bonus:0.0449
+step:2060/20000 router_probe window_steps:10 avg_depth:3.355 router_objective:-0.0296 router_entropy:0.2644
+step:2060/20000 router_matrix
+step:2060/20000 train_loss:2.1140 train_time:519168ms step_avg:252.02ms router_forward:1 router_objective:-0.0457 router_entropy:0.2643 router_entropy_bonus:0.0443
+step:2070/20000 router_probe window_steps:10 avg_depth:3.343 router_objective:-0.0360 router_entropy:0.2538
+step:2070/20000 router_matrix
+step:2070/20000 train_loss:2.2199 train_time:520976ms step_avg:251.68ms router_forward:1 router_objective:-0.0277 router_entropy:0.2325 router_entropy_bonus:0.0438
+step:2080/20000 router_probe window_steps:10 avg_depth:3.249 router_objective:-0.0200 router_entropy:0.2065
+step:2080/20000 router_matrix
+step:2080/20000 train_loss:2.2334 train_time:522719ms step_avg:251.31ms router_forward:1 router_objective:-0.0332 router_entropy:0.1969 router_entropy_bonus:0.0432
+step:2090/20000 router_probe window_steps:10 avg_depth:3.234 router_objective:-0.0257 router_entropy:0.1964
+step:2090/20000 router_matrix
+step:2090/20000 train_loss:2.1880 train_time:524448ms step_avg:250.93ms router_forward:1 router_objective:-0.0170 router_entropy:0.1942 router_entropy_bonus:0.0427
+step:2100/20000 router_probe window_steps:10 avg_depth:3.240 router_objective:-0.0121 router_entropy:0.2090
+step:2100/20000 router_matrix
+step:2100/20000 train_loss:2.1972 train_time:526166ms step_avg:250.56ms router_forward:1 router_objective:-0.0278 router_entropy:0.2420 router_entropy_bonus:0.0422
+step:2110/20000 router_probe window_steps:10 avg_depth:3.410 router_objective:-0.0235 router_entropy:0.2970
+step:2110/20000 router_matrix
+step:2110/20000 train_loss:2.1479 train_time:528020ms step_avg:250.25ms router_forward:1 router_objective:-0.0222 router_entropy:0.3496 router_entropy_bonus:0.0417
+step:2120/20000 router_probe window_steps:10 avg_depth:3.646 router_objective:-0.0410 router_entropy:0.3665
+step:2120/20000 router_matrix
+step:2120/20000 train_loss:2.1681 train_time:530021ms step_avg:250.01ms router_forward:1 router_objective:-0.0423 router_entropy:0.3575 router_entropy_bonus:0.0411
+step:2130/20000 router_probe window_steps:10 avg_depth:3.573 router_objective:-0.0310 router_entropy:0.3377
+step:2130/20000 router_matrix
+step:2130/20000 train_loss:2.1514 train_time:531972ms step_avg:249.75ms router_forward:1 router_objective:-0.0335 router_entropy:0.3193 router_entropy_bonus:0.0405
+step:2140/20000 router_probe window_steps:10 avg_depth:3.460 router_objective:-0.0319 router_entropy:0.3163
+step:2140/20000 router_matrix
+step:2140/20000 train_loss:2.0814 train_time:533840ms step_avg:249.46ms router_forward:1 router_objective:-0.0121 router_entropy:0.3140 router_entropy_bonus:0.0399
+step:2150/20000 router_probe window_steps:10 avg_depth:3.433 router_objective:-0.0336 router_entropy:0.3031
+step:2150/20000 router_matrix
+step:2150/20000 train_loss:2.1809 train_time:535723ms step_avg:249.17ms router_forward:1 router_objective:-0.0127 router_entropy:0.3031 router_entropy_bonus:0.0393
+step:2160/20000 router_probe window_steps:10 avg_depth:3.421 router_objective:-0.0368 router_entropy:0.3003
+step:2160/20000 router_matrix
+step:2160/20000 train_loss:2.1758 train_time:537577ms step_avg:248.88ms router_forward:1 router_objective:-0.0736 router_entropy:0.2800 router_entropy_bonus:0.0388
+step:2170/20000 router_probe window_steps:10 avg_depth:3.340 router_objective:-0.0276 router_entropy:0.2632
+step:2170/20000 router_matrix
+step:2170/20000 train_loss:2.1026 train_time:539372ms step_avg:248.56ms router_forward:1 router_objective:-0.0459 router_entropy:0.2623 router_entropy_bonus:0.0382
+step:2180/20000 router_probe window_steps:10 avg_depth:3.338 router_objective:-0.0295 router_entropy:0.2608
+step:2180/20000 router_matrix
+step:2180/20000 train_loss:2.1079 train_time:541162ms step_avg:248.24ms router_forward:1 router_objective:-0.0201 router_entropy:0.2596 router_entropy_bonus:0.0377
+step:2190/20000 router_probe window_steps:10 avg_depth:3.408 router_objective:-0.0267 router_entropy:0.2859
+step:2190/20000 router_matrix
+step:2190/20000 train_loss:2.1787 train_time:543014ms step_avg:247.95ms router_forward:1 router_objective:-0.0313 router_entropy:0.3021 router_entropy_bonus:0.0372
+step:2200/20000 router_probe window_steps:10 avg_depth:3.364 router_objective:-0.0381 router_entropy:0.2709
+step:2200/20000 router_matrix
+step:2200/20000 train_loss:2.0775 train_time:544847ms step_avg:247.66ms router_forward:1 router_objective:-0.0137 router_entropy:0.2286 router_entropy_bonus:0.0366
+step:2210/20000 router_probe window_steps:10 avg_depth:3.226 router_objective:-0.0195 router_entropy:0.1992
+step:2210/20000 router_matrix
+step:2210/20000 train_loss:2.1300 train_time:546575ms step_avg:247.32ms router_forward:1 router_objective:0.0210 router_entropy:0.1806 router_entropy_bonus:0.0361
+step:2220/20000 router_probe window_steps:10 avg_depth:3.179 router_objective:-0.0261 router_entropy:0.1675
+step:2220/20000 router_matrix
+step:2220/20000 train_loss:2.1259 train_time:548265ms step_avg:246.97ms router_forward:1 router_objective:-0.0437 router_entropy:0.1533 router_entropy_bonus:0.0356
+step:2230/20000 router_probe window_steps:10 avg_depth:3.149 router_objective:-0.0138 router_entropy:0.1458
+step:2230/20000 router_matrix
+step:2230/20000 train_loss:2.1364 train_time:549942ms step_avg:246.61ms router_forward:1 router_objective:-0.0306 router_entropy:0.1459 router_entropy_bonus:0.0351
+step:2240/20000 router_probe window_steps:10 avg_depth:3.212 router_objective:-0.0197 router_entropy:0.1635
+step:2240/20000 router_matrix
+step:2240/20000 train_loss:2.1451 train_time:551654ms step_avg:246.27ms router_forward:1 router_objective:-0.0302 router_entropy:0.1754 router_entropy_bonus:0.0346
+step:2250/20000 router_probe window_steps:10 avg_depth:3.226 router_objective:-0.0175 router_entropy:0.1666
+step:2250/20000 router_matrix
+step:2250/20000 train_loss:2.1452 train_time:553364ms step_avg:245.94ms router_forward:1 router_objective:-0.0117 router_entropy:0.1559 router_entropy_bonus:0.0340
+step:2260/20000 router_probe window_steps:10 avg_depth:3.161 router_objective:-0.0173 router_entropy:0.1435
+step:2260/20000 router_matrix
+step:2260/20000 train_loss:2.1827 train_time:555046ms step_avg:245.60ms router_forward:1 router_objective:-0.0123 router_entropy:0.1376 router_entropy_bonus:0.0335
+step:2270/20000 router_probe window_steps:10 avg_depth:3.149 router_objective:-0.0149 router_entropy:0.1413
+step:2270/20000 router_matrix
+step:2270/20000 train_loss:2.1062 train_time:556735ms step_avg:245.26ms router_forward:1 router_objective:-0.0392 router_entropy:0.1504 router_entropy_bonus:0.0330
+step:2280/20000 router_probe window_steps:10 avg_depth:3.198 router_objective:-0.0174 router_entropy:0.1654
+step:2280/20000 router_matrix
+step:2280/20000 train_loss:2.0629 train_time:558422ms step_avg:244.92ms router_forward:1 router_objective:-0.0481 router_entropy:0.1770 router_entropy_bonus:0.0325
+step:2290/20000 router_probe window_steps:10 avg_depth:3.202 router_objective:-0.0259 router_entropy:0.1693
+step:2290/20000 router_matrix
+step:2290/20000 train_loss:2.1137 train_time:560131ms step_avg:244.60ms router_forward:1 router_objective:-0.0201 router_entropy:0.1554 router_entropy_bonus:0.0320
+step:2300/20000 router_probe window_steps:10 avg_depth:3.140 router_objective:-0.0204 router_entropy:0.1364
+step:2300/20000 router_matrix
+step:2300/20000 train_loss:2.1004 train_time:561791ms step_avg:244.26ms router_forward:1 router_objective:-0.0452 router_entropy:0.1245 router_entropy_bonus:0.0315
+step:2310/20000 router_probe window_steps:10 avg_depth:3.121 router_objective:-0.0216 router_entropy:0.1153
+step:2310/20000 router_matrix
+step:2310/20000 train_loss:2.1579 train_time:563464ms step_avg:243.92ms router_forward:1 router_objective:-0.0198 router_entropy:0.1154 router_entropy_bonus:0.0310
+step:2320/20000 router_probe window_steps:10 avg_depth:3.131 router_objective:-0.0270 router_entropy:0.1178
+step:2320/20000 router_matrix
+step:2320/20000 train_loss:2.1137 train_time:565187ms step_avg:243.61ms router_forward:1 router_objective:-0.0079 router_entropy:0.1252 router_entropy_bonus:0.0305
+step:2330/20000 router_probe window_steps:10 avg_depth:3.179 router_objective:-0.0261 router_entropy:0.1427
+step:2330/20000 router_matrix
+step:2330/20000 train_loss:2.0899 train_time:566921ms step_avg:243.31ms router_forward:1 router_objective:-0.0006 router_entropy:0.1559 router_entropy_bonus:0.0300
+step:2340/20000 router_probe window_steps:10 avg_depth:3.191 router_objective:-0.0105 router_entropy:0.1666
+step:2340/20000 router_matrix
+step:2340/20000 train_loss:2.1485 train_time:568601ms step_avg:242.99ms router_forward:1 router_objective:-0.0257 router_entropy:0.1771 router_entropy_bonus:0.0295
+step:2350/20000 router_probe window_steps:10 avg_depth:3.217 router_objective:-0.0184 router_entropy:0.1835
+step:2350/20000 router_matrix
+step:2350/20000 train_loss:2.1072 train_time:570320ms step_avg:242.69ms router_forward:1 router_objective:-0.0275 router_entropy:0.1827 router_entropy_bonus:0.0290
+step:2360/20000 router_probe window_steps:10 avg_depth:3.208 router_objective:-0.0183 router_entropy:0.1723
+step:2360/20000 router_matrix
+step:2360/20000 train_loss:2.1010 train_time:572034ms step_avg:242.39ms router_forward:1 router_objective:-0.0043 router_entropy:0.1612 router_entropy_bonus:0.0284
+step:2370/20000 router_probe window_steps:10 avg_depth:3.169 router_objective:-0.0229 router_entropy:0.1453
+step:2370/20000 router_matrix
+step:2370/20000 train_loss:2.1108 train_time:573712ms step_avg:242.07ms router_forward:1 router_objective:-0.0061 router_entropy:0.1290 router_entropy_bonus:0.0279
+step:2380/20000 router_probe window_steps:10 avg_depth:3.110 router_objective:-0.0113 router_entropy:0.1174
+step:2380/20000 router_matrix
+step:2380/20000 train_loss:2.1592 train_time:575337ms step_avg:241.74ms router_forward:1 router_objective:-0.0150 router_entropy:0.1107 router_entropy_bonus:0.0274
+step:2390/20000 router_probe window_steps:10 avg_depth:3.114 router_objective:-0.0326 router_entropy:0.1095
+step:2390/20000 router_matrix
+step:2390/20000 train_loss:2.0581 train_time:577032ms step_avg:241.44ms router_forward:1 router_objective:-0.0110 router_entropy:0.1094 router_entropy_bonus:0.0269
+step:2400/20000 router_probe window_steps:10 avg_depth:3.116 router_objective:-0.0218 router_entropy:0.1089
+step:2400/20000 router_matrix
+step:2400/20000 train_loss:2.1319 train_time:578696ms step_avg:241.12ms router_forward:1 router_objective:-0.0201 router_entropy:0.1103 router_entropy_bonus:0.0264
+step:2410/20000 router_probe window_steps:10 avg_depth:3.114 router_objective:-0.0118 router_entropy:0.1063
+step:2410/20000 router_matrix
+step:2410/20000 train_loss:2.0201 train_time:580334ms step_avg:240.80ms router_forward:1 router_objective:-0.0189 router_entropy:0.1032 router_entropy_bonus:0.0259
+step:2420/20000 router_probe window_steps:10 avg_depth:3.096 router_objective:-0.0130 router_entropy:0.1044
+step:2420/20000 router_matrix
+step:2420/20000 train_loss:2.1476 train_time:581974ms step_avg:240.49ms router_forward:1 router_objective:-0.0305 router_entropy:0.1042 router_entropy_bonus:0.0255
+step:2430/20000 router_probe window_steps:10 avg_depth:3.087 router_objective:-0.0101 router_entropy:0.1011
+step:2430/20000 router_matrix
+step:2430/20000 train_loss:2.0966 train_time:583602ms step_avg:240.17ms router_forward:1 router_objective:-0.0198 router_entropy:0.0999 router_entropy_bonus:0.0250
+step:2440/20000 router_probe window_steps:10 avg_depth:3.078 router_objective:-0.0080 router_entropy:0.0971
+step:2440/20000 router_matrix
+step:2440/20000 train_loss:2.0715 train_time:585220ms step_avg:239.84ms router_forward:1 router_objective:0.0038 router_entropy:0.0956 router_entropy_bonus:0.0245
+step:2450/20000 router_probe window_steps:10 avg_depth:3.077 router_objective:-0.0102 router_entropy:0.0972
+step:2450/20000 router_matrix
+step:2450/20000 train_loss:2.0445 train_time:586844ms step_avg:239.53ms router_forward:1 router_objective:-0.0143 router_entropy:0.0991 router_entropy_bonus:0.0240
+step:2460/20000 router_probe window_steps:10 avg_depth:3.080 router_objective:-0.0091 router_entropy:0.0980
+step:2460/20000 router_matrix
+step:2460/20000 train_loss:2.0871 train_time:588462ms step_avg:239.21ms router_forward:1 router_objective:-0.0235 router_entropy:0.0964 router_entropy_bonus:0.0235
+step:2470/20000 router_probe window_steps:10 avg_depth:3.074 router_objective:-0.0034 router_entropy:0.0974
+step:2470/20000 router_matrix
+step:2470/20000 train_loss:2.1398 train_time:590065ms step_avg:238.89ms router_forward:1 router_objective:0.0033 router_entropy:0.1014 router_entropy_bonus:0.0230
+step:2480/20000 router_probe window_steps:10 avg_depth:3.091 router_objective:-0.0057 router_entropy:0.1070
+step:2480/20000 router_matrix
+step:2480/20000 train_loss:2.0345 train_time:591693ms step_avg:238.59ms router_forward:1 router_objective:0.0090 router_entropy:0.1100 router_entropy_bonus:0.0225
+step:2490/20000 router_probe window_steps:10 avg_depth:3.108 router_objective:-0.0300 router_entropy:0.1122
+step:2490/20000 router_matrix
+step:2490/20000 train_loss:2.0943 train_time:593360ms step_avg:238.30ms router_forward:1 router_objective:-0.0043 router_entropy:0.1146 router_entropy_bonus:0.0220
+step:2500/20000 router_probe window_steps:10 avg_depth:3.109 router_objective:-0.0308 router_entropy:0.1144
+step:2500/20000 router_matrix
+step:2500/20000 train_loss:2.1151 train_time:595067ms step_avg:238.03ms router_forward:1 router_objective:0.0041 router_entropy:0.1143 router_entropy_bonus:0.0215
+step:2510/20000 router_probe window_steps:10 avg_depth:3.093 router_objective:-0.0143 router_entropy:0.1149
+step:2510/20000 router_matrix
+step:2510/20000 train_loss:2.1276 train_time:596689ms step_avg:237.72ms router_forward:1 router_objective:-0.0035 router_entropy:0.1143 router_entropy_bonus:0.0210
+step:2520/20000 router_probe window_steps:10 avg_depth:3.090 router_objective:-0.0030 router_entropy:0.1116
+step:2520/20000 router_matrix
+step:2520/20000 train_loss:2.0603 train_time:598320ms step_avg:237.43ms router_forward:1 router_objective:-0.0111 router_entropy:0.1098 router_entropy_bonus:0.0206
+step:2530/20000 router_probe window_steps:10 avg_depth:3.097 router_objective:-0.0108 router_entropy:0.1106
+step:2530/20000 router_matrix
+step:2530/20000 train_loss:2.0847 train_time:599954ms step_avg:237.14ms router_forward:1 router_objective:-0.0005 router_entropy:0.1105 router_entropy_bonus:0.0201
+stopping_early: wallclock_cap train_time:600116ms step:2531/20000
+peak memory allocated: 54886 MiB reserved: 79100 MiB
+ema:applying EMA weights
+Serialized model: 129974489 bytes
+Serialized model int6+zlib: 13423905 bytes
+final_int6_roundtrip val_loss:2.2299 val_bpb:1.3207 eval_time:3943ms
+final_int6_roundtrip_exact val_loss:2.22988748 val_bpb:1.32066497

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_3_dashboard_20260419_225908_cf9443b3.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_3_dashboard_20260419_225908_cf9443b3.stdout.log
@@ -1,0 +1,463 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260419_225908_cf9443b3.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+model_params:56230945
+attention_router_params:397472 mlp_router_params:132748
+unique_blocks:1 recurrent_steps:8
+world_size:8 grad_accum_steps:1
+train_batch_tokens:786432 train_seq_len:2048 iterations:20000 warmup_steps:20 warmdown_frac:0.72 min_lr:0.0000 val_loss_every:0 num_recurrent_steps:8 max_wallclock_seconds:600.000
+attention_head_top_k:16 mlp_num_experts:12 mlp_expert_top_k:2 eval_recurrent_steps:8
+attention_router_input_dim:3072 attention_router_hidden_dim:128 attention_router_lr:0.001 attention_router_wd:0.01 attention_router_entropy_bonus_start:0.02 attention_router_entropy_bonus_end:0.002 attention_router_js_bonus:0.5 mlp_router_hidden_dim:128 mlp_router_lr:0.001 mlp_router_wd:0.01 mlp_router_entropy_bonus_start:0.02 mlp_router_entropy_bonus_end:0.002 mlp_router_js_bonus:0.02 activation_checkpointing:0 ema_decay:0.9965 muon_momentum_warmup_steps:1500
+warmup_step:1/20
+warmup_step:10/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9755 train_time:576ms step_avg:576.08ms routers_forward:2 attn_aux:-0.0693 attn_entropy:3.4657 attn_js:0.0000 attn_entropy_bonus:0.0200 mlp_aux:-0.0497 mlp_entropy:2.4849 mlp_js:0.0000 mlp_entropy_bonus:0.0200
+step:2/20000 train_loss:12.4794 train_time:1137ms step_avg:568.41ms routers_forward:2 attn_aux:-0.0693 attn_entropy:3.4657 attn_js:0.0000 attn_entropy_bonus:0.0200 mlp_aux:-0.0497 mlp_entropy:2.4849 mlp_js:0.0000 mlp_entropy_bonus:0.0200
+step:3/20000 train_loss:9.7572 train_time:1709ms step_avg:569.67ms routers_forward:2 attn_aux:-0.0692 attn_entropy:3.4655 attn_js:0.0000 attn_entropy_bonus:0.0200 mlp_aux:-0.0496 mlp_entropy:2.4848 mlp_js:0.0000 mlp_entropy_bonus:0.0200
+step:4/20000 train_loss:7.5495 train_time:2273ms step_avg:568.21ms routers_forward:2 attn_aux:-0.0688 attn_entropy:3.4458 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0495 mlp_entropy:2.4817 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:5/20000 train_loss:6.4237 train_time:2847ms step_avg:569.37ms routers_forward:2 attn_aux:-0.0690 attn_entropy:3.4603 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0491 mlp_entropy:2.4613 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:6/20000 train_loss:6.0739 train_time:3419ms step_avg:569.80ms routers_forward:2 attn_aux:-0.0690 attn_entropy:3.4649 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0492 mlp_entropy:2.4721 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:7/20000 train_loss:6.0176 train_time:3985ms step_avg:569.26ms routers_forward:2 attn_aux:-0.0689 attn_entropy:3.4624 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0493 mlp_entropy:2.4793 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:8/20000 train_loss:5.9297 train_time:4553ms step_avg:569.14ms routers_forward:2 attn_aux:-0.0688 attn_entropy:3.4598 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0493 mlp_entropy:2.4784 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:9/20000 train_loss:5.8194 train_time:5121ms step_avg:568.95ms routers_forward:2 attn_aux:-0.0686 attn_entropy:3.4534 attn_js:0.0000 attn_entropy_bonus:0.0199 mlp_aux:-0.0490 mlp_entropy:2.4688 mlp_js:0.0000 mlp_entropy_bonus:0.0199
+step:10/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.0689 attn_entropy:3.4585 attn_js:0.0000 mlp_aux:-0.0493 mlp_entropy:2.4739 mlp_js:0.0000
+step:10/20000 attention_head_matrix
+step:10/20000 mlp_expert_matrix
+step:10/20000 train_loss:5.6630 train_time:5689ms step_avg:568.88ms routers_forward:2 attn_aux:-0.0684 attn_entropy:3.4413 attn_js:0.0002 attn_entropy_bonus:0.0198 mlp_aux:-0.0485 mlp_entropy:2.4430 mlp_js:0.0000 mlp_entropy_bonus:0.0198
+step:20/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.0711 attn_entropy:3.3471 attn_js:0.0099 mlp_aux:-0.0467 mlp_entropy:2.3624 mlp_js:0.0023
+step:20/20000 attention_head_matrix
+step:20/20000 mlp_expert_matrix
+step:20/20000 train_loss:4.6675 train_time:11775ms step_avg:588.73ms routers_forward:2 attn_aux:-0.0803 attn_entropy:3.0423 attn_js:0.0410 attn_entropy_bonus:0.0197 mlp_aux:-0.0457 mlp_entropy:2.3199 mlp_js:0.0050 mlp_entropy_bonus:0.0197
+step:30/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1209 attn_entropy:2.1095 attn_js:0.1592 mlp_aux:-0.0469 mlp_entropy:2.3903 mlp_js:0.0056
+step:30/20000 attention_head_matrix
+step:30/20000 mlp_expert_matrix
+step:30/20000 train_loss:4.1220 train_time:17543ms step_avg:584.77ms routers_forward:2 attn_aux:-0.1630 attn_entropy:1.6043 attn_js:0.2635 attn_entropy_bonus:0.0195 mlp_aux:-0.0472 mlp_entropy:2.4154 mlp_js:0.0065 mlp_entropy_bonus:0.0195
+step:40/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1892 attn_entropy:1.8234 attn_js:0.3076 mlp_aux:-0.0472 mlp_entropy:2.4263 mlp_js:0.0061
+step:40/20000 attention_head_matrix
+step:40/20000 mlp_expert_matrix
+step:40/20000 train_loss:3.7310 train_time:23255ms step_avg:581.36ms routers_forward:2 attn_aux:-0.2017 attn_entropy:1.8351 attn_js:0.3325 attn_entropy_bonus:0.0193 mlp_aux:-0.0474 mlp_entropy:2.4483 mlp_js:0.0040 mlp_entropy_bonus:0.0193
+step:50/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2071 attn_entropy:1.7705 attn_js:0.3461 mlp_aux:-0.0474 mlp_entropy:2.4629 mlp_js:0.0027
+step:50/20000 attention_head_matrix
+step:50/20000 mlp_expert_matrix
+step:50/20000 train_loss:3.5541 train_time:28909ms step_avg:578.18ms routers_forward:2 attn_aux:-0.2104 attn_entropy:1.7552 attn_js:0.3535 attn_entropy_bonus:0.0191 mlp_aux:-0.0473 mlp_entropy:2.4676 mlp_js:0.0023 mlp_entropy_bonus:0.0191
+step:60/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2112 attn_entropy:1.7408 attn_js:0.3561 mlp_aux:-0.0471 mlp_entropy:2.4674 mlp_js:0.0023
+step:60/20000 attention_head_matrix
+step:60/20000 mlp_expert_matrix
+step:60/20000 train_loss:3.5016 train_time:34546ms step_avg:575.77ms routers_forward:2 attn_aux:-0.2114 attn_entropy:1.7429 attn_js:0.3566 attn_entropy_bonus:0.0190 mlp_aux:-0.0469 mlp_entropy:2.4693 mlp_js:0.0018 mlp_entropy_bonus:0.0190
+step:70/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2114 attn_entropy:1.7403 attn_js:0.3570 mlp_aux:-0.0467 mlp_entropy:2.4707 mlp_js:0.0012
+step:70/20000 attention_head_matrix
+step:70/20000 mlp_expert_matrix
+step:70/20000 train_loss:3.3765 train_time:40156ms step_avg:573.66ms routers_forward:2 attn_aux:-0.2106 attn_entropy:1.7511 attn_js:0.3554 attn_entropy_bonus:0.0188 mlp_aux:-0.0465 mlp_entropy:2.4724 mlp_js:0.0008 mlp_entropy_bonus:0.0188
+step:80/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2115 attn_entropy:1.7373 attn_js:0.3579 mlp_aux:-0.0463 mlp_entropy:2.4706 mlp_js:0.0008
+step:80/20000 attention_head_matrix
+step:80/20000 mlp_expert_matrix
+step:80/20000 train_loss:3.3788 train_time:45738ms step_avg:571.73ms routers_forward:2 attn_aux:-0.2116 attn_entropy:1.7396 attn_js:0.3582 attn_entropy_bonus:0.0186 mlp_aux:-0.0460 mlp_entropy:2.4686 mlp_js:0.0009 mlp_entropy_bonus:0.0186
+step:90/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2117 attn_entropy:1.7352 attn_js:0.3590 mlp_aux:-0.0459 mlp_entropy:2.4722 mlp_js:0.0006
+step:90/20000 attention_head_matrix
+step:90/20000 mlp_expert_matrix
+step:90/20000 train_loss:3.2863 train_time:51308ms step_avg:570.09ms routers_forward:2 attn_aux:-0.2116 attn_entropy:1.7370 attn_js:0.3589 attn_entropy_bonus:0.0185 mlp_aux:-0.0457 mlp_entropy:2.4738 mlp_js:0.0003 mlp_entropy_bonus:0.0185
+step:100/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2118 attn_entropy:1.7338 attn_js:0.3598 mlp_aux:-0.0455 mlp_entropy:2.4726 mlp_js:0.0002
+step:100/20000 attention_head_matrix
+step:100/20000 mlp_expert_matrix
+step:100/20000 train_loss:3.2205 train_time:56862ms step_avg:568.62ms routers_forward:2 attn_aux:-0.2118 attn_entropy:1.7336 attn_js:0.3601 attn_entropy_bonus:0.0183 mlp_aux:-0.0453 mlp_entropy:2.4721 mlp_js:0.0001 mlp_entropy_bonus:0.0183
+step:110/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2118 attn_entropy:1.7339 attn_js:0.3603 mlp_aux:-0.0450 mlp_entropy:2.4714 mlp_js:0.0001
+step:110/20000 attention_head_matrix
+step:110/20000 mlp_expert_matrix
+step:110/20000 train_loss:3.2432 train_time:62422ms step_avg:567.47ms routers_forward:2 attn_aux:-0.2118 attn_entropy:1.7332 attn_js:0.3607 attn_entropy_bonus:0.0181 mlp_aux:-0.0448 mlp_entropy:2.4710 mlp_js:0.0001 mlp_entropy_bonus:0.0181
+step:120/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2116 attn_entropy:1.7341 attn_js:0.3607 mlp_aux:-0.0446 mlp_entropy:2.4696 mlp_js:0.0001
+step:120/20000 attention_head_matrix
+step:120/20000 mlp_expert_matrix
+step:120/20000 train_loss:3.1624 train_time:67979ms step_avg:566.49ms routers_forward:2 attn_aux:-0.2117 attn_entropy:1.7326 attn_js:0.3610 attn_entropy_bonus:0.0180 mlp_aux:-0.0444 mlp_entropy:2.4703 mlp_js:0.0001 mlp_entropy_bonus:0.0180
+step:130/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2116 attn_entropy:1.7337 attn_js:0.3612 mlp_aux:-0.0442 mlp_entropy:2.4694 mlp_js:0.0002
+step:130/20000 attention_head_matrix
+step:130/20000 mlp_expert_matrix
+step:130/20000 train_loss:3.1606 train_time:73532ms step_avg:565.63ms routers_forward:2 attn_aux:-0.2116 attn_entropy:1.7313 attn_js:0.3616 attn_entropy_bonus:0.0178 mlp_aux:-0.0440 mlp_entropy:2.4695 mlp_js:0.0003 mlp_entropy_bonus:0.0178
+step:140/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2117 attn_entropy:1.7329 attn_js:0.3620 mlp_aux:-0.0438 mlp_entropy:2.4689 mlp_js:0.0003
+step:140/20000 attention_head_matrix
+step:140/20000 mlp_expert_matrix
+step:140/20000 train_loss:3.0897 train_time:79109ms step_avg:565.06ms routers_forward:2 attn_aux:-0.2115 attn_entropy:1.7330 attn_js:0.3618 attn_entropy_bonus:0.0176 mlp_aux:-0.0436 mlp_entropy:2.4691 mlp_js:0.0004 mlp_entropy_bonus:0.0176
+step:150/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2116 attn_entropy:1.7332 attn_js:0.3623 mlp_aux:-0.0433 mlp_entropy:2.4680 mlp_js:0.0004
+step:150/20000 attention_head_matrix
+step:150/20000 mlp_expert_matrix
+step:150/20000 train_loss:3.0563 train_time:84685ms step_avg:564.57ms routers_forward:2 attn_aux:-0.2115 attn_entropy:1.7324 attn_js:0.3625 attn_entropy_bonus:0.0175 mlp_aux:-0.0431 mlp_entropy:2.4670 mlp_js:0.0003 mlp_entropy_bonus:0.0175
+step:160/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2115 attn_entropy:1.7325 attn_js:0.3628 mlp_aux:-0.0429 mlp_entropy:2.4682 mlp_js:0.0004
+step:160/20000 attention_head_matrix
+step:160/20000 mlp_expert_matrix
+step:160/20000 train_loss:3.0204 train_time:90274ms step_avg:564.21ms routers_forward:2 attn_aux:-0.2114 attn_entropy:1.7315 attn_js:0.3629 attn_entropy_bonus:0.0173 mlp_aux:-0.0427 mlp_entropy:2.4695 mlp_js:0.0002 mlp_entropy_bonus:0.0173
+step:170/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2115 attn_entropy:1.7326 attn_js:0.3634 mlp_aux:-0.0425 mlp_entropy:2.4700 mlp_js:0.0005
+step:170/20000 attention_head_matrix
+step:170/20000 mlp_expert_matrix
+step:170/20000 train_loss:2.9665 train_time:95852ms step_avg:563.83ms routers_forward:2 attn_aux:-0.2115 attn_entropy:1.7325 attn_js:0.3636 attn_entropy_bonus:0.0171 mlp_aux:-0.0423 mlp_entropy:2.4693 mlp_js:0.0005 mlp_entropy_bonus:0.0171
+step:180/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2113 attn_entropy:1.7324 attn_js:0.3636 mlp_aux:-0.0421 mlp_entropy:2.4692 mlp_js:0.0004
+step:180/20000 attention_head_matrix
+step:180/20000 mlp_expert_matrix
+step:180/20000 train_loss:2.9482 train_time:101431ms step_avg:563.51ms routers_forward:2 attn_aux:-0.2110 attn_entropy:1.7322 attn_js:0.3631 attn_entropy_bonus:0.0170 mlp_aux:-0.0419 mlp_entropy:2.4681 mlp_js:0.0003 mlp_entropy_bonus:0.0170
+step:190/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2111 attn_entropy:1.7336 attn_js:0.3636 mlp_aux:-0.0417 mlp_entropy:2.4698 mlp_js:0.0005
+step:190/20000 attention_head_matrix
+step:190/20000 mlp_expert_matrix
+step:190/20000 train_loss:2.9481 train_time:107000ms step_avg:563.16ms routers_forward:2 attn_aux:-0.2111 attn_entropy:1.7322 attn_js:0.3639 attn_entropy_bonus:0.0168 mlp_aux:-0.0415 mlp_entropy:2.4700 mlp_js:0.0003 mlp_entropy_bonus:0.0168
+step:200/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2112 attn_entropy:1.7324 attn_js:0.3645 mlp_aux:-0.0413 mlp_entropy:2.4703 mlp_js:0.0004
+step:200/20000 attention_head_matrix
+step:200/20000 mlp_expert_matrix
+step:200/20000 train_loss:2.9169 train_time:112572ms step_avg:562.86ms routers_forward:2 attn_aux:-0.2112 attn_entropy:1.7324 attn_js:0.3647 attn_entropy_bonus:0.0166 mlp_aux:-0.0411 mlp_entropy:2.4703 mlp_js:0.0003 mlp_entropy_bonus:0.0166
+step:210/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2112 attn_entropy:1.7323 attn_js:0.3650 mlp_aux:-0.0409 mlp_entropy:2.4709 mlp_js:0.0004
+step:210/20000 attention_head_matrix
+step:210/20000 mlp_expert_matrix
+step:210/20000 train_loss:2.9053 train_time:118130ms step_avg:562.52ms routers_forward:2 attn_aux:-0.2111 attn_entropy:1.7334 attn_js:0.3651 attn_entropy_bonus:0.0165 mlp_aux:-0.0407 mlp_entropy:2.4705 mlp_js:0.0005 mlp_entropy_bonus:0.0165
+step:220/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2110 attn_entropy:1.7318 attn_js:0.3653 mlp_aux:-0.0405 mlp_entropy:2.4707 mlp_js:0.0004
+step:220/20000 attention_head_matrix
+step:220/20000 mlp_expert_matrix
+step:220/20000 train_loss:2.8774 train_time:123704ms step_avg:562.29ms routers_forward:2 attn_aux:-0.2109 attn_entropy:1.7308 attn_js:0.3654 attn_entropy_bonus:0.0163 mlp_aux:-0.0403 mlp_entropy:2.4714 mlp_js:0.0005 mlp_entropy_bonus:0.0163
+step:230/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2109 attn_entropy:1.7324 attn_js:0.3656 mlp_aux:-0.0401 mlp_entropy:2.4720 mlp_js:0.0003
+step:230/20000 attention_head_matrix
+step:230/20000 mlp_expert_matrix
+step:230/20000 train_loss:2.8651 train_time:129266ms step_avg:562.03ms routers_forward:2 attn_aux:-0.2109 attn_entropy:1.7318 attn_js:0.3659 attn_entropy_bonus:0.0161 mlp_aux:-0.0399 mlp_entropy:2.4719 mlp_js:0.0002 mlp_entropy_bonus:0.0161
+step:240/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2108 attn_entropy:1.7322 attn_js:0.3659 mlp_aux:-0.0397 mlp_entropy:2.4720 mlp_js:0.0003
+step:240/20000 attention_head_matrix
+step:240/20000 mlp_expert_matrix
+step:240/20000 train_loss:2.8311 train_time:134808ms step_avg:561.70ms routers_forward:2 attn_aux:-0.2108 attn_entropy:1.7316 attn_js:0.3663 attn_entropy_bonus:0.0160 mlp_aux:-0.0395 mlp_entropy:2.4716 mlp_js:0.0004 mlp_entropy_bonus:0.0160
+step:250/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2108 attn_entropy:1.7316 attn_js:0.3665 mlp_aux:-0.0393 mlp_entropy:2.4727 mlp_js:0.0002
+step:250/20000 attention_head_matrix
+step:250/20000 mlp_expert_matrix
+step:250/20000 train_loss:2.8377 train_time:140348ms step_avg:561.39ms routers_forward:2 attn_aux:-0.2106 attn_entropy:1.7319 attn_js:0.3665 attn_entropy_bonus:0.0158 mlp_aux:-0.0391 mlp_entropy:2.4726 mlp_js:0.0002 mlp_entropy_bonus:0.0158
+step:260/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2106 attn_entropy:1.7316 attn_js:0.3667 mlp_aux:-0.0389 mlp_entropy:2.4723 mlp_js:0.0003
+step:260/20000 attention_head_matrix
+step:260/20000 mlp_expert_matrix
+step:260/20000 train_loss:2.8218 train_time:145872ms step_avg:561.05ms routers_forward:2 attn_aux:-0.2105 attn_entropy:1.7306 attn_js:0.3669 attn_entropy_bonus:0.0156 mlp_aux:-0.0387 mlp_entropy:2.4724 mlp_js:0.0003 mlp_entropy_bonus:0.0156
+step:270/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2105 attn_entropy:1.7313 attn_js:0.3671 mlp_aux:-0.0385 mlp_entropy:2.4733 mlp_js:0.0002
+step:270/20000 attention_head_matrix
+step:270/20000 mlp_expert_matrix
+step:270/20000 train_loss:2.7386 train_time:151398ms step_avg:560.73ms routers_forward:2 attn_aux:-0.2104 attn_entropy:1.7313 attn_js:0.3673 attn_entropy_bonus:0.0155 mlp_aux:-0.0383 mlp_entropy:2.4745 mlp_js:0.0001 mlp_entropy_bonus:0.0155
+step:280/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2102 attn_entropy:1.7319 attn_js:0.3670 mlp_aux:-0.0380 mlp_entropy:2.4729 mlp_js:0.0002
+step:280/20000 attention_head_matrix
+step:280/20000 mlp_expert_matrix
+step:280/20000 train_loss:2.7691 train_time:156918ms step_avg:560.42ms routers_forward:2 attn_aux:-0.2101 attn_entropy:1.7322 attn_js:0.3672 attn_entropy_bonus:0.0153 mlp_aux:-0.0379 mlp_entropy:2.4730 mlp_js:0.0003 mlp_entropy_bonus:0.0153
+step:290/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2102 attn_entropy:1.7310 attn_js:0.3677 mlp_aux:-0.0376 mlp_entropy:2.4732 mlp_js:0.0002
+step:290/20000 attention_head_matrix
+step:290/20000 mlp_expert_matrix
+step:290/20000 train_loss:2.7530 train_time:162430ms step_avg:560.10ms routers_forward:2 attn_aux:-0.2102 attn_entropy:1.7310 attn_js:0.3679 attn_entropy_bonus:0.0151 mlp_aux:-0.0375 mlp_entropy:2.4730 mlp_js:0.0002 mlp_entropy_bonus:0.0151
+step:300/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2101 attn_entropy:1.7309 attn_js:0.3681 mlp_aux:-0.0372 mlp_entropy:2.4731 mlp_js:0.0002
+step:300/20000 attention_head_matrix
+step:300/20000 mlp_expert_matrix
+step:300/20000 train_loss:2.7601 train_time:167936ms step_avg:559.79ms routers_forward:2 attn_aux:-0.2101 attn_entropy:1.7307 attn_js:0.3683 attn_entropy_bonus:0.0150 mlp_aux:-0.0370 mlp_entropy:2.4728 mlp_js:0.0002 mlp_entropy_bonus:0.0150
+step:310/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2099 attn_entropy:1.7307 attn_js:0.3683 mlp_aux:-0.0368 mlp_entropy:2.4730 mlp_js:0.0002
+step:310/20000 attention_head_matrix
+step:310/20000 mlp_expert_matrix
+step:310/20000 train_loss:2.7089 train_time:173441ms step_avg:559.49ms routers_forward:2 attn_aux:-0.2099 attn_entropy:1.7308 attn_js:0.3684 attn_entropy_bonus:0.0148 mlp_aux:-0.0366 mlp_entropy:2.4730 mlp_js:0.0002 mlp_entropy_bonus:0.0148
+step:320/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2098 attn_entropy:1.7306 attn_js:0.3686 mlp_aux:-0.0364 mlp_entropy:2.4729 mlp_js:0.0002
+step:320/20000 attention_head_matrix
+step:320/20000 mlp_expert_matrix
+step:320/20000 train_loss:2.7601 train_time:178940ms step_avg:559.19ms routers_forward:2 attn_aux:-0.2097 attn_entropy:1.7306 attn_js:0.3687 attn_entropy_bonus:0.0146 mlp_aux:-0.0362 mlp_entropy:2.4729 mlp_js:0.0002 mlp_entropy_bonus:0.0146
+step:330/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2097 attn_entropy:1.7305 attn_js:0.3689 mlp_aux:-0.0360 mlp_entropy:2.4722 mlp_js:0.0002
+step:330/20000 attention_head_matrix
+step:330/20000 mlp_expert_matrix
+step:330/20000 train_loss:2.6881 train_time:184442ms step_avg:558.92ms routers_forward:2 attn_aux:-0.2096 attn_entropy:1.7304 attn_js:0.3691 attn_entropy_bonus:0.0145 mlp_aux:-0.0358 mlp_entropy:2.4716 mlp_js:0.0002 mlp_entropy_bonus:0.0145
+step:340/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2094 attn_entropy:1.7307 attn_js:0.3690 mlp_aux:-0.0356 mlp_entropy:2.4724 mlp_js:0.0001
+step:340/20000 attention_head_matrix
+step:340/20000 mlp_expert_matrix
+step:340/20000 train_loss:2.7283 train_time:189954ms step_avg:558.69ms routers_forward:2 attn_aux:-0.2095 attn_entropy:1.7301 attn_js:0.3694 attn_entropy_bonus:0.0143 mlp_aux:-0.0354 mlp_entropy:2.4726 mlp_js:0.0001 mlp_entropy_bonus:0.0143
+step:350/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2094 attn_entropy:1.7300 attn_js:0.3696 mlp_aux:-0.0352 mlp_entropy:2.4719 mlp_js:0.0001
+step:350/20000 attention_head_matrix
+step:350/20000 mlp_expert_matrix
+step:350/20000 train_loss:2.7301 train_time:195452ms step_avg:558.43ms routers_forward:2 attn_aux:-0.2093 attn_entropy:1.7299 attn_js:0.3697 attn_entropy_bonus:0.0142 mlp_aux:-0.0350 mlp_entropy:2.4710 mlp_js:0.0001 mlp_entropy_bonus:0.0142
+step:360/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2092 attn_entropy:1.7299 attn_js:0.3698 mlp_aux:-0.0348 mlp_entropy:2.4712 mlp_js:0.0001
+step:360/20000 attention_head_matrix
+step:360/20000 mlp_expert_matrix
+step:360/20000 train_loss:2.7173 train_time:200945ms step_avg:558.18ms routers_forward:2 attn_aux:-0.2092 attn_entropy:1.7297 attn_js:0.3700 attn_entropy_bonus:0.0140 mlp_aux:-0.0346 mlp_entropy:2.4713 mlp_js:0.0001 mlp_entropy_bonus:0.0140
+step:370/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2091 attn_entropy:1.7297 attn_js:0.3701 mlp_aux:-0.0343 mlp_entropy:2.4709 mlp_js:0.0001
+step:370/20000 attention_head_matrix
+step:370/20000 mlp_expert_matrix
+step:370/20000 train_loss:2.6862 train_time:206428ms step_avg:557.91ms routers_forward:2 attn_aux:-0.2090 attn_entropy:1.7296 attn_js:0.3702 attn_entropy_bonus:0.0138 mlp_aux:-0.0342 mlp_entropy:2.4705 mlp_js:0.0001 mlp_entropy_bonus:0.0138
+step:380/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2089 attn_entropy:1.7295 attn_js:0.3703 mlp_aux:-0.0339 mlp_entropy:2.4703 mlp_js:0.0001
+step:380/20000 attention_head_matrix
+step:380/20000 mlp_expert_matrix
+step:380/20000 train_loss:2.6066 train_time:211917ms step_avg:557.68ms routers_forward:2 attn_aux:-0.2086 attn_entropy:1.7294 attn_js:0.3699 attn_entropy_bonus:0.0137 mlp_aux:-0.0337 mlp_entropy:2.4698 mlp_js:0.0001 mlp_entropy_bonus:0.0137
+step:390/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2086 attn_entropy:1.7299 attn_js:0.3703 mlp_aux:-0.0335 mlp_entropy:2.4703 mlp_js:0.0001
+step:390/20000 attention_head_matrix
+step:390/20000 mlp_expert_matrix
+step:390/20000 train_loss:2.5977 train_time:217398ms step_avg:557.43ms routers_forward:2 attn_aux:-0.2086 attn_entropy:1.7296 attn_js:0.3706 attn_entropy_bonus:0.0135 mlp_aux:-0.0333 mlp_entropy:2.4700 mlp_js:0.0001 mlp_entropy_bonus:0.0135
+step:400/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2086 attn_entropy:1.7291 attn_js:0.3709 mlp_aux:-0.0331 mlp_entropy:2.4697 mlp_js:0.0001
+step:400/20000 attention_head_matrix
+step:400/20000 mlp_expert_matrix
+step:400/20000 train_loss:2.6451 train_time:222890ms step_avg:557.23ms routers_forward:2 attn_aux:-0.2086 attn_entropy:1.7290 attn_js:0.3711 attn_entropy_bonus:0.0133 mlp_aux:-0.0329 mlp_entropy:2.4699 mlp_js:0.0001 mlp_entropy_bonus:0.0133
+step:410/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2085 attn_entropy:1.7289 attn_js:0.3712 mlp_aux:-0.0327 mlp_entropy:2.4692 mlp_js:0.0001
+step:410/20000 attention_head_matrix
+step:410/20000 mlp_expert_matrix
+step:410/20000 train_loss:2.6434 train_time:228375ms step_avg:557.01ms routers_forward:2 attn_aux:-0.2084 attn_entropy:1.7289 attn_js:0.3712 attn_entropy_bonus:0.0132 mlp_aux:-0.0325 mlp_entropy:2.4684 mlp_js:0.0001 mlp_entropy_bonus:0.0132
+step:420/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2083 attn_entropy:1.7288 attn_js:0.3713 mlp_aux:-0.0323 mlp_entropy:2.4685 mlp_js:0.0001
+step:420/20000 attention_head_matrix
+step:420/20000 mlp_expert_matrix
+step:420/20000 train_loss:2.6092 train_time:233865ms step_avg:556.82ms routers_forward:2 attn_aux:-0.2082 attn_entropy:1.7287 attn_js:0.3715 attn_entropy_bonus:0.0130 mlp_aux:-0.0321 mlp_entropy:2.4683 mlp_js:0.0001 mlp_entropy_bonus:0.0130
+step:430/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2082 attn_entropy:1.7285 attn_js:0.3717 mlp_aux:-0.0319 mlp_entropy:2.4685 mlp_js:0.0001
+step:430/20000 attention_head_matrix
+step:430/20000 mlp_expert_matrix
+step:430/20000 train_loss:2.5958 train_time:239359ms step_avg:556.65ms routers_forward:2 attn_aux:-0.2081 attn_entropy:1.7284 attn_js:0.3718 attn_entropy_bonus:0.0128 mlp_aux:-0.0317 mlp_entropy:2.4685 mlp_js:0.0001 mlp_entropy_bonus:0.0128
+step:440/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2080 attn_entropy:1.7284 attn_js:0.3719 mlp_aux:-0.0315 mlp_entropy:2.4682 mlp_js:0.0001
+step:440/20000 attention_head_matrix
+step:440/20000 mlp_expert_matrix
+step:440/20000 train_loss:2.5781 train_time:244850ms step_avg:556.48ms routers_forward:2 attn_aux:-0.2078 attn_entropy:1.7285 attn_js:0.3719 attn_entropy_bonus:0.0127 mlp_aux:-0.0313 mlp_entropy:2.4688 mlp_js:0.0001 mlp_entropy_bonus:0.0127
+step:450/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2078 attn_entropy:1.7283 attn_js:0.3720 mlp_aux:-0.0310 mlp_entropy:2.4673 mlp_js:0.0001
+step:450/20000 attention_head_matrix
+step:450/20000 mlp_expert_matrix
+step:450/20000 train_loss:2.6202 train_time:250337ms step_avg:556.30ms routers_forward:2 attn_aux:-0.2077 attn_entropy:1.7281 attn_js:0.3722 attn_entropy_bonus:0.0125 mlp_aux:-0.0309 mlp_entropy:2.4667 mlp_js:0.0001 mlp_entropy_bonus:0.0125
+step:460/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2075 attn_entropy:1.7282 attn_js:0.3722 mlp_aux:-0.0306 mlp_entropy:2.4670 mlp_js:0.0001
+step:460/20000 attention_head_matrix
+step:460/20000 mlp_expert_matrix
+step:460/20000 train_loss:2.6064 train_time:255832ms step_avg:556.16ms routers_forward:2 attn_aux:-0.2073 attn_entropy:1.7283 attn_js:0.3720 attn_entropy_bonus:0.0123 mlp_aux:-0.0304 mlp_entropy:2.4668 mlp_js:0.0001 mlp_entropy_bonus:0.0123
+step:470/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2074 attn_entropy:1.7282 attn_js:0.3724 mlp_aux:-0.0302 mlp_entropy:2.4665 mlp_js:0.0001
+step:470/20000 attention_head_matrix
+step:470/20000 mlp_expert_matrix
+step:470/20000 train_loss:2.5540 train_time:261330ms step_avg:556.02ms routers_forward:2 attn_aux:-0.2074 attn_entropy:1.7278 attn_js:0.3727 attn_entropy_bonus:0.0122 mlp_aux:-0.0300 mlp_entropy:2.4664 mlp_js:0.0001 mlp_entropy_bonus:0.0122
+step:480/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2073 attn_entropy:1.7277 attn_js:0.3728 mlp_aux:-0.0298 mlp_entropy:2.4662 mlp_js:0.0001
+step:480/20000 attention_head_matrix
+step:480/20000 mlp_expert_matrix
+step:480/20000 train_loss:2.6300 train_time:266822ms step_avg:555.88ms routers_forward:2 attn_aux:-0.2072 attn_entropy:1.7276 attn_js:0.3729 attn_entropy_bonus:0.0120 mlp_aux:-0.0296 mlp_entropy:2.4655 mlp_js:0.0001 mlp_entropy_bonus:0.0120
+step:490/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2071 attn_entropy:1.7275 attn_js:0.3730 mlp_aux:-0.0294 mlp_entropy:2.4657 mlp_js:0.0001
+step:490/20000 attention_head_matrix
+step:490/20000 mlp_expert_matrix
+step:490/20000 train_loss:2.5900 train_time:272321ms step_avg:555.76ms routers_forward:2 attn_aux:-0.2071 attn_entropy:1.7274 attn_js:0.3732 attn_entropy_bonus:0.0118 mlp_aux:-0.0292 mlp_entropy:2.4655 mlp_js:0.0001 mlp_entropy_bonus:0.0118
+step:500/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2069 attn_entropy:1.7274 attn_js:0.3732 mlp_aux:-0.0290 mlp_entropy:2.4653 mlp_js:0.0001
+step:500/20000 attention_head_matrix
+step:500/20000 mlp_expert_matrix
+step:500/20000 train_loss:2.5928 train_time:277809ms step_avg:555.62ms routers_forward:2 attn_aux:-0.2069 attn_entropy:1.7273 attn_js:0.3734 attn_entropy_bonus:0.0117 mlp_aux:-0.0288 mlp_entropy:2.4652 mlp_js:0.0001 mlp_entropy_bonus:0.0117
+step:510/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2068 attn_entropy:1.7272 attn_js:0.3735 mlp_aux:-0.0286 mlp_entropy:2.4649 mlp_js:0.0001
+step:510/20000 attention_head_matrix
+step:510/20000 mlp_expert_matrix
+step:510/20000 train_loss:2.6396 train_time:283289ms step_avg:555.47ms routers_forward:2 attn_aux:-0.2066 attn_entropy:1.7272 attn_js:0.3734 attn_entropy_bonus:0.0115 mlp_aux:-0.0284 mlp_entropy:2.4648 mlp_js:0.0001 mlp_entropy_bonus:0.0115
+step:520/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2065 attn_entropy:1.7272 attn_js:0.3735 mlp_aux:-0.0282 mlp_entropy:2.4648 mlp_js:0.0001
+step:520/20000 attention_head_matrix
+step:520/20000 mlp_expert_matrix
+step:520/20000 train_loss:2.4884 train_time:288774ms step_avg:555.33ms routers_forward:2 attn_aux:-0.2064 attn_entropy:1.7272 attn_js:0.3735 attn_entropy_bonus:0.0114 mlp_aux:-0.0280 mlp_entropy:2.4651 mlp_js:0.0001 mlp_entropy_bonus:0.0114
+step:530/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2063 attn_entropy:1.7270 attn_js:0.3737 mlp_aux:-0.0278 mlp_entropy:2.4640 mlp_js:0.0001
+step:530/20000 attention_head_matrix
+step:530/20000 mlp_expert_matrix
+step:530/20000 train_loss:2.5249 train_time:294258ms step_avg:555.20ms routers_forward:2 attn_aux:-0.2062 attn_entropy:1.7269 attn_js:0.3738 attn_entropy_bonus:0.0112 mlp_aux:-0.0276 mlp_entropy:2.4641 mlp_js:0.0001 mlp_entropy_bonus:0.0112
+step:540/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2061 attn_entropy:1.7269 attn_js:0.3739 mlp_aux:-0.0273 mlp_entropy:2.4636 mlp_js:0.0001
+step:540/20000 attention_head_matrix
+step:540/20000 mlp_expert_matrix
+step:540/20000 train_loss:2.5828 train_time:299763ms step_avg:555.12ms routers_forward:2 attn_aux:-0.2060 attn_entropy:1.7267 attn_js:0.3740 attn_entropy_bonus:0.0110 mlp_aux:-0.0272 mlp_entropy:2.4628 mlp_js:0.0001 mlp_entropy_bonus:0.0110
+step:550/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2059 attn_entropy:1.7266 attn_js:0.3741 mlp_aux:-0.0269 mlp_entropy:2.4632 mlp_js:0.0001
+step:550/20000 attention_head_matrix
+step:550/20000 mlp_expert_matrix
+step:550/20000 train_loss:2.5176 train_time:305260ms step_avg:555.02ms routers_forward:2 attn_aux:-0.2059 attn_entropy:1.7266 attn_js:0.3742 attn_entropy_bonus:0.0109 mlp_aux:-0.0268 mlp_entropy:2.4634 mlp_js:0.0001 mlp_entropy_bonus:0.0109
+step:560/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2057 attn_entropy:1.7265 attn_js:0.3743 mlp_aux:-0.0265 mlp_entropy:2.4628 mlp_js:0.0001
+step:560/20000 attention_head_matrix
+step:560/20000 mlp_expert_matrix
+step:560/20000 train_loss:2.4918 train_time:310751ms step_avg:554.91ms routers_forward:2 attn_aux:-0.2057 attn_entropy:1.7264 attn_js:0.3744 attn_entropy_bonus:0.0107 mlp_aux:-0.0263 mlp_entropy:2.4623 mlp_js:0.0001 mlp_entropy_bonus:0.0107
+step:570/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2056 attn_entropy:1.7264 attn_js:0.3745 mlp_aux:-0.0261 mlp_entropy:2.4625 mlp_js:0.0001
+step:570/20000 attention_head_matrix
+step:570/20000 mlp_expert_matrix
+step:570/20000 train_loss:2.5335 train_time:316251ms step_avg:554.83ms routers_forward:2 attn_aux:-0.2054 attn_entropy:1.7263 attn_js:0.3745 attn_entropy_bonus:0.0105 mlp_aux:-0.0259 mlp_entropy:2.4626 mlp_js:0.0001 mlp_entropy_bonus:0.0105
+step:580/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2054 attn_entropy:1.7263 attn_js:0.3747 mlp_aux:-0.0257 mlp_entropy:2.4618 mlp_js:0.0001
+step:580/20000 attention_head_matrix
+step:580/20000 mlp_expert_matrix
+step:580/20000 train_loss:2.5027 train_time:321742ms step_avg:554.73ms routers_forward:2 attn_aux:-0.2053 attn_entropy:1.7262 attn_js:0.3748 attn_entropy_bonus:0.0104 mlp_aux:-0.0255 mlp_entropy:2.4616 mlp_js:0.0001 mlp_entropy_bonus:0.0104
+step:590/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2052 attn_entropy:1.7261 attn_js:0.3750 mlp_aux:-0.0253 mlp_entropy:2.4617 mlp_js:0.0001
+step:590/20000 attention_head_matrix
+step:590/20000 mlp_expert_matrix
+step:590/20000 train_loss:2.5379 train_time:327233ms step_avg:554.63ms routers_forward:2 attn_aux:-0.2052 attn_entropy:1.7260 attn_js:0.3752 attn_entropy_bonus:0.0102 mlp_aux:-0.0251 mlp_entropy:2.4612 mlp_js:0.0001 mlp_entropy_bonus:0.0102
+step:600/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2050 attn_entropy:1.7259 attn_js:0.3752 mlp_aux:-0.0249 mlp_entropy:2.4617 mlp_js:0.0001
+step:600/20000 attention_head_matrix
+step:600/20000 mlp_expert_matrix
+step:600/20000 train_loss:2.5650 train_time:332737ms step_avg:554.56ms routers_forward:2 attn_aux:-0.2049 attn_entropy:1.7259 attn_js:0.3752 attn_entropy_bonus:0.0100 mlp_aux:-0.0247 mlp_entropy:2.4615 mlp_js:0.0001 mlp_entropy_bonus:0.0100
+step:610/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2048 attn_entropy:1.7259 attn_js:0.3752 mlp_aux:-0.0245 mlp_entropy:2.4608 mlp_js:0.0001
+step:610/20000 attention_head_matrix
+step:610/20000 mlp_expert_matrix
+step:610/20000 train_loss:2.4815 train_time:338237ms step_avg:554.49ms routers_forward:2 attn_aux:-0.2047 attn_entropy:1.7258 attn_js:0.3753 attn_entropy_bonus:0.0099 mlp_aux:-0.0243 mlp_entropy:2.4604 mlp_js:0.0001 mlp_entropy_bonus:0.0099
+step:620/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2047 attn_entropy:1.7256 attn_js:0.3756 mlp_aux:-0.0241 mlp_entropy:2.4606 mlp_js:0.0001
+step:620/20000 attention_head_matrix
+step:620/20000 mlp_expert_matrix
+step:620/20000 train_loss:2.4809 train_time:343734ms step_avg:554.41ms routers_forward:2 attn_aux:-0.2046 attn_entropy:1.7255 attn_js:0.3758 attn_entropy_bonus:0.0097 mlp_aux:-0.0239 mlp_entropy:2.4600 mlp_js:0.0001 mlp_entropy_bonus:0.0097
+step:630/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2045 attn_entropy:1.7255 attn_js:0.3759 mlp_aux:-0.0236 mlp_entropy:2.4596 mlp_js:0.0001
+step:630/20000 attention_head_matrix
+step:630/20000 mlp_expert_matrix
+step:630/20000 train_loss:2.5508 train_time:349221ms step_avg:554.32ms routers_forward:2 attn_aux:-0.2045 attn_entropy:1.7254 attn_js:0.3760 attn_entropy_bonus:0.0095 mlp_aux:-0.0235 mlp_entropy:2.4599 mlp_js:0.0001 mlp_entropy_bonus:0.0095
+step:640/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2044 attn_entropy:1.7253 attn_js:0.3762 mlp_aux:-0.0232 mlp_entropy:2.4595 mlp_js:0.0001
+step:640/20000 attention_head_matrix
+step:640/20000 mlp_expert_matrix
+step:640/20000 train_loss:2.4178 train_time:354716ms step_avg:554.24ms routers_forward:2 attn_aux:-0.2043 attn_entropy:1.7252 attn_js:0.3762 attn_entropy_bonus:0.0094 mlp_aux:-0.0231 mlp_entropy:2.4597 mlp_js:0.0001 mlp_entropy_bonus:0.0094
+step:650/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2042 attn_entropy:1.7252 attn_js:0.3763 mlp_aux:-0.0228 mlp_entropy:2.4592 mlp_js:0.0001
+step:650/20000 attention_head_matrix
+step:650/20000 mlp_expert_matrix
+step:650/20000 train_loss:2.5521 train_time:360216ms step_avg:554.18ms routers_forward:2 attn_aux:-0.2041 attn_entropy:1.7251 attn_js:0.3763 attn_entropy_bonus:0.0092 mlp_aux:-0.0226 mlp_entropy:2.4586 mlp_js:0.0001 mlp_entropy_bonus:0.0092
+step:660/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2040 attn_entropy:1.7251 attn_js:0.3765 mlp_aux:-0.0224 mlp_entropy:2.4586 mlp_js:0.0001
+step:660/20000 attention_head_matrix
+step:660/20000 mlp_expert_matrix
+step:660/20000 train_loss:2.4688 train_time:365710ms step_avg:554.11ms routers_forward:2 attn_aux:-0.2039 attn_entropy:1.7250 attn_js:0.3766 attn_entropy_bonus:0.0090 mlp_aux:-0.0222 mlp_entropy:2.4586 mlp_js:0.0001 mlp_entropy_bonus:0.0090
+step:670/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2038 attn_entropy:1.7250 attn_js:0.3767 mlp_aux:-0.0220 mlp_entropy:2.4583 mlp_js:0.0001
+step:670/20000 attention_head_matrix
+step:670/20000 mlp_expert_matrix
+step:670/20000 train_loss:2.5253 train_time:371198ms step_avg:554.03ms routers_forward:2 attn_aux:-0.2037 attn_entropy:1.7249 attn_js:0.3768 attn_entropy_bonus:0.0089 mlp_aux:-0.0218 mlp_entropy:2.4580 mlp_js:0.0001 mlp_entropy_bonus:0.0089
+step:680/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2036 attn_entropy:1.7248 attn_js:0.3769 mlp_aux:-0.0216 mlp_entropy:2.4577 mlp_js:0.0001
+step:680/20000 attention_head_matrix
+step:680/20000 mlp_expert_matrix
+step:680/20000 train_loss:2.4343 train_time:376705ms step_avg:553.98ms routers_forward:2 attn_aux:-0.2035 attn_entropy:1.7247 attn_js:0.3770 attn_entropy_bonus:0.0087 mlp_aux:-0.0214 mlp_entropy:2.4575 mlp_js:0.0001 mlp_entropy_bonus:0.0087
+step:690/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2034 attn_entropy:1.7247 attn_js:0.3771 mlp_aux:-0.0212 mlp_entropy:2.4572 mlp_js:0.0001
+step:690/20000 attention_head_matrix
+step:690/20000 mlp_expert_matrix
+step:690/20000 train_loss:2.4831 train_time:382211ms step_avg:553.93ms routers_forward:2 attn_aux:-0.2033 attn_entropy:1.7246 attn_js:0.3772 attn_entropy_bonus:0.0086 mlp_aux:-0.0210 mlp_entropy:2.4573 mlp_js:0.0001 mlp_entropy_bonus:0.0086
+step:700/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2032 attn_entropy:1.7246 attn_js:0.3772 mlp_aux:-0.0208 mlp_entropy:2.4571 mlp_js:0.0001
+step:700/20000 attention_head_matrix
+step:700/20000 mlp_expert_matrix
+step:700/20000 train_loss:2.3965 train_time:387709ms step_avg:553.87ms routers_forward:2 attn_aux:-0.2031 attn_entropy:1.7245 attn_js:0.3773 attn_entropy_bonus:0.0084 mlp_aux:-0.0206 mlp_entropy:2.4572 mlp_js:0.0001 mlp_entropy_bonus:0.0084
+step:710/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2030 attn_entropy:1.7245 attn_js:0.3773 mlp_aux:-0.0204 mlp_entropy:2.4565 mlp_js:0.0001
+step:710/20000 attention_head_matrix
+step:710/20000 mlp_expert_matrix
+step:710/20000 train_loss:2.5017 train_time:393216ms step_avg:553.83ms routers_forward:2 attn_aux:-0.2029 attn_entropy:1.7244 attn_js:0.3774 attn_entropy_bonus:0.0082 mlp_aux:-0.0202 mlp_entropy:2.4558 mlp_js:0.0001 mlp_entropy_bonus:0.0082
+step:720/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2028 attn_entropy:1.7243 attn_js:0.3776 mlp_aux:-0.0200 mlp_entropy:2.4563 mlp_js:0.0001
+step:720/20000 attention_head_matrix
+step:720/20000 mlp_expert_matrix
+step:720/20000 train_loss:2.3828 train_time:398716ms step_avg:553.77ms routers_forward:2 attn_aux:-0.2027 attn_entropy:1.7243 attn_js:0.3776 attn_entropy_bonus:0.0081 mlp_aux:-0.0198 mlp_entropy:2.4560 mlp_js:0.0001 mlp_entropy_bonus:0.0081
+step:730/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2026 attn_entropy:1.7242 attn_js:0.3777 mlp_aux:-0.0196 mlp_entropy:2.4559 mlp_js:0.0001
+step:730/20000 attention_head_matrix
+step:730/20000 mlp_expert_matrix
+step:730/20000 train_loss:2.4439 train_time:404215ms step_avg:553.72ms routers_forward:2 attn_aux:-0.2025 attn_entropy:1.7242 attn_js:0.3778 attn_entropy_bonus:0.0079 mlp_aux:-0.0194 mlp_entropy:2.4551 mlp_js:0.0001 mlp_entropy_bonus:0.0079
+step:740/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2024 attn_entropy:1.7241 attn_js:0.3778 mlp_aux:-0.0192 mlp_entropy:2.4554 mlp_js:0.0001
+step:740/20000 attention_head_matrix
+step:740/20000 mlp_expert_matrix
+step:740/20000 train_loss:2.4564 train_time:409709ms step_avg:553.66ms routers_forward:2 attn_aux:-0.2023 attn_entropy:1.7241 attn_js:0.3779 attn_entropy_bonus:0.0077 mlp_aux:-0.0190 mlp_entropy:2.4553 mlp_js:0.0001 mlp_entropy_bonus:0.0077
+step:750/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2021 attn_entropy:1.7241 attn_js:0.3779 mlp_aux:-0.0187 mlp_entropy:2.4553 mlp_js:0.0001
+step:750/20000 attention_head_matrix
+step:750/20000 mlp_expert_matrix
+step:750/20000 train_loss:2.4419 train_time:415207ms step_avg:553.61ms routers_forward:2 attn_aux:-0.2021 attn_entropy:1.7240 attn_js:0.3780 attn_entropy_bonus:0.0076 mlp_aux:-0.0186 mlp_entropy:2.4554 mlp_js:0.0001 mlp_entropy_bonus:0.0076
+step:760/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2019 attn_entropy:1.7240 attn_js:0.3781 mlp_aux:-0.0183 mlp_entropy:2.4546 mlp_js:0.0001
+step:760/20000 attention_head_matrix
+step:760/20000 mlp_expert_matrix
+step:760/20000 train_loss:2.4355 train_time:420705ms step_avg:553.56ms routers_forward:2 attn_aux:-0.2018 attn_entropy:1.7240 attn_js:0.3781 attn_entropy_bonus:0.0074 mlp_aux:-0.0182 mlp_entropy:2.4546 mlp_js:0.0001 mlp_entropy_bonus:0.0074
+step:770/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2017 attn_entropy:1.7239 attn_js:0.3782 mlp_aux:-0.0179 mlp_entropy:2.4543 mlp_js:0.0001
+step:770/20000 attention_head_matrix
+step:770/20000 mlp_expert_matrix
+step:770/20000 train_loss:2.4484 train_time:426205ms step_avg:553.51ms routers_forward:2 attn_aux:-0.2016 attn_entropy:1.7239 attn_js:0.3782 attn_entropy_bonus:0.0072 mlp_aux:-0.0177 mlp_entropy:2.4540 mlp_js:0.0001 mlp_entropy_bonus:0.0072
+step:780/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2015 attn_entropy:1.7238 attn_js:0.3783 mlp_aux:-0.0175 mlp_entropy:2.4539 mlp_js:0.0001
+step:780/20000 attention_head_matrix
+step:780/20000 mlp_expert_matrix
+step:780/20000 train_loss:2.4451 train_time:431698ms step_avg:553.46ms routers_forward:2 attn_aux:-0.2014 attn_entropy:1.7238 attn_js:0.3784 attn_entropy_bonus:0.0071 mlp_aux:-0.0173 mlp_entropy:2.4537 mlp_js:0.0001 mlp_entropy_bonus:0.0071
+step:790/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2012 attn_entropy:1.7237 attn_js:0.3785 mlp_aux:-0.0171 mlp_entropy:2.4535 mlp_js:0.0001
+step:790/20000 attention_head_matrix
+step:790/20000 mlp_expert_matrix
+step:790/20000 train_loss:2.3854 train_time:437343ms step_avg:553.60ms routers_forward:2 attn_aux:-0.2012 attn_entropy:1.7237 attn_js:0.3785 attn_entropy_bonus:0.0069 mlp_aux:-0.0169 mlp_entropy:2.4542 mlp_js:0.0001 mlp_entropy_bonus:0.0069
+step:800/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2010 attn_entropy:1.7237 attn_js:0.3785 mlp_aux:-0.0167 mlp_entropy:2.4529 mlp_js:0.0001
+step:800/20000 attention_head_matrix
+step:800/20000 mlp_expert_matrix
+step:800/20000 train_loss:2.4480 train_time:442830ms step_avg:553.54ms routers_forward:2 attn_aux:-0.2009 attn_entropy:1.7236 attn_js:0.3786 attn_entropy_bonus:0.0067 mlp_aux:-0.0165 mlp_entropy:2.4528 mlp_js:0.0001 mlp_entropy_bonus:0.0067
+step:810/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2008 attn_entropy:1.7236 attn_js:0.3787 mlp_aux:-0.0163 mlp_entropy:2.4527 mlp_js:0.0001
+step:810/20000 attention_head_matrix
+step:810/20000 mlp_expert_matrix
+step:810/20000 train_loss:2.3914 train_time:448325ms step_avg:553.49ms routers_forward:2 attn_aux:-0.2007 attn_entropy:1.7236 attn_js:0.3787 attn_entropy_bonus:0.0066 mlp_aux:-0.0161 mlp_entropy:2.4526 mlp_js:0.0001 mlp_entropy_bonus:0.0066
+step:820/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2005 attn_entropy:1.7235 attn_js:0.3788 mlp_aux:-0.0159 mlp_entropy:2.4521 mlp_js:0.0001
+step:820/20000 attention_head_matrix
+step:820/20000 mlp_expert_matrix
+step:820/20000 train_loss:2.3868 train_time:453824ms step_avg:553.44ms routers_forward:2 attn_aux:-0.2005 attn_entropy:1.7235 attn_js:0.3788 attn_entropy_bonus:0.0064 mlp_aux:-0.0157 mlp_entropy:2.4518 mlp_js:0.0001 mlp_entropy_bonus:0.0064
+step:830/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2003 attn_entropy:1.7235 attn_js:0.3789 mlp_aux:-0.0155 mlp_entropy:2.4518 mlp_js:0.0001
+step:830/20000 attention_head_matrix
+step:830/20000 mlp_expert_matrix
+step:830/20000 train_loss:2.4247 train_time:459473ms step_avg:553.58ms routers_forward:2 attn_aux:-0.2002 attn_entropy:1.7235 attn_js:0.3788 attn_entropy_bonus:0.0062 mlp_aux:-0.0153 mlp_entropy:2.4518 mlp_js:0.0001 mlp_entropy_bonus:0.0062
+step:840/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.2001 attn_entropy:1.7234 attn_js:0.3790 mlp_aux:-0.0151 mlp_entropy:2.4514 mlp_js:0.0001
+step:840/20000 attention_head_matrix
+step:840/20000 mlp_expert_matrix
+step:840/20000 train_loss:2.4124 train_time:465138ms step_avg:553.74ms routers_forward:2 attn_aux:-0.2000 attn_entropy:1.7234 attn_js:0.3790 attn_entropy_bonus:0.0061 mlp_aux:-0.0149 mlp_entropy:2.4509 mlp_js:0.0001 mlp_entropy_bonus:0.0061
+step:850/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1998 attn_entropy:1.7234 attn_js:0.3791 mlp_aux:-0.0146 mlp_entropy:2.4510 mlp_js:0.0001
+step:850/20000 attention_head_matrix
+step:850/20000 mlp_expert_matrix
+step:850/20000 train_loss:2.4311 train_time:470640ms step_avg:553.69ms routers_forward:2 attn_aux:-0.1997 attn_entropy:1.7234 attn_js:0.3791 attn_entropy_bonus:0.0059 mlp_aux:-0.0145 mlp_entropy:2.4511 mlp_js:0.0001 mlp_entropy_bonus:0.0059
+step:860/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1996 attn_entropy:1.7233 attn_js:0.3791 mlp_aux:-0.0142 mlp_entropy:2.4506 mlp_js:0.0001
+step:860/20000 attention_head_matrix
+step:860/20000 mlp_expert_matrix
+step:860/20000 train_loss:2.3567 train_time:476139ms step_avg:553.65ms routers_forward:2 attn_aux:-0.1995 attn_entropy:1.7233 attn_js:0.3792 attn_entropy_bonus:0.0057 mlp_aux:-0.0141 mlp_entropy:2.4509 mlp_js:0.0001 mlp_entropy_bonus:0.0057
+step:870/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1993 attn_entropy:1.7233 attn_js:0.3792 mlp_aux:-0.0138 mlp_entropy:2.4505 mlp_js:0.0001
+step:870/20000 attention_head_matrix
+step:870/20000 mlp_expert_matrix
+step:870/20000 train_loss:2.3907 train_time:481636ms step_avg:553.60ms routers_forward:2 attn_aux:-0.1992 attn_entropy:1.7233 attn_js:0.3793 attn_entropy_bonus:0.0056 mlp_aux:-0.0136 mlp_entropy:2.4507 mlp_js:0.0001 mlp_entropy_bonus:0.0056
+step:880/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1991 attn_entropy:1.7233 attn_js:0.3793 mlp_aux:-0.0134 mlp_entropy:2.4502 mlp_js:0.0001
+step:880/20000 attention_head_matrix
+step:880/20000 mlp_expert_matrix
+step:880/20000 train_loss:2.3569 train_time:487130ms step_avg:553.56ms routers_forward:2 attn_aux:-0.1990 attn_entropy:1.7232 attn_js:0.3793 attn_entropy_bonus:0.0054 mlp_aux:-0.0132 mlp_entropy:2.4501 mlp_js:0.0001 mlp_entropy_bonus:0.0054
+step:890/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1988 attn_entropy:1.7232 attn_js:0.3794 mlp_aux:-0.0130 mlp_entropy:2.4495 mlp_js:0.0001
+step:890/20000 attention_head_matrix
+step:890/20000 mlp_expert_matrix
+step:890/20000 train_loss:2.3774 train_time:492624ms step_avg:553.51ms routers_forward:2 attn_aux:-0.1987 attn_entropy:1.7232 attn_js:0.3794 attn_entropy_bonus:0.0052 mlp_aux:-0.0128 mlp_entropy:2.4488 mlp_js:0.0001 mlp_entropy_bonus:0.0052
+step:900/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1986 attn_entropy:1.7232 attn_js:0.3794 mlp_aux:-0.0126 mlp_entropy:2.4493 mlp_js:0.0001
+step:900/20000 attention_head_matrix
+step:900/20000 mlp_expert_matrix
+step:900/20000 train_loss:2.3634 train_time:498129ms step_avg:553.48ms routers_forward:2 attn_aux:-0.1985 attn_entropy:1.7231 attn_js:0.3795 attn_entropy_bonus:0.0051 mlp_aux:-0.0124 mlp_entropy:2.4497 mlp_js:0.0001 mlp_entropy_bonus:0.0051
+step:910/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1984 attn_entropy:1.7231 attn_js:0.3796 mlp_aux:-0.0122 mlp_entropy:2.4490 mlp_js:0.0001
+step:910/20000 attention_head_matrix
+step:910/20000 mlp_expert_matrix
+step:910/20000 train_loss:2.3339 train_time:503633ms step_avg:553.44ms routers_forward:2 attn_aux:-0.1982 attn_entropy:1.7231 attn_js:0.3796 attn_entropy_bonus:0.0049 mlp_aux:-0.0120 mlp_entropy:2.4489 mlp_js:0.0001 mlp_entropy_bonus:0.0049
+step:920/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1981 attn_entropy:1.7231 attn_js:0.3796 mlp_aux:-0.0118 mlp_entropy:2.4486 mlp_js:0.0001
+step:920/20000 attention_head_matrix
+step:920/20000 mlp_expert_matrix
+step:920/20000 train_loss:2.3893 train_time:509135ms step_avg:553.41ms routers_forward:2 attn_aux:-0.1980 attn_entropy:1.7231 attn_js:0.3797 attn_entropy_bonus:0.0047 mlp_aux:-0.0116 mlp_entropy:2.4486 mlp_js:0.0001 mlp_entropy_bonus:0.0047
+step:930/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1979 attn_entropy:1.7231 attn_js:0.3797 mlp_aux:-0.0114 mlp_entropy:2.4484 mlp_js:0.0001
+step:930/20000 attention_head_matrix
+step:930/20000 mlp_expert_matrix
+step:930/20000 train_loss:2.3462 train_time:514636ms step_avg:553.37ms routers_forward:2 attn_aux:-0.1977 attn_entropy:1.7230 attn_js:0.3797 attn_entropy_bonus:0.0046 mlp_aux:-0.0112 mlp_entropy:2.4481 mlp_js:0.0001 mlp_entropy_bonus:0.0046
+step:940/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1976 attn_entropy:1.7230 attn_js:0.3797 mlp_aux:-0.0110 mlp_entropy:2.4484 mlp_js:0.0001
+step:940/20000 attention_head_matrix
+step:940/20000 mlp_expert_matrix
+step:940/20000 train_loss:2.3853 train_time:520129ms step_avg:553.33ms routers_forward:2 attn_aux:-0.1975 attn_entropy:1.7230 attn_js:0.3798 attn_entropy_bonus:0.0044 mlp_aux:-0.0108 mlp_entropy:2.4479 mlp_js:0.0001 mlp_entropy_bonus:0.0044
+step:950/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1973 attn_entropy:1.7230 attn_js:0.3798 mlp_aux:-0.0106 mlp_entropy:2.4477 mlp_js:0.0001
+step:950/20000 attention_head_matrix
+step:950/20000 mlp_expert_matrix
+step:950/20000 train_loss:2.3416 train_time:525627ms step_avg:553.29ms routers_forward:2 attn_aux:-0.1972 attn_entropy:1.7230 attn_js:0.3798 attn_entropy_bonus:0.0042 mlp_aux:-0.0104 mlp_entropy:2.4474 mlp_js:0.0001 mlp_entropy_bonus:0.0042
+step:960/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1971 attn_entropy:1.7230 attn_js:0.3798 mlp_aux:-0.0102 mlp_entropy:2.4474 mlp_js:0.0001
+step:960/20000 attention_head_matrix
+step:960/20000 mlp_expert_matrix
+step:960/20000 train_loss:2.3037 train_time:531328ms step_avg:553.47ms routers_forward:2 attn_aux:-0.1969 attn_entropy:1.7230 attn_js:0.3798 attn_entropy_bonus:0.0041 mlp_aux:-0.0100 mlp_entropy:2.4473 mlp_js:0.0001 mlp_entropy_bonus:0.0041
+step:970/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1968 attn_entropy:1.7230 attn_js:0.3799 mlp_aux:-0.0098 mlp_entropy:2.4471 mlp_js:0.0001
+step:970/20000 attention_head_matrix
+step:970/20000 mlp_expert_matrix
+step:970/20000 train_loss:2.3502 train_time:536823ms step_avg:553.43ms routers_forward:2 attn_aux:-0.1967 attn_entropy:1.7230 attn_js:0.3799 attn_entropy_bonus:0.0039 mlp_aux:-0.0096 mlp_entropy:2.4468 mlp_js:0.0001 mlp_entropy_bonus:0.0039
+step:980/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1965 attn_entropy:1.7230 attn_js:0.3799 mlp_aux:-0.0094 mlp_entropy:2.4466 mlp_js:0.0001
+step:980/20000 attention_head_matrix
+step:980/20000 mlp_expert_matrix
+step:980/20000 train_loss:2.3320 train_time:542312ms step_avg:553.38ms routers_forward:2 attn_aux:-0.1964 attn_entropy:1.7229 attn_js:0.3799 attn_entropy_bonus:0.0037 mlp_aux:-0.0092 mlp_entropy:2.4465 mlp_js:0.0001 mlp_entropy_bonus:0.0037
+step:990/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1963 attn_entropy:1.7229 attn_js:0.3799 mlp_aux:-0.0089 mlp_entropy:2.4465 mlp_js:0.0001
+step:990/20000 attention_head_matrix
+step:990/20000 mlp_expert_matrix
+step:990/20000 train_loss:2.3872 train_time:547805ms step_avg:553.34ms routers_forward:2 attn_aux:-0.1962 attn_entropy:1.7229 attn_js:0.3800 attn_entropy_bonus:0.0036 mlp_aux:-0.0088 mlp_entropy:2.4461 mlp_js:0.0001 mlp_entropy_bonus:0.0036
+step:1000/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1961 attn_entropy:1.7229 attn_js:0.3801 mlp_aux:-0.0085 mlp_entropy:2.4460 mlp_js:0.0001
+step:1000/20000 attention_head_matrix
+step:1000/20000 mlp_expert_matrix
+step:1000/20000 train_loss:2.2412 train_time:553292ms step_avg:553.29ms routers_forward:2 attn_aux:-0.1959 attn_entropy:1.7229 attn_js:0.3801 attn_entropy_bonus:0.0034 mlp_aux:-0.0084 mlp_entropy:2.4461 mlp_js:0.0001 mlp_entropy_bonus:0.0034
+step:1010/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1958 attn_entropy:1.7228 attn_js:0.3801 mlp_aux:-0.0081 mlp_entropy:2.4458 mlp_js:0.0001
+step:1010/20000 attention_head_matrix
+step:1010/20000 mlp_expert_matrix
+step:1010/20000 train_loss:2.3871 train_time:558798ms step_avg:553.27ms routers_forward:2 attn_aux:-0.1957 attn_entropy:1.7228 attn_js:0.3801 attn_entropy_bonus:0.0033 mlp_aux:-0.0080 mlp_entropy:2.4453 mlp_js:0.0001 mlp_entropy_bonus:0.0033
+step:1020/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1955 attn_entropy:1.7228 attn_js:0.3802 mlp_aux:-0.0077 mlp_entropy:2.4458 mlp_js:0.0001
+step:1020/20000 attention_head_matrix
+step:1020/20000 mlp_expert_matrix
+step:1020/20000 train_loss:2.3828 train_time:564298ms step_avg:553.23ms routers_forward:2 attn_aux:-0.1954 attn_entropy:1.7228 attn_js:0.3802 attn_entropy_bonus:0.0031 mlp_aux:-0.0076 mlp_entropy:2.4456 mlp_js:0.0001 mlp_entropy_bonus:0.0031
+step:1030/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1953 attn_entropy:1.7228 attn_js:0.3802 mlp_aux:-0.0073 mlp_entropy:2.4454 mlp_js:0.0001
+step:1030/20000 attention_head_matrix
+step:1030/20000 mlp_expert_matrix
+step:1030/20000 train_loss:2.3344 train_time:569800ms step_avg:553.20ms routers_forward:2 attn_aux:-0.1951 attn_entropy:1.7228 attn_js:0.3802 attn_entropy_bonus:0.0029 mlp_aux:-0.0071 mlp_entropy:2.4457 mlp_js:0.0001 mlp_entropy_bonus:0.0029
+step:1040/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1950 attn_entropy:1.7228 attn_js:0.3802 mlp_aux:-0.0069 mlp_entropy:2.4451 mlp_js:0.0001
+step:1040/20000 attention_head_matrix
+step:1040/20000 mlp_expert_matrix
+step:1040/20000 train_loss:2.3567 train_time:575307ms step_avg:553.18ms routers_forward:2 attn_aux:-0.1949 attn_entropy:1.7228 attn_js:0.3802 attn_entropy_bonus:0.0028 mlp_aux:-0.0067 mlp_entropy:2.4448 mlp_js:0.0001 mlp_entropy_bonus:0.0028
+step:1050/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1947 attn_entropy:1.7228 attn_js:0.3802 mlp_aux:-0.0065 mlp_entropy:2.4448 mlp_js:0.0001
+step:1050/20000 attention_head_matrix
+step:1050/20000 mlp_expert_matrix
+step:1050/20000 train_loss:2.3959 train_time:580807ms step_avg:553.15ms routers_forward:2 attn_aux:-0.1946 attn_entropy:1.7228 attn_js:0.3803 attn_entropy_bonus:0.0026 mlp_aux:-0.0063 mlp_entropy:2.4448 mlp_js:0.0001 mlp_entropy_bonus:0.0026
+step:1060/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1944 attn_entropy:1.7228 attn_js:0.3803 mlp_aux:-0.0061 mlp_entropy:2.4446 mlp_js:0.0001
+step:1060/20000 attention_head_matrix
+step:1060/20000 mlp_expert_matrix
+step:1060/20000 train_loss:2.3403 train_time:586308ms step_avg:553.12ms routers_forward:2 attn_aux:-0.1943 attn_entropy:1.7228 attn_js:0.3803 attn_entropy_bonus:0.0024 mlp_aux:-0.0059 mlp_entropy:2.4446 mlp_js:0.0001 mlp_entropy_bonus:0.0024
+step:1070/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1942 attn_entropy:1.7228 attn_js:0.3803 mlp_aux:-0.0057 mlp_entropy:2.4444 mlp_js:0.0001
+step:1070/20000 attention_head_matrix
+step:1070/20000 mlp_expert_matrix
+step:1070/20000 train_loss:2.3194 train_time:591816ms step_avg:553.10ms routers_forward:2 attn_aux:-0.1940 attn_entropy:1.7228 attn_js:0.3803 attn_entropy_bonus:0.0023 mlp_aux:-0.0055 mlp_entropy:2.4445 mlp_js:0.0001 mlp_entropy_bonus:0.0023
+step:1080/20000 router_probe window_steps:10 avg_depth:8.000 attn_aux:-0.1939 attn_entropy:1.7228 attn_js:0.3803 mlp_aux:-0.0053 mlp_entropy:2.4443 mlp_js:0.0001
+step:1080/20000 attention_head_matrix
+step:1080/20000 mlp_expert_matrix
+step:1080/20000 train_loss:2.3613 train_time:597319ms step_avg:553.07ms routers_forward:2 attn_aux:-0.1937 attn_entropy:1.7228 attn_js:0.3803 attn_entropy_bonus:0.0021 mlp_aux:-0.0051 mlp_entropy:2.4441 mlp_js:0.0001 mlp_entropy_bonus:0.0021
+stopping_early: wallclock_cap train_time:600064ms step:1085/20000
+peak memory allocated: 56915 MiB reserved: 72672 MiB
+ema:applying EMA weights
+Serialized model: 223913189 bytes
+Serialized model int6+zlib: 17024904 bytes
+final_int6_roundtrip val_loss:2.5071 val_bpb:1.4849 eval_time:16158ms
+final_int6_roundtrip_exact val_loss:2.50713751 val_bpb:1.48486805

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_saved_rope_ttt_dashboard_20260429_162729_57cac6b0.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/art_saved_rope_ttt_dashboard_20260429_162729_57cac6b0.stdout.log
@@ -1,0 +1,137 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260429_162729_57cac6b0.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+  art_router_hidden_dim: 64
+  grad_accum_steps: 8
+  quantized_model_path: ckpt/final_model.int6.ptz
+  world_size: 1
+model_params:36143382
+router_params:197190
+triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; fixed triple recurrence activates at ENABLE_LOOPING_AT; routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; route_group_size:1 cycle_penalty:0.001 shard_coherent_batches:0
+warmup_step: 1/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup_step: 1/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/50000 train_loss: 9.0085 train_time: 0.0m step_avg: 577.82ms tok/s: 1361023
+2/50000 train_loss: 12.2490 train_time: 0.0m step_avg: 583.33ms tok/s: 1348175
+3/50000 train_loss: 10.8011 train_time: 0.0m step_avg: 587.10ms tok/s: 1339512
+4/50000 train_loss: 9.2221 train_time: 0.0m step_avg: 588.99ms tok/s: 1335212
+5/50000 train_loss: 8.2198 train_time: 0.0m step_avg: 590.00ms tok/s: 1332932
+10/50000 train_loss: 6.8365 train_time: 0.1m step_avg: 593.24ms tok/s: 1325647
+20/50000 train_loss: 5.9263 train_time: 0.2m step_avg: 595.98ms tok/s: 1319552
+30/50000 train_loss: 5.4731 train_time: 0.3m step_avg: 597.35ms tok/s: 1316529
+40/50000 train_loss: 5.3018 train_time: 0.4m step_avg: 597.59ms tok/s: 1316016
+50/50000 train_loss: 5.1570 train_time: 0.5m step_avg: 597.92ms tok/s: 1315269
+60/50000 train_loss: 5.0203 train_time: 0.6m step_avg: 598.07ms tok/s: 1314956
+70/50000 train_loss: 4.8772 train_time: 0.7m step_avg: 598.32ms tok/s: 1314408
+80/50000 train_loss: 4.7327 train_time: 0.8m step_avg: 598.43ms tok/s: 1314166
+90/50000 train_loss: 4.6182 train_time: 0.9m step_avg: 598.67ms tok/s: 1313622
+100/50000 train_loss: 4.4200 train_time: 1.0m step_avg: 598.69ms tok/s: 1313586
+110/50000 train_loss: 4.2782 train_time: 1.1m step_avg: 598.84ms tok/s: 1313258
+120/50000 train_loss: 4.1695 train_time: 1.2m step_avg: 598.82ms tok/s: 1313295
+130/50000 train_loss: 4.0156 train_time: 1.3m step_avg: 598.90ms tok/s: 1313135
+140/50000 train_loss: 3.9746 train_time: 1.4m step_avg: 598.91ms tok/s: 1313101
+150/50000 train_loss: 3.9226 train_time: 1.5m step_avg: 598.86ms tok/s: 1313220
+160/50000 train_loss: 3.8609 train_time: 1.6m step_avg: 598.88ms tok/s: 1313175
+170/50000 train_loss: 3.7946 train_time: 1.7m step_avg: 598.94ms tok/s: 1313046
+180/50000 train_loss: 3.7565 train_time: 1.8m step_avg: 599.01ms tok/s: 1312888
+190/50000 train_loss: 3.7579 train_time: 1.9m step_avg: 599.09ms tok/s: 1312704
+200/50000 train_loss: 3.7375 train_time: 2.0m step_avg: 599.09ms tok/s: 1312714
+210/50000 train_loss: 3.6517 train_time: 2.1m step_avg: 599.06ms tok/s: 1312785
+220/50000 train_loss: 3.6777 train_time: 2.2m step_avg: 599.09ms tok/s: 1312701
+230/50000 train_loss: 3.6516 train_time: 2.3m step_avg: 599.09ms tok/s: 1312703
+240/50000 train_loss: 3.6286 train_time: 2.4m step_avg: 599.10ms tok/s: 1312700
+250/50000 train_loss: 3.6173 train_time: 2.5m step_avg: 599.15ms tok/s: 1312579
+260/50000 train_loss: 3.5687 train_time: 2.6m step_avg: 599.18ms tok/s: 1312512
+270/50000 train_loss: 3.5644 train_time: 2.7m step_avg: 599.19ms tok/s: 1312484
+280/50000 train_loss: 3.5336 train_time: 2.8m step_avg: 599.21ms tok/s: 1312447
+290/50000 train_loss: 3.5577 train_time: 2.9m step_avg: 599.23ms tok/s: 1312408
+300/50000 train_loss: 3.5312 train_time: 3.0m step_avg: 599.21ms tok/s: 1312438
+310/50000 train_loss: 3.5517 train_time: 3.1m step_avg: 599.23ms tok/s: 1312407
+320/50000 train_loss: 3.5074 train_time: 3.2m step_avg: 599.19ms tok/s: 1312491
+330/50000 train_loss: 3.4631 train_time: 3.3m step_avg: 599.16ms tok/s: 1312567
+340/50000 train_loss: 3.4746 train_time: 3.4m step_avg: 599.14ms tok/s: 1312594
+350/50000 train_loss: 3.4711 train_time: 3.5m step_avg: 599.11ms tok/s: 1312661
+360/50000 train_loss: 3.4275 train_time: 3.7m step_avg: 613.39ms tok/s: 1282106
+370/50000 train_loss: 3.4539 train_time: 3.9m step_avg: 628.57ms tok/s: 1251136
+380/50000 train_loss: 3.4353 train_time: 4.1m step_avg: 642.97ms tok/s: 1223131
+390/50000 train_loss: 3.3942 train_time: 4.3m step_avg: 656.61ms tok/s: 1197724
+400/50000 train_loss: 3.4107 train_time: 4.5m step_avg: 669.58ms tok/s: 1174514
+410/50000 train_loss: 3.3715 train_time: 4.7m step_avg: 681.90ms tok/s: 1153294
+420/50000 train_loss: 3.3935 train_time: 4.9m step_avg: 693.64ms tok/s: 1133769
+430/50000 train_loss: 3.3632 train_time: 5.1m step_avg: 704.83ms tok/s: 1115772
+440/50000 train_loss: 3.3313 train_time: 5.2m step_avg: 715.54ms tok/s: 1099082
+450/50000 train_loss: 3.3113 train_time: 5.4m step_avg: 725.73ms tok/s: 1083645
+460/50000 train_loss: 3.2780 train_time: 5.8m step_avg: 754.88ms tok/s: 1041798 art_cycles:0.914 extra_cycle_frac:0.305 art_continue:cycle1=0.547,cycle2=0.448,cycle3=0.496 art_entropy:1.2389 art_router_loss:-0.0202
+step:460/50000 art_probe window_steps:7 avg_cycles:0.899 extra_cycle_frac:0.300 avg_stop:0.700 router_entropy:1.2320
+470/50000 train_loss: 3.3072 train_time: 6.0m step_avg: 760.84ms tok/s: 1033642 art_cycles:0.758 extra_cycle_frac:0.253 art_continue:cycle1=0.440,cycle2=0.510,cycle3=0.434 art_entropy:1.1492 art_router_loss:-0.0620
+step:470/50000 art_probe window_steps:10 avg_cycles:0.872 extra_cycle_frac:0.291 avg_stop:0.709 router_entropy:1.2042
+480/50000 train_loss: 3.3068 train_time: 6.1m step_avg: 766.36ms tok/s: 1026185 art_cycles:0.880 extra_cycle_frac:0.293 art_continue:cycle1=0.461,cycle2=0.615,cycle3=0.496 art_entropy:1.1880 art_router_loss:-0.0713
+step:480/50000 art_probe window_steps:10 avg_cycles:0.852 extra_cycle_frac:0.284 avg_stop:0.716 router_entropy:1.1730
+490/50000 train_loss: 3.2983 train_time: 6.3m step_avg: 772.09ms tok/s: 1018577 art_cycles:0.992 extra_cycle_frac:0.331 art_continue:cycle1=0.508,cycle2=0.588,cycle3=0.628 art_entropy:1.2429 art_router_loss:-0.0135
+step:490/50000 art_probe window_steps:10 avg_cycles:0.945 extra_cycle_frac:0.315 avg_stop:0.685 router_entropy:1.2277
+500/50000 train_loss: 3.2981 train_time: 6.5m step_avg: 778.19ms tok/s: 1010594 art_cycles:0.927 extra_cycle_frac:0.309 art_continue:cycle1=0.484,cycle2=0.633,cycle3=0.450 art_entropy:1.2184 art_router_loss:-0.0361
+step:500/50000 art_probe window_steps:10 avg_cycles:0.884 extra_cycle_frac:0.295 avg_stop:0.705 router_entropy:1.1977
+510/50000 train_loss: 3.2552 train_time: 6.7m step_avg: 783.29ms tok/s: 1004012 art_cycles:0.872 extra_cycle_frac:0.291 art_continue:cycle1=0.445,cycle2=0.698,cycle3=0.405 art_entropy:1.1761 art_router_loss:-0.0435
+step:510/50000 art_probe window_steps:10 avg_cycles:0.905 extra_cycle_frac:0.302 avg_stop:0.698 router_entropy:1.1937
+520/50000 train_loss: 3.2711 train_time: 6.9m step_avg: 790.72ms tok/s: 994578 art_cycles:0.945 extra_cycle_frac:0.315 art_continue:cycle1=0.487,cycle2=0.642,cycle3=0.471 art_entropy:1.2235 art_router_loss:-0.0619
+step:520/50000 art_probe window_steps:10 avg_cycles:0.846 extra_cycle_frac:0.282 avg_stop:0.718 router_entropy:1.1712
+530/50000 train_loss: 3.2363 train_time: 7.0m step_avg: 794.94ms tok/s: 989296 art_cycles:0.727 extra_cycle_frac:0.242 art_continue:cycle1=0.432,cycle2=0.452,cycle3=0.511 art_entropy:1.1117 art_router_loss:-0.0109
+step:530/50000 art_probe window_steps:10 avg_cycles:0.779 extra_cycle_frac:0.260 avg_stop:0.740 router_entropy:1.1457
+540/50000 train_loss: 3.2704 train_time: 7.2m step_avg: 799.16ms tok/s: 984074 art_cycles:0.661 extra_cycle_frac:0.220 art_continue:cycle1=0.362,cycle2=0.570,cycle3=0.426 art_entropy:1.0581 art_router_loss:-0.0053
+step:540/50000 art_probe window_steps:10 avg_cycles:0.720 extra_cycle_frac:0.240 avg_stop:0.760 router_entropy:1.1080
+550/50000 train_loss: 3.2939 train_time: 7.4m step_avg: 802.84ms tok/s: 979563 art_cycles:0.542 extra_cycle_frac:0.181 art_continue:cycle1=0.346,cycle2=0.458,cycle3=0.254 art_entropy:0.9615 art_router_loss:0.0088
+step:550/50000 art_probe window_steps:10 avg_cycles:0.592 extra_cycle_frac:0.197 avg_stop:0.803 router_entropy:1.0047
+560/50000 train_loss: 3.2511 train_time: 7.5m step_avg: 806.42ms tok/s: 975217 art_cycles:0.680 extra_cycle_frac:0.227 art_continue:cycle1=0.409,cycle2=0.513,cycle3=0.288 art_entropy:1.0609 art_router_loss:0.0097
+step:560/50000 art_probe window_steps:10 avg_cycles:0.602 extra_cycle_frac:0.201 avg_stop:0.799 router_entropy:1.0084
+570/50000 train_loss: 3.2336 train_time: 7.7m step_avg: 810.00ms tok/s: 970902 art_cycles:0.638 extra_cycle_frac:0.213 art_continue:cycle1=0.391,cycle2=0.471,cycle3=0.334 art_entropy:1.0616 art_router_loss:-0.0530
+step:570/50000 art_probe window_steps:10 avg_cycles:0.626 extra_cycle_frac:0.209 avg_stop:0.791 router_entropy:1.0463
+580/50000 train_loss: 3.2058 train_time: 7.9m step_avg: 813.63ms tok/s: 966574 art_cycles:0.690 extra_cycle_frac:0.230 art_continue:cycle1=0.435,cycle2=0.429,cycle3=0.372 art_entropy:1.0913 art_router_loss:-0.0006
+step:580/50000 art_probe window_steps:10 avg_cycles:0.661 extra_cycle_frac:0.220 avg_stop:0.780 router_entropy:1.0654
+590/50000 train_loss: 3.2361 train_time: 8.0m step_avg: 817.92ms tok/s: 961508 art_cycles:0.711 extra_cycle_frac:0.237 art_continue:cycle1=0.404,cycle2=0.575,cycle3=0.330 art_entropy:1.1024 art_router_loss:-0.0335
+step:590/50000 art_probe window_steps:10 avg_cycles:0.664 extra_cycle_frac:0.221 avg_stop:0.779 router_entropy:1.0680
+600/50000 train_loss: 3.2263 train_time: 8.2m step_avg: 821.50ms tok/s: 957315 art_cycles:0.867 extra_cycle_frac:0.289 art_continue:cycle1=0.497,cycle2=0.555,cycle3=0.341 art_entropy:1.2092 art_router_loss:-0.0128
+step:600/50000 art_probe window_steps:10 avg_cycles:0.729 extra_cycle_frac:0.243 avg_stop:0.757 router_entropy:1.1227
+610/50000 train_loss: 3.2184 train_time: 8.4m step_avg: 825.15ms tok/s: 953074 art_cycles:0.732 extra_cycle_frac:0.244 art_continue:cycle1=0.430,cycle2=0.525,cycle3=0.319 art_entropy:1.1387 art_router_loss:0.0270
+step:610/50000 art_probe window_steps:10 avg_cycles:0.801 extra_cycle_frac:0.267 avg_stop:0.733 router_entropy:1.1788
+620/50000 train_loss: 3.2075 train_time: 8.6m step_avg: 828.83ms tok/s: 948844 art_cycles:0.875 extra_cycle_frac:0.292 art_continue:cycle1=0.505,cycle2=0.519,cycle3=0.425 art_entropy:1.2193 art_router_loss:0.0120
+step:620/50000 art_probe window_steps:10 avg_cycles:0.843 extra_cycle_frac:0.281 avg_stop:0.719 router_entropy:1.2019
+630/50000 train_loss: 3.2424 train_time: 8.7m step_avg: 832.35ms tok/s: 944836 art_cycles:0.750 extra_cycle_frac:0.250 art_continue:cycle1=0.430,cycle2=0.519,cycle3=0.436 art_entropy:1.1420 art_router_loss:0.0068
+step:630/50000 art_probe window_steps:10 avg_cycles:0.820 extra_cycle_frac:0.273 avg_stop:0.727 router_entropy:1.1888
+640/50000 train_loss: 3.2099 train_time: 8.9m step_avg: 835.64ms tok/s: 941119 art_cycles:0.836 extra_cycle_frac:0.279 art_continue:cycle1=0.492,cycle2=0.502,cycle3=0.398 art_entropy:1.2002 art_router_loss:-0.0112
+step:640/50000 art_probe window_steps:10 avg_cycles:0.781 extra_cycle_frac:0.260 avg_stop:0.740 router_entropy:1.1651
+650/50000 train_loss: 3.2425 train_time: 9.1m step_avg: 838.82ms tok/s: 937545 art_cycles:0.797 extra_cycle_frac:0.266 art_continue:cycle1=0.466,cycle2=0.521,cycle3=0.359 art_entropy:1.1779 art_router_loss:-0.0485
+step:650/50000 art_probe window_steps:10 avg_cycles:0.802 extra_cycle_frac:0.267 avg_stop:0.733 router_entropy:1.1715
+660/50000 train_loss: 3.1968 train_time: 9.3m step_avg: 841.91ms tok/s: 934105 art_cycles:0.833 extra_cycle_frac:0.278 art_continue:cycle1=0.453,cycle2=0.566,cycle3=0.481 art_entropy:1.1767 art_router_loss:-0.0158
+step:660/50000 art_probe window_steps:10 avg_cycles:0.776 extra_cycle_frac:0.259 avg_stop:0.741 router_entropy:1.1509
+670/50000 train_loss: 3.2005 train_time: 9.4m step_avg: 844.82ms tok/s: 930890 art_cycles:0.760 extra_cycle_frac:0.253 art_continue:cycle1=0.443,cycle2=0.536,cycle3=0.345 art_entropy:1.1512 art_router_loss:-0.0368
+step:670/50000 art_probe window_steps:10 avg_cycles:0.758 extra_cycle_frac:0.253 avg_stop:0.747 router_entropy:1.1445
+680/50000 train_loss: 3.1990 train_time: 9.6m step_avg: 847.46ms tok/s: 927985 art_cycles:0.729 extra_cycle_frac:0.243 art_continue:cycle1=0.417,cycle2=0.532,cycle3=0.465 art_entropy:1.1119 art_router_loss:-0.0355
+step:680/50000 art_probe window_steps:10 avg_cycles:0.719 extra_cycle_frac:0.240 avg_stop:0.760 router_entropy:1.1127
+690/50000 train_loss: 3.1914 train_time: 9.8m step_avg: 850.07ms tok/s: 925133 art_cycles:0.742 extra_cycle_frac:0.247 art_continue:cycle1=0.409,cycle2=0.567,cycle3=0.439 art_entropy:1.1160 art_router_loss:0.0009
+step:690/50000 art_probe window_steps:10 avg_cycles:0.707 extra_cycle_frac:0.236 avg_stop:0.764 router_entropy:1.1078
+700/50000 train_loss: 3.1801 train_time: 9.9m step_avg: 852.51ms tok/s: 922485 art_cycles:0.760 extra_cycle_frac:0.253 art_continue:cycle1=0.419,cycle2=0.601,cycle3=0.338 art_entropy:1.1351 art_router_loss:-0.0276
+step:700/50000 art_probe window_steps:10 avg_cycles:0.706 extra_cycle_frac:0.235 avg_stop:0.765 router_entropy:1.1042
+704/50000 val_loss: 3.1946 val_bpb: 1.2367
+stopping_early: wallclock_cap train_time: 600809ms step: 704/50000
+peak memory allocated: 39313 MiB reserved: 50120 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:3.23521523 val_bpb:1.25245263 eval_time:20833ms
+pre-quantization post-ema_art_routes avg_cycles:0.797 extra_cycle_frac:0.266 art_entropy:1.1638 art_continue:cycle1=0.455,cycle2=0.502,cycle3=0.484
+Serialized model: 136234857 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:calibration path fixed_full
+GPTQ:collected 67 Hessians in 13.5s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): art_router.fc.bias, art_router.fc.weight, art_router.proj.bias, art_router.proj.weight, art_router_early.fc.bias, art_router_early.fc.weight, art_router_early.proj.bias, art_router_early.proj.weight, art_router_first.fc.bias, art_router_first.fc.weight, art_router_first.proj.bias, art_router_first.proj.weight, blocks.attn.attn_out_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, embed_scale, skip_gates, skip_weights
+Serialized model quantized+brotli: 16333783 bytes
+quantized val_loss:3.25285338 val_bpb:1.25928091 eval_time:39435ms
+quantized_art_routes avg_cycles:0.791 extra_cycle_frac:0.264 art_entropy:1.1642 art_continue:cycle1=0.455,cycle2=0.505,cycle3=0.455
+ttt:start chunks=619 windows=633409 ttt_lr=0.005 ttt_epochs=4
+quantized_ttt val_loss:3.20652665 val_bpb:1.24134639 eval_time:1791370ms

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1812_art_dashboard_20260429_224456_a9eaabed.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1812_art_dashboard_20260429_224456_a9eaabed.stdout.log
@@ -1,0 +1,572 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260429_224456_a9eaabed.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+  art_router_hidden_dim: 64
+  grad_accum_steps: 1
+  quantized_model_path: ckpt/final_model.int6.ptz
+  world_size: 8
+model_params:36143382
+router_params:197190
+triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; fixed triple recurrence activates at ENABLE_LOOPING_AT; routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; route_group_size:1 cycle_penalty:0.001 shard_coherent_batches:0
+warmup_step: 1/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup_step: 1/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/50000 train_loss: 9.0120 train_time: 0.0m step_avg: 199.82ms tok/s: 2623780
+2/50000 train_loss: 12.2645 train_time: 0.0m step_avg: 189.00ms tok/s: 2774039
+3/50000 train_loss: 10.9784 train_time: 0.0m step_avg: 185.56ms tok/s: 2825476
+4/50000 train_loss: 9.4945 train_time: 0.0m step_avg: 183.96ms tok/s: 2850044
+5/50000 train_loss: 8.3930 train_time: 0.0m step_avg: 182.06ms tok/s: 2879789
+10/50000 train_loss: 6.8276 train_time: 0.0m step_avg: 179.34ms tok/s: 2923447
+20/50000 train_loss: 5.9755 train_time: 0.1m step_avg: 179.68ms tok/s: 2917880
+30/50000 train_loss: 5.5393 train_time: 0.1m step_avg: 179.34ms tok/s: 2923405
+40/50000 train_loss: 5.3160 train_time: 0.1m step_avg: 179.70ms tok/s: 2917644
+50/50000 train_loss: 5.2275 train_time: 0.1m step_avg: 179.94ms tok/s: 2913651
+60/50000 train_loss: 5.0724 train_time: 0.2m step_avg: 175.83ms tok/s: 2981795
+70/50000 train_loss: 4.9274 train_time: 0.2m step_avg: 168.91ms tok/s: 3103911
+80/50000 train_loss: 4.8404 train_time: 0.2m step_avg: 163.71ms tok/s: 3202551
+90/50000 train_loss: 4.6629 train_time: 0.2m step_avg: 159.69ms tok/s: 3283261
+100/50000 train_loss: 4.5540 train_time: 0.3m step_avg: 156.45ms tok/s: 3351172
+110/50000 train_loss: 4.3768 train_time: 0.3m step_avg: 153.81ms tok/s: 3408730
+120/50000 train_loss: 4.2180 train_time: 0.3m step_avg: 151.60ms tok/s: 3458333
+130/50000 train_loss: 4.0632 train_time: 0.3m step_avg: 149.75ms tok/s: 3501085
+140/50000 train_loss: 3.9523 train_time: 0.3m step_avg: 148.15ms tok/s: 3538826
+150/50000 train_loss: 4.0226 train_time: 0.4m step_avg: 146.76ms tok/s: 3572408
+160/50000 train_loss: 3.9005 train_time: 0.4m step_avg: 145.54ms tok/s: 3602292
+170/50000 train_loss: 3.8381 train_time: 0.4m step_avg: 144.52ms tok/s: 3627786
+180/50000 train_loss: 3.8071 train_time: 0.4m step_avg: 145.77ms tok/s: 3596602
+190/50000 train_loss: 3.8092 train_time: 0.5m step_avg: 144.80ms tok/s: 3620704
+200/50000 train_loss: 3.7941 train_time: 0.5m step_avg: 143.93ms tok/s: 3642566
+210/50000 train_loss: 3.8155 train_time: 0.5m step_avg: 143.14ms tok/s: 3662688
+220/50000 train_loss: 3.8521 train_time: 0.5m step_avg: 142.42ms tok/s: 3681358
+230/50000 train_loss: 3.8877 train_time: 0.5m step_avg: 141.76ms tok/s: 3698397
+240/50000 train_loss: 3.6749 train_time: 0.6m step_avg: 141.16ms tok/s: 3714216
+250/50000 train_loss: 3.6689 train_time: 0.6m step_avg: 140.60ms tok/s: 3728808
+260/50000 train_loss: 3.6336 train_time: 0.6m step_avg: 140.09ms tok/s: 3742421
+270/50000 train_loss: 3.5612 train_time: 0.6m step_avg: 139.62ms tok/s: 3755131
+280/50000 train_loss: 3.5926 train_time: 0.6m step_avg: 139.18ms tok/s: 3767023
+290/50000 train_loss: 3.5586 train_time: 0.7m step_avg: 138.77ms tok/s: 3778137
+300/50000 train_loss: 3.6417 train_time: 0.7m step_avg: 138.39ms tok/s: 3788604
+310/50000 train_loss: 3.6689 train_time: 0.7m step_avg: 138.03ms tok/s: 3798393
+320/50000 train_loss: 3.5840 train_time: 0.7m step_avg: 137.69ms tok/s: 3807630
+330/50000 train_loss: 3.5850 train_time: 0.8m step_avg: 137.38ms tok/s: 3816391
+340/50000 train_loss: 3.5185 train_time: 0.8m step_avg: 137.08ms tok/s: 3824618
+350/50000 train_loss: 3.4625 train_time: 0.8m step_avg: 136.80ms tok/s: 3832425
+360/50000 train_loss: 3.5721 train_time: 0.8m step_avg: 136.54ms tok/s: 3839837
+370/50000 train_loss: 3.4514 train_time: 0.8m step_avg: 136.29ms tok/s: 3846828
+380/50000 train_loss: 3.4734 train_time: 0.9m step_avg: 136.05ms tok/s: 3853663
+390/50000 train_loss: 3.5568 train_time: 0.9m step_avg: 135.82ms tok/s: 3860049
+400/50000 train_loss: 3.5357 train_time: 0.9m step_avg: 135.61ms tok/s: 3866125
+410/50000 train_loss: 3.5032 train_time: 0.9m step_avg: 135.41ms tok/s: 3871966
+420/50000 train_loss: 3.4605 train_time: 0.9m step_avg: 135.21ms tok/s: 3877513
+430/50000 train_loss: 3.5453 train_time: 1.0m step_avg: 135.03ms tok/s: 3882867
+440/50000 train_loss: 3.4185 train_time: 1.0m step_avg: 134.85ms tok/s: 3888003
+450/50000 train_loss: 3.4753 train_time: 1.0m step_avg: 134.68ms tok/s: 3892844
+460/50000 train_loss: 3.3937 train_time: 1.0m step_avg: 134.62ms tok/s: 3894531
+470/50000 train_loss: 3.3813 train_time: 1.0m step_avg: 133.01ms tok/s: 3941602
+480/50000 train_loss: 3.4115 train_time: 1.1m step_avg: 131.39ms tok/s: 3990433
+490/50000 train_loss: 3.4762 train_time: 1.1m step_avg: 129.82ms tok/s: 4038476
+500/50000 train_loss: 3.3313 train_time: 1.1m step_avg: 128.32ms tok/s: 4085707
+510/50000 train_loss: 3.4035 train_time: 1.1m step_avg: 126.88ms tok/s: 4132184
+520/50000 train_loss: 3.4135 train_time: 1.1m step_avg: 125.50ms tok/s: 4177753
+530/50000 train_loss: 3.4418 train_time: 1.1m step_avg: 124.16ms tok/s: 4222679
+540/50000 train_loss: 3.4138 train_time: 1.1m step_avg: 122.88ms tok/s: 4266827
+550/50000 train_loss: 3.4081 train_time: 1.1m step_avg: 121.64ms tok/s: 4310301
+560/50000 train_loss: 3.3285 train_time: 1.1m step_avg: 120.44ms tok/s: 4352998
+570/50000 train_loss: 3.3525 train_time: 1.1m step_avg: 119.29ms tok/s: 4395007
+580/50000 train_loss: 3.3074 train_time: 1.1m step_avg: 118.18ms tok/s: 4436336
+590/50000 train_loss: 3.3449 train_time: 1.2m step_avg: 117.11ms tok/s: 4476887
+600/50000 train_loss: 3.5170 train_time: 1.2m step_avg: 116.08ms tok/s: 4516753
+610/50000 train_loss: 3.4100 train_time: 1.2m step_avg: 115.08ms tok/s: 4555940
+620/50000 train_loss: 3.3271 train_time: 1.2m step_avg: 114.11ms tok/s: 4594507
+630/50000 train_loss: 3.3052 train_time: 1.2m step_avg: 113.17ms tok/s: 4632770
+640/50000 train_loss: 3.4417 train_time: 1.2m step_avg: 112.26ms tok/s: 4670375
+650/50000 train_loss: 3.4379 train_time: 1.2m step_avg: 111.38ms tok/s: 4707410
+660/50000 train_loss: 3.3572 train_time: 1.2m step_avg: 110.52ms tok/s: 4743868
+670/50000 train_loss: 3.3818 train_time: 1.2m step_avg: 109.69ms tok/s: 4779821
+680/50000 train_loss: 3.3352 train_time: 1.2m step_avg: 108.88ms tok/s: 4815202
+690/50000 train_loss: 3.3678 train_time: 1.2m step_avg: 108.10ms tok/s: 4849959
+700/50000 train_loss: 3.3107 train_time: 1.3m step_avg: 107.34ms tok/s: 4884338
+710/50000 train_loss: 3.3975 train_time: 1.3m step_avg: 106.60ms tok/s: 4918097
+720/50000 train_loss: 3.3710 train_time: 1.3m step_avg: 105.89ms tok/s: 4951444
+730/50000 train_loss: 3.3375 train_time: 1.3m step_avg: 105.19ms tok/s: 4984330
+740/50000 train_loss: 3.4678 train_time: 1.3m step_avg: 104.51ms tok/s: 5016771
+750/50000 train_loss: 3.3702 train_time: 1.3m step_avg: 103.84ms tok/s: 5048774
+760/50000 train_loss: 3.3200 train_time: 1.3m step_avg: 103.20ms tok/s: 5080074
+770/50000 train_loss: 3.3775 train_time: 1.3m step_avg: 102.58ms tok/s: 5111184
+780/50000 train_loss: 3.3628 train_time: 1.3m step_avg: 101.97ms tok/s: 5141834
+790/50000 train_loss: 3.3924 train_time: 1.3m step_avg: 101.37ms tok/s: 5172024
+800/50000 train_loss: 3.3143 train_time: 1.3m step_avg: 100.79ms tok/s: 5201805
+810/50000 train_loss: 3.3628 train_time: 1.4m step_avg: 100.22ms tok/s: 5231197
+820/50000 train_loss: 3.3491 train_time: 1.4m step_avg: 99.67ms tok/s: 5260222
+830/50000 train_loss: 3.3614 train_time: 1.4m step_avg: 99.13ms tok/s: 5288814
+840/50000 train_loss: 3.3515 train_time: 1.4m step_avg: 98.60ms tok/s: 5317061
+850/50000 train_loss: 3.3212 train_time: 1.4m step_avg: 98.09ms tok/s: 5344883
+860/50000 train_loss: 3.3929 train_time: 1.4m step_avg: 97.59ms tok/s: 5372230
+870/50000 train_loss: 3.3555 train_time: 1.4m step_avg: 97.10ms tok/s: 5399312
+880/50000 train_loss: 3.3382 train_time: 1.4m step_avg: 96.62ms tok/s: 5426082
+890/50000 train_loss: 3.3052 train_time: 1.4m step_avg: 96.16ms tok/s: 5452501
+900/50000 train_loss: 3.4274 train_time: 1.4m step_avg: 95.70ms tok/s: 5478551
+910/50000 train_loss: 3.4128 train_time: 1.4m step_avg: 95.25ms tok/s: 5504233
+920/50000 train_loss: 3.3587 train_time: 1.5m step_avg: 94.81ms tok/s: 5529672
+930/50000 train_loss: 3.3644 train_time: 1.5m step_avg: 94.39ms tok/s: 5554708
+940/50000 train_loss: 3.3149 train_time: 1.5m step_avg: 93.97ms tok/s: 5579451
+950/50000 train_loss: 3.4109 train_time: 1.5m step_avg: 93.56ms tok/s: 5603899
+960/50000 train_loss: 3.3223 train_time: 1.5m step_avg: 93.16ms tok/s: 5628071
+970/50000 train_loss: 3.3200 train_time: 1.5m step_avg: 92.77ms tok/s: 5651675
+980/50000 train_loss: 3.4820 train_time: 1.5m step_avg: 92.88ms tok/s: 5644593
+990/50000 train_loss: 3.3124 train_time: 1.5m step_avg: 93.00ms tok/s: 5637654
+1000/50000 train_loss: 3.3263 train_time: 1.6m step_avg: 93.12ms tok/s: 5630127
+1010/50000 train_loss: 3.2946 train_time: 1.6m step_avg: 93.25ms tok/s: 5622118
+1020/50000 train_loss: 3.3512 train_time: 1.6m step_avg: 93.36ms tok/s: 5615584
+1030/50000 train_loss: 3.3527 train_time: 1.6m step_avg: 93.47ms tok/s: 5609249
+1040/50000 train_loss: 3.4222 train_time: 1.6m step_avg: 93.57ms tok/s: 5603019
+1050/50000 train_loss: 3.3577 train_time: 1.6m step_avg: 93.68ms tok/s: 5596831
+1060/50000 train_loss: 3.2541 train_time: 1.7m step_avg: 93.78ms tok/s: 5590786
+1070/50000 train_loss: 3.3003 train_time: 1.7m step_avg: 93.88ms tok/s: 5584912
+1080/50000 train_loss: 3.3542 train_time: 1.7m step_avg: 93.97ms tok/s: 5579120
+1090/50000 train_loss: 3.2744 train_time: 1.7m step_avg: 94.07ms tok/s: 5573510
+1100/50000 train_loss: 3.3070 train_time: 1.7m step_avg: 94.16ms tok/s: 5567962
+1110/50000 train_loss: 3.3448 train_time: 1.7m step_avg: 94.25ms tok/s: 5562453
+1120/50000 train_loss: 3.3131 train_time: 1.8m step_avg: 94.35ms tok/s: 5557038
+1130/50000 train_loss: 3.3947 train_time: 1.8m step_avg: 94.44ms tok/s: 5551732
+1140/50000 train_loss: 3.3820 train_time: 1.8m step_avg: 94.53ms tok/s: 5546544
+1150/50000 train_loss: 3.2839 train_time: 1.8m step_avg: 94.61ms tok/s: 5541340
+1160/50000 train_loss: 3.4072 train_time: 1.8m step_avg: 94.70ms tok/s: 5536434
+1170/50000 train_loss: 3.3277 train_time: 1.8m step_avg: 94.78ms tok/s: 5531505
+1180/50000 train_loss: 3.4197 train_time: 1.9m step_avg: 94.87ms tok/s: 5526672
+1190/50000 train_loss: 3.3011 train_time: 1.9m step_avg: 94.95ms tok/s: 5521833
+1200/50000 train_loss: 3.2971 train_time: 1.9m step_avg: 95.03ms tok/s: 5517284
+1210/50000 train_loss: 3.2722 train_time: 1.9m step_avg: 95.10ms tok/s: 5512803
+1220/50000 train_loss: 3.3501 train_time: 1.9m step_avg: 95.18ms tok/s: 5508420
+1230/50000 train_loss: 3.2649 train_time: 2.0m step_avg: 95.25ms tok/s: 5504081
+1240/50000 train_loss: 3.3523 train_time: 2.0m step_avg: 95.33ms tok/s: 5499813
+1250/50000 train_loss: 3.2982 train_time: 2.0m step_avg: 95.40ms tok/s: 5495707
+1260/50000 train_loss: 3.3300 train_time: 2.0m step_avg: 95.47ms tok/s: 5491639
+1270/50000 train_loss: 3.2636 train_time: 2.0m step_avg: 95.54ms tok/s: 5487437
+1280/50000 train_loss: 3.2902 train_time: 2.0m step_avg: 95.61ms tok/s: 5483479
+1290/50000 train_loss: 3.2915 train_time: 2.1m step_avg: 95.68ms tok/s: 5479384
+1300/50000 train_loss: 3.3126 train_time: 2.1m step_avg: 95.75ms tok/s: 5475576
+1310/50000 train_loss: 3.2697 train_time: 2.1m step_avg: 95.82ms tok/s: 5471803
+1320/50000 train_loss: 3.2596 train_time: 2.1m step_avg: 95.88ms tok/s: 5468106
+1330/50000 train_loss: 3.3024 train_time: 2.1m step_avg: 95.95ms tok/s: 5464355
+1340/50000 train_loss: 3.2106 train_time: 2.1m step_avg: 96.01ms tok/s: 5460823
+1350/50000 train_loss: 3.2669 train_time: 2.2m step_avg: 96.07ms tok/s: 5457270
+1360/50000 train_loss: 3.1970 train_time: 2.2m step_avg: 96.13ms tok/s: 5453793
+1370/50000 train_loss: 3.2143 train_time: 2.2m step_avg: 96.19ms tok/s: 5450331
+1380/50000 train_loss: 3.3141 train_time: 2.2m step_avg: 96.25ms tok/s: 5447025
+1390/50000 train_loss: 3.1729 train_time: 2.2m step_avg: 96.31ms tok/s: 5443737
+1400/50000 train_loss: 3.3095 train_time: 2.2m step_avg: 96.37ms tok/s: 5440411
+1410/50000 train_loss: 3.1844 train_time: 2.3m step_avg: 96.43ms tok/s: 5437230
+1420/50000 train_loss: 3.2588 train_time: 2.3m step_avg: 96.48ms tok/s: 5434024
+1430/50000 train_loss: 3.2521 train_time: 2.3m step_avg: 96.54ms tok/s: 5430897
+1440/50000 train_loss: 3.2673 train_time: 2.3m step_avg: 96.59ms tok/s: 5427827
+1450/50000 train_loss: 3.2444 train_time: 2.3m step_avg: 96.65ms tok/s: 5424809
+1460/50000 train_loss: 3.3236 train_time: 2.4m step_avg: 96.70ms tok/s: 5421861
+1470/50000 train_loss: 3.2485 train_time: 2.4m step_avg: 96.75ms tok/s: 5418932
+1480/50000 train_loss: 3.2456 train_time: 2.4m step_avg: 96.80ms tok/s: 5416106
+1490/50000 train_loss: 3.2281 train_time: 2.4m step_avg: 96.85ms tok/s: 5413338
+1500/50000 train_loss: 3.2546 train_time: 2.4m step_avg: 96.90ms tok/s: 5410570
+1510/50000 train_loss: 3.2561 train_time: 2.4m step_avg: 96.95ms tok/s: 5407873
+1520/50000 train_loss: 3.3132 train_time: 2.5m step_avg: 97.00ms tok/s: 5405088
+1530/50000 train_loss: 3.1572 train_time: 2.5m step_avg: 97.05ms tok/s: 5402413
+1540/50000 train_loss: 3.1527 train_time: 2.5m step_avg: 97.09ms tok/s: 5399766
+1550/50000 train_loss: 3.2827 train_time: 2.5m step_avg: 97.14ms tok/s: 5397175
+1560/50000 train_loss: 3.3338 train_time: 2.5m step_avg: 97.19ms tok/s: 5394612
+1570/50000 train_loss: 3.2129 train_time: 2.5m step_avg: 97.23ms tok/s: 5392140
+1580/50000 train_loss: 3.2565 train_time: 2.6m step_avg: 97.28ms tok/s: 5389677
+1590/50000 train_loss: 3.2806 train_time: 2.6m step_avg: 97.32ms tok/s: 5387214
+1600/50000 train_loss: 3.2039 train_time: 2.6m step_avg: 97.36ms tok/s: 5384778
+1610/50000 train_loss: 3.2267 train_time: 2.6m step_avg: 97.41ms tok/s: 5382380
+1620/50000 train_loss: 3.2918 train_time: 2.6m step_avg: 97.45ms tok/s: 5380110
+1630/50000 train_loss: 3.1842 train_time: 2.6m step_avg: 97.49ms tok/s: 5377798
+1640/50000 train_loss: 3.3751 train_time: 2.7m step_avg: 97.89ms tok/s: 5355686
+1650/50000 train_loss: 3.3213 train_time: 2.7m step_avg: 97.93ms tok/s: 5353597
+1660/50000 train_loss: 3.2011 train_time: 2.7m step_avg: 97.97ms tok/s: 5351545
+1670/50000 train_loss: 3.2485 train_time: 2.7m step_avg: 98.01ms tok/s: 5349498
+1680/50000 train_loss: 3.2363 train_time: 2.7m step_avg: 98.04ms tok/s: 5347503
+1690/50000 train_loss: 3.1129 train_time: 2.8m step_avg: 98.08ms tok/s: 5345530
+1700/50000 train_loss: 3.2590 train_time: 2.8m step_avg: 98.12ms tok/s: 5343559
+1710/50000 train_loss: 3.2794 train_time: 2.8m step_avg: 98.51ms tok/s: 5322404
+1720/50000 train_loss: 3.3057 train_time: 2.8m step_avg: 98.86ms tok/s: 5303258
+1730/50000 train_loss: 3.2900 train_time: 2.9m step_avg: 99.21ms tok/s: 5284463
+1740/50000 train_loss: 3.1283 train_time: 2.9m step_avg: 99.24ms tok/s: 5282842
+1750/50000 train_loss: 3.1606 train_time: 2.9m step_avg: 99.27ms tok/s: 5281273
+1760/50000 train_loss: 3.2814 train_time: 2.9m step_avg: 99.30ms tok/s: 5279736
+1770/50000 train_loss: 3.1154 train_time: 2.9m step_avg: 99.33ms tok/s: 5278318
+1780/50000 train_loss: 3.2070 train_time: 2.9m step_avg: 99.36ms tok/s: 5276862
+1790/50000 train_loss: 3.1271 train_time: 3.0m step_avg: 99.38ms tok/s: 5275442
+1800/50000 train_loss: 3.2046 train_time: 3.0m step_avg: 99.41ms tok/s: 5274080
+1810/50000 train_loss: 3.3587 train_time: 3.0m step_avg: 100.13ms tok/s: 5236289 art_cycles:0.973 extra_cycle_frac:0.324 art_continue:cycle1=0.531,cycle2=0.537,cycle3=0.549 art_entropy:1.2357 art_router_loss:-0.0007
+step:1810/50000 art_probe window_steps:2 avg_cycles:0.861 extra_cycle_frac:0.287 avg_stop:0.713 router_entropy:1.2027
+1820/50000 train_loss: 3.3088 train_time: 3.1m step_avg: 101.01ms tok/s: 5190292 art_cycles:2.438 extra_cycle_frac:0.813 art_continue:cycle1=1.000,cycle2=0.996,cycle3=0.443 art_entropy:0.7443 art_router_loss:-0.0122
+step:1820/50000 art_probe window_steps:10 avg_cycles:2.123 extra_cycle_frac:0.708 avg_stop:0.292 router_entropy:1.0194
+1830/50000 train_loss: 3.1857 train_time: 3.1m step_avg: 101.92ms tok/s: 5144103 art_cycles:2.281 extra_cycle_frac:0.760 art_continue:cycle1=1.000,cycle2=0.781,cycle3=0.640 art_entropy:0.9581 art_router_loss:-0.0529
+step:1830/50000 art_probe window_steps:10 avg_cycles:2.342 extra_cycle_frac:0.781 avg_stop:0.219 router_entropy:0.8319
+1840/50000 train_loss: 3.2423 train_time: 3.1m step_avg: 102.71ms tok/s: 5104657 art_cycles:1.836 extra_cycle_frac:0.612 art_continue:cycle1=1.000,cycle2=0.590,cycle3=0.417 art_entropy:1.0910 art_router_loss:-0.0465
+step:1840/50000 art_probe window_steps:10 avg_cycles:1.907 extra_cycle_frac:0.636 avg_stop:0.364 router_entropy:1.0707
+1850/50000 train_loss: 3.2166 train_time: 3.2m step_avg: 103.45ms tok/s: 5067844 art_cycles:1.758 extra_cycle_frac:0.586 art_continue:cycle1=1.000,cycle2=0.520,cycle3=0.458 art_entropy:1.0435 art_router_loss:-0.0265
+step:1850/50000 art_probe window_steps:10 avg_cycles:1.782 extra_cycle_frac:0.594 avg_stop:0.406 router_entropy:1.0295
+1860/50000 train_loss: 3.1739 train_time: 3.2m step_avg: 104.18ms tok/s: 5032541 art_cycles:1.820 extra_cycle_frac:0.607 art_continue:cycle1=1.000,cycle2=0.520,cycle3=0.579 art_entropy:1.0510 art_router_loss:-0.0197
+step:1860/50000 art_probe window_steps:10 avg_cycles:1.757 extra_cycle_frac:0.586 avg_stop:0.414 router_entropy:1.0448
+1870/50000 train_loss: 3.2035 train_time: 3.3m step_avg: 104.92ms tok/s: 4996980 art_cycles:1.914 extra_cycle_frac:0.638 art_continue:cycle1=1.000,cycle2=0.582,cycle3=0.570 art_entropy:1.0717 art_router_loss:-0.0351
+step:1870/50000 art_probe window_steps:10 avg_cycles:1.843 extra_cycle_frac:0.614 avg_stop:0.386 router_entropy:1.0647
+1880/50000 train_loss: 3.1784 train_time: 3.3m step_avg: 105.68ms tok/s: 4960884 art_cycles:1.754 extra_cycle_frac:0.585 art_continue:cycle1=1.000,cycle2=0.566,cycle3=0.331 art_entropy:1.0467 art_router_loss:-0.0287
+step:1880/50000 art_probe window_steps:10 avg_cycles:1.963 extra_cycle_frac:0.654 avg_stop:0.346 router_entropy:1.1112
+1890/50000 train_loss: 3.2950 train_time: 3.4m step_avg: 106.47ms tok/s: 4924479 art_cycles:2.043 extra_cycle_frac:0.681 art_continue:cycle1=1.000,cycle2=0.672,cycle3=0.552 art_entropy:0.9693 art_router_loss:-0.0267
+step:1890/50000 art_probe window_steps:10 avg_cycles:2.030 extra_cycle_frac:0.677 avg_stop:0.323 router_entropy:1.0751
+1900/50000 train_loss: 3.2069 train_time: 3.4m step_avg: 107.29ms tok/s: 4886493 art_cycles:2.359 extra_cycle_frac:0.786 art_continue:cycle1=1.000,cycle2=0.852,cycle3=0.596 art_entropy:1.0270 art_router_loss:-0.0590
+step:1900/50000 art_probe window_steps:10 avg_cycles:2.265 extra_cycle_frac:0.755 avg_stop:0.245 router_entropy:1.0210
+1910/50000 train_loss: 3.2115 train_time: 3.4m step_avg: 108.09ms tok/s: 4850589 art_cycles:1.871 extra_cycle_frac:0.624 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.466 art_entropy:1.0734 art_router_loss:-0.0345
+step:1910/50000 art_probe window_steps:10 avg_cycles:2.068 extra_cycle_frac:0.689 avg_stop:0.311 router_entropy:1.0603
+1920/50000 train_loss: 3.2652 train_time: 3.5m step_avg: 108.85ms tok/s: 4816556 art_cycles:2.004 extra_cycle_frac:0.668 art_continue:cycle1=1.000,cycle2=0.621,cycle3=0.617 art_entropy:1.0297 art_router_loss:-0.0217
+step:1920/50000 art_probe window_steps:10 avg_cycles:2.025 extra_cycle_frac:0.675 avg_stop:0.325 router_entropy:1.0948
+1930/50000 train_loss: 3.1351 train_time: 3.5m step_avg: 109.61ms tok/s: 4783390 art_cycles:2.172 extra_cycle_frac:0.724 art_continue:cycle1=1.000,cycle2=0.680,cycle3=0.724 art_entropy:1.0919 art_router_loss:-0.0443
+step:1930/50000 art_probe window_steps:10 avg_cycles:2.078 extra_cycle_frac:0.693 avg_stop:0.307 router_entropy:1.0973
+1940/50000 train_loss: 3.2341 train_time: 3.6m step_avg: 110.32ms tok/s: 4752547 art_cycles:1.832 extra_cycle_frac:0.611 art_continue:cycle1=1.000,cycle2=0.602,cycle3=0.383 art_entropy:1.1009 art_router_loss:-0.0230
+step:1940/50000 art_probe window_steps:10 avg_cycles:1.938 extra_cycle_frac:0.646 avg_stop:0.354 router_entropy:1.0868
+1950/50000 train_loss: 3.2869 train_time: 3.6m step_avg: 110.98ms tok/s: 4724368 art_cycles:2.000 extra_cycle_frac:0.667 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.455 art_entropy:1.1680 art_router_loss:-0.0220
+step:1950/50000 art_probe window_steps:10 avg_cycles:1.762 extra_cycle_frac:0.588 avg_stop:0.412 router_entropy:1.0346
+1960/50000 train_loss: 3.1139 train_time: 3.6m step_avg: 111.63ms tok/s: 4696653 art_cycles:1.816 extra_cycle_frac:0.605 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.537 art_entropy:1.0609 art_router_loss:-0.0264
+step:1960/50000 art_probe window_steps:10 avg_cycles:1.774 extra_cycle_frac:0.591 avg_stop:0.409 router_entropy:1.0425
+1970/50000 train_loss: 3.1050 train_time: 3.7m step_avg: 112.27ms tok/s: 4669989 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.471 art_entropy:1.0599 art_router_loss:-0.0453
+step:1970/50000 art_probe window_steps:10 avg_cycles:1.733 extra_cycle_frac:0.578 avg_stop:0.422 router_entropy:1.0191
+1980/50000 train_loss: 3.1172 train_time: 3.7m step_avg: 112.90ms tok/s: 4643687 art_cycles:1.562 extra_cycle_frac:0.521 art_continue:cycle1=1.000,cycle2=0.375,cycle3=0.500 art_entropy:0.9518 art_router_loss:-0.0064
+step:1980/50000 art_probe window_steps:10 avg_cycles:1.750 extra_cycle_frac:0.583 avg_stop:0.417 router_entropy:1.0285
+1990/50000 train_loss: 3.1562 train_time: 3.8m step_avg: 113.53ms tok/s: 4618065 art_cycles:1.898 extra_cycle_frac:0.633 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.513 art_entropy:1.0993 art_router_loss:-0.0218
+step:1990/50000 art_probe window_steps:10 avg_cycles:1.739 extra_cycle_frac:0.580 avg_stop:0.420 router_entropy:1.0347
+2000/50000 train_loss: 3.1885 train_time: 3.8m step_avg: 114.15ms tok/s: 4593032 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.368 art_entropy:1.1015 art_router_loss:-0.0418
+step:2000/50000 art_probe window_steps:10 avg_cycles:1.739 extra_cycle_frac:0.580 avg_stop:0.420 router_entropy:1.0272
+2010/50000 train_loss: 3.1857 train_time: 3.8m step_avg: 114.78ms tok/s: 4567866 art_cycles:1.676 extra_cycle_frac:0.559 art_continue:cycle1=1.000,cycle2=0.375,cycle3=0.802 art_entropy:0.9408 art_router_loss:-0.0215
+step:2010/50000 art_probe window_steps:10 avg_cycles:1.809 extra_cycle_frac:0.603 avg_stop:0.397 router_entropy:1.0266
+2020/50000 train_loss: 3.0995 train_time: 3.9m step_avg: 115.38ms tok/s: 4544053 art_cycles:1.832 extra_cycle_frac:0.611 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.479 art_entropy:1.0745 art_router_loss:-0.0462
+step:2020/50000 art_probe window_steps:10 avg_cycles:1.712 extra_cycle_frac:0.571 avg_stop:0.429 router_entropy:1.0007
+2030/50000 train_loss: 3.0569 train_time: 3.9m step_avg: 116.00ms tok/s: 4519761 art_cycles:1.578 extra_cycle_frac:0.526 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.321 art_entropy:0.9779 art_router_loss:-0.0458
+step:2030/50000 art_probe window_steps:10 avg_cycles:1.822 extra_cycle_frac:0.607 avg_stop:0.393 router_entropy:1.0338
+2040/50000 train_loss: 3.2390 train_time: 4.0m step_avg: 116.62ms tok/s: 4495637 art_cycles:2.098 extra_cycle_frac:0.699 art_continue:cycle1=1.000,cycle2=0.656,cycle3=0.673 art_entropy:1.1220 art_router_loss:-0.0457
+step:2040/50000 art_probe window_steps:10 avg_cycles:1.853 extra_cycle_frac:0.618 avg_stop:0.382 router_entropy:1.0223
+2050/50000 train_loss: 3.1761 train_time: 4.0m step_avg: 117.20ms tok/s: 4473408 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.625 art_entropy:1.0378 art_router_loss:-0.0165
+step:2050/50000 art_probe window_steps:10 avg_cycles:1.705 extra_cycle_frac:0.568 avg_stop:0.432 router_entropy:1.0040
+2060/50000 train_loss: 3.0887 train_time: 4.0m step_avg: 117.79ms tok/s: 4450921 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.471 art_entropy:1.0581 art_router_loss:-0.0644
+step:2060/50000 art_probe window_steps:10 avg_cycles:1.754 extra_cycle_frac:0.585 avg_stop:0.415 router_entropy:1.0267
+2070/50000 train_loss: 3.1272 train_time: 4.1m step_avg: 118.38ms tok/s: 4428999 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0591 art_router_loss:-0.0276
+step:2070/50000 art_probe window_steps:10 avg_cycles:1.766 extra_cycle_frac:0.589 avg_stop:0.411 router_entropy:1.0482
+2080/50000 train_loss: 3.1678 train_time: 4.1m step_avg: 118.96ms tok/s: 4407380 art_cycles:1.934 extra_cycle_frac:0.645 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.660 art_entropy:1.0784 art_router_loss:-0.0161
+step:2080/50000 art_probe window_steps:10 avg_cycles:1.778 extra_cycle_frac:0.593 avg_stop:0.407 router_entropy:1.0405
+2090/50000 train_loss: 3.1336 train_time: 4.2m step_avg: 119.53ms tok/s: 4386230 art_cycles:1.676 extra_cycle_frac:0.559 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.545 art_entropy:0.9947 art_router_loss:-0.0059
+step:2090/50000 art_probe window_steps:10 avg_cycles:1.771 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0231
+2100/50000 train_loss: 3.0953 train_time: 4.2m step_avg: 120.09ms tok/s: 4365774 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.533 art_entropy:1.0165 art_router_loss:-0.0354
+step:2100/50000 art_probe window_steps:10 avg_cycles:1.739 extra_cycle_frac:0.580 avg_stop:0.420 router_entropy:1.0124
+2110/50000 train_loss: 3.1038 train_time: 4.2m step_avg: 120.66ms tok/s: 4345308 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.467 art_entropy:1.0136 art_router_loss:-0.0693
+step:2110/50000 art_probe window_steps:10 avg_cycles:1.789 extra_cycle_frac:0.596 avg_stop:0.404 router_entropy:1.0295
+2120/50000 train_loss: 3.1629 train_time: 4.3m step_avg: 121.20ms tok/s: 4325738 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.406,cycle3=0.769 art_entropy:0.9712 art_router_loss:-0.0346
+step:2120/50000 art_probe window_steps:10 avg_cycles:1.717 extra_cycle_frac:0.572 avg_stop:0.428 router_entropy:1.0060
+2130/50000 train_loss: 3.0418 train_time: 4.3m step_avg: 121.76ms tok/s: 4306073 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.600 art_entropy:1.0170 art_router_loss:-0.0215
+step:2130/50000 art_probe window_steps:10 avg_cycles:1.780 extra_cycle_frac:0.593 avg_stop:0.407 router_entropy:1.0429
+2140/50000 train_loss: 3.0551 train_time: 4.4m step_avg: 122.30ms tok/s: 4286739 art_cycles:2.035 extra_cycle_frac:0.678 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.656 art_entropy:1.1256 art_router_loss:-0.0426
+step:2140/50000 art_probe window_steps:10 avg_cycles:1.784 extra_cycle_frac:0.595 avg_stop:0.405 router_entropy:1.0367
+2150/50000 train_loss: 3.1016 train_time: 4.4m step_avg: 122.84ms tok/s: 4268082 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.438 art_entropy:1.0394 art_router_loss:-0.0246
+step:2150/50000 art_probe window_steps:10 avg_cycles:1.738 extra_cycle_frac:0.579 avg_stop:0.421 router_entropy:1.0328
+2160/50000 train_loss: 3.0064 train_time: 4.4m step_avg: 123.35ms tok/s: 4250531 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.611 art_entropy:1.0829 art_router_loss:-0.0227
+step:2160/50000 art_probe window_steps:10 avg_cycles:1.637 extra_cycle_frac:0.546 avg_stop:0.454 router_entropy:0.9767
+2170/50000 train_loss: 3.1419 train_time: 4.5m step_avg: 123.89ms tok/s: 4231911 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0612 art_router_loss:-0.0373
+step:2170/50000 art_probe window_steps:10 avg_cycles:1.823 extra_cycle_frac:0.608 avg_stop:0.392 router_entropy:1.0655
+2180/50000 train_loss: 3.2078 train_time: 4.5m step_avg: 124.42ms tok/s: 4213757 art_cycles:1.785 extra_cycle_frac:0.595 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.478 art_entropy:1.0611 art_router_loss:-0.0315
+step:2180/50000 art_probe window_steps:10 avg_cycles:1.802 extra_cycle_frac:0.601 avg_stop:0.399 router_entropy:1.0503
+2190/50000 train_loss: 3.0865 train_time: 4.6m step_avg: 124.94ms tok/s: 4196224 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.733 art_entropy:1.0177 art_router_loss:-0.0128
+step:2190/50000 art_probe window_steps:10 avg_cycles:1.752 extra_cycle_frac:0.584 avg_stop:0.416 router_entropy:1.0329
+2200/50000 train_loss: 3.1388 train_time: 4.6m step_avg: 125.47ms tok/s: 4178646 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.688 art_entropy:1.0380 art_router_loss:-0.0113
+step:2200/50000 art_probe window_steps:10 avg_cycles:1.805 extra_cycle_frac:0.602 avg_stop:0.398 router_entropy:1.0428
+2210/50000 train_loss: 3.0839 train_time: 4.6m step_avg: 125.98ms tok/s: 4161640 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.389 art_entropy:1.0799 art_router_loss:-0.0136
+step:2210/50000 art_probe window_steps:10 avg_cycles:1.772 extra_cycle_frac:0.591 avg_stop:0.409 router_entropy:1.0480
+2220/50000 train_loss: 3.1170 train_time: 4.7m step_avg: 126.49ms tok/s: 4144871 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.643 art_entropy:0.9955 art_router_loss:-0.0640
+step:2220/50000 art_probe window_steps:10 avg_cycles:1.778 extra_cycle_frac:0.593 avg_stop:0.407 router_entropy:1.0442
+2230/50000 train_loss: 3.0585 train_time: 4.7m step_avg: 127.00ms tok/s: 4128295 art_cycles:1.723 extra_cycle_frac:0.574 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.445 art_entropy:1.0395 art_router_loss:-0.0125
+step:2230/50000 art_probe window_steps:10 avg_cycles:1.789 extra_cycle_frac:0.596 avg_stop:0.404 router_entropy:1.0566
+2240/50000 train_loss: 3.0297 train_time: 4.8m step_avg: 127.51ms tok/s: 4111616 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.406,cycle3=0.692 art_entropy:0.9746 art_router_loss:-0.0226
+step:2240/50000 art_probe window_steps:10 avg_cycles:1.845 extra_cycle_frac:0.615 avg_stop:0.385 router_entropy:1.0460
+2250/50000 train_loss: 3.1651 train_time: 4.8m step_avg: 128.01ms tok/s: 4095793 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.406,cycle3=0.692 art_entropy:0.9746 art_router_loss:-0.0157
+step:2250/50000 art_probe window_steps:10 avg_cycles:1.761 extra_cycle_frac:0.587 avg_stop:0.413 router_entropy:1.0482
+2260/50000 train_loss: 3.0480 train_time: 4.8m step_avg: 128.50ms tok/s: 4080008 art_cycles:2.250 extra_cycle_frac:0.750 art_continue:cycle1=1.000,cycle2=0.750,cycle3=0.667 art_entropy:1.2128 art_router_loss:-0.0163
+step:2260/50000 art_probe window_steps:10 avg_cycles:1.775 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.0451
+2270/50000 train_loss: 3.0721 train_time: 4.9m step_avg: 128.99ms tok/s: 4064607 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.500 art_entropy:0.9962 art_router_loss:-0.0211
+step:2270/50000 art_probe window_steps:10 avg_cycles:1.781 extra_cycle_frac:0.594 avg_stop:0.406 router_entropy:1.0568
+2280/50000 train_loss: 3.1015 train_time: 4.9m step_avg: 129.48ms tok/s: 4049115 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.474 art_entropy:1.1045 art_router_loss:-0.0246
+step:2280/50000 art_probe window_steps:10 avg_cycles:1.825 extra_cycle_frac:0.608 avg_stop:0.392 router_entropy:1.0720
+2290/50000 train_loss: 3.0667 train_time: 5.0m step_avg: 129.97ms tok/s: 4033778 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.500 art_entropy:1.0395 art_router_loss:-0.0189
+step:2290/50000 art_probe window_steps:10 avg_cycles:1.850 extra_cycle_frac:0.617 avg_stop:0.383 router_entropy:1.0893
+2300/50000 train_loss: 3.0313 train_time: 5.0m step_avg: 130.44ms tok/s: 4019304 art_cycles:1.438 extra_cycle_frac:0.479 art_continue:cycle1=1.000,cycle2=0.281,cycle3=0.556 art_entropy:0.8878 art_router_loss:-0.0269
+step:2300/50000 art_probe window_steps:10 avg_cycles:1.750 extra_cycle_frac:0.583 avg_stop:0.417 router_entropy:1.0286
+2310/50000 train_loss: 3.0629 train_time: 5.0m step_avg: 130.91ms tok/s: 4005080 art_cycles:1.562 extra_cycle_frac:0.521 art_continue:cycle1=1.000,cycle2=0.406,cycle3=0.385 art_entropy:0.9744 art_router_loss:-0.0171
+step:2310/50000 art_probe window_steps:10 avg_cycles:1.741 extra_cycle_frac:0.580 avg_stop:0.420 router_entropy:1.0524
+2320/50000 train_loss: 3.1238 train_time: 5.1m step_avg: 131.36ms tok/s: 3991082 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.412 art_entropy:1.0610 art_router_loss:-0.0220
+step:2320/50000 art_probe window_steps:10 avg_cycles:1.744 extra_cycle_frac:0.581 avg_stop:0.419 router_entropy:1.0199
+2330/50000 train_loss: 3.0568 train_time: 5.1m step_avg: 131.83ms tok/s: 3977102 art_cycles:2.031 extra_cycle_frac:0.677 art_continue:cycle1=1.000,cycle2=0.719,cycle3=0.435 art_entropy:1.1910 art_router_loss:-0.0301
+step:2330/50000 art_probe window_steps:10 avg_cycles:1.769 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0567
+2340/50000 train_loss: 3.0981 train_time: 5.2m step_avg: 132.26ms tok/s: 3963948 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.600 art_entropy:1.0177 art_router_loss:0.0062
+step:2340/50000 art_probe window_steps:10 avg_cycles:1.663 extra_cycle_frac:0.554 avg_stop:0.446 router_entropy:0.9939
+2350/50000 train_loss: 3.0823 train_time: 5.2m step_avg: 132.73ms tok/s: 3949925 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.556 art_entropy:1.0826 art_router_loss:-0.0387
+step:2350/50000 art_probe window_steps:10 avg_cycles:1.856 extra_cycle_frac:0.619 avg_stop:0.381 router_entropy:1.0631
+2360/50000 train_loss: 3.0113 train_time: 5.2m step_avg: 133.18ms tok/s: 3936636 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.412 art_entropy:1.0609 art_router_loss:-0.0408
+step:2360/50000 art_probe window_steps:10 avg_cycles:1.766 extra_cycle_frac:0.589 avg_stop:0.411 router_entropy:1.0458
+2370/50000 train_loss: 3.0293 train_time: 5.3m step_avg: 133.63ms tok/s: 3923361 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.500 art_entropy:1.0825 art_router_loss:-0.0279
+step:2370/50000 art_probe window_steps:10 avg_cycles:1.797 extra_cycle_frac:0.599 avg_stop:0.401 router_entropy:1.0631
+2380/50000 train_loss: 3.1505 train_time: 5.3m step_avg: 134.07ms tok/s: 3910432 art_cycles:2.094 extra_cycle_frac:0.698 art_continue:cycle1=1.000,cycle2=0.719,cycle3=0.522 art_entropy:1.1908 art_router_loss:-0.0333
+step:2380/50000 art_probe window_steps:10 avg_cycles:1.775 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.0392
+2390/50000 train_loss: 3.1410 train_time: 5.4m step_avg: 134.51ms tok/s: 3897700 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.688 art_entropy:1.0392 art_router_loss:-0.0261
+step:2390/50000 art_probe window_steps:10 avg_cycles:1.772 extra_cycle_frac:0.591 avg_stop:0.409 router_entropy:1.0370
+2400/50000 train_loss: 3.1984 train_time: 5.4m step_avg: 134.94ms tok/s: 3885378 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.571 art_entropy:0.9958 art_router_loss:-0.0010
+step:2400/50000 art_probe window_steps:10 avg_cycles:1.734 extra_cycle_frac:0.578 avg_stop:0.422 router_entropy:1.0327
+2410/50000 train_loss: 3.0474 train_time: 5.4m step_avg: 135.38ms tok/s: 3872624 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.450 art_entropy:1.1257 art_router_loss:-0.0612
+step:2410/50000 art_probe window_steps:10 avg_cycles:1.831 extra_cycle_frac:0.610 avg_stop:0.390 router_entropy:1.0694
+2420/50000 train_loss: 2.9549 train_time: 5.5m step_avg: 135.80ms tok/s: 3860806 art_cycles:1.562 extra_cycle_frac:0.521 art_continue:cycle1=1.000,cycle2=0.344,cycle3=0.636 art_entropy:0.9308 art_router_loss:-0.0136
+step:2420/50000 art_probe window_steps:10 avg_cycles:1.706 extra_cycle_frac:0.569 avg_stop:0.431 router_entropy:1.0196
+2430/50000 train_loss: 3.1071 train_time: 5.5m step_avg: 136.23ms tok/s: 3848665 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.400 art_entropy:1.0173 art_router_loss:-0.0103
+step:2430/50000 art_probe window_steps:10 avg_cycles:1.794 extra_cycle_frac:0.598 avg_stop:0.402 router_entropy:1.0629
+2440/50000 train_loss: 2.9262 train_time: 5.6m step_avg: 136.63ms tok/s: 3837175 art_cycles:1.469 extra_cycle_frac:0.490 art_continue:cycle1=1.000,cycle2=0.344,cycle3=0.364 art_entropy:0.9306 art_router_loss:-0.0626
+step:2440/50000 art_probe window_steps:10 avg_cycles:1.709 extra_cycle_frac:0.570 avg_stop:0.430 router_entropy:1.0173
+2450/50000 train_loss: 3.1107 train_time: 5.6m step_avg: 137.08ms tok/s: 3824624 art_cycles:2.031 extra_cycle_frac:0.677 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.500 art_entropy:1.1688 art_router_loss:0.0083
+step:2450/50000 art_probe window_steps:10 avg_cycles:1.934 extra_cycle_frac:0.645 avg_stop:0.355 router_entropy:1.1256
+2460/50000 train_loss: 3.1069 train_time: 5.6m step_avg: 137.52ms tok/s: 3812548 art_cycles:1.969 extra_cycle_frac:0.656 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.632 art_entropy:1.1038 art_router_loss:-0.0028
+step:2460/50000 art_probe window_steps:10 avg_cycles:1.883 extra_cycle_frac:0.628 avg_stop:0.372 router_entropy:1.0800
+2470/50000 train_loss: 2.9988 train_time: 5.7m step_avg: 137.92ms tok/s: 3801289 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.600 art_entropy:1.0171 art_router_loss:-0.0212
+step:2470/50000 art_probe window_steps:10 avg_cycles:1.743 extra_cycle_frac:0.581 avg_stop:0.419 router_entropy:1.0388
+2480/50000 train_loss: 3.0863 train_time: 5.7m step_avg: 138.34ms tok/s: 3789930 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.368 art_entropy:1.1064 art_router_loss:-0.0371
+step:2480/50000 art_probe window_steps:10 avg_cycles:1.803 extra_cycle_frac:0.601 avg_stop:0.399 router_entropy:1.0662
+2490/50000 train_loss: 3.0880 train_time: 5.8m step_avg: 138.73ms tok/s: 3779156 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.571 art_entropy:0.9995 art_router_loss:-0.0272
+step:2490/50000 art_probe window_steps:10 avg_cycles:1.722 extra_cycle_frac:0.574 avg_stop:0.426 router_entropy:1.0347
+2500/50000 train_loss: 3.1050 train_time: 5.8m step_avg: 139.15ms tok/s: 3767735 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.500 art_entropy:1.0866 art_router_loss:-0.0342
+step:2500/50000 art_probe window_steps:10 avg_cycles:1.875 extra_cycle_frac:0.625 avg_stop:0.375 router_entropy:1.1017
+2510/50000 train_loss: 3.1493 train_time: 5.8m step_avg: 139.55ms tok/s: 3757016 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.235 art_entropy:1.0649 art_router_loss:-0.0241
+step:2510/50000 art_probe window_steps:10 avg_cycles:1.772 extra_cycle_frac:0.591 avg_stop:0.409 router_entropy:1.0572
+2520/50000 train_loss: 2.9315 train_time: 5.9m step_avg: 139.95ms tok/s: 3746319 art_cycles:1.703 extra_cycle_frac:0.568 art_continue:cycle1=0.977,cycle2=0.520,cycle3=0.431 art_entropy:1.1247 art_router_loss:-0.0480
+step:2520/50000 art_probe window_steps:10 avg_cycles:1.792 extra_cycle_frac:0.597 avg_stop:0.403 router_entropy:1.0813
+2530/50000 train_loss: 3.0338 train_time: 5.9m step_avg: 140.34ms tok/s: 3735873 art_cycles:1.531 extra_cycle_frac:0.510 art_continue:cycle1=0.969,cycle2=0.419,cycle3=0.385 art_entropy:1.0910 art_router_loss:-0.0255
+step:2530/50000 art_probe window_steps:10 avg_cycles:1.743 extra_cycle_frac:0.581 avg_stop:0.419 router_entropy:1.1805
+2540/50000 train_loss: 3.0237 train_time: 6.0m step_avg: 140.74ms tok/s: 3725245 art_cycles:2.000 extra_cycle_frac:0.667 art_continue:cycle1=0.969,cycle2=0.710,cycle3=0.500 art_entropy:1.1602 art_router_loss:-0.0391
+step:2540/50000 art_probe window_steps:10 avg_cycles:1.828 extra_cycle_frac:0.609 avg_stop:0.391 router_entropy:1.1126
+2550/50000 train_loss: 3.0409 train_time: 6.0m step_avg: 141.14ms tok/s: 3714696 art_cycles:2.094 extra_cycle_frac:0.698 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.591 art_entropy:1.1823 art_router_loss:-0.0147
+step:2550/50000 art_probe window_steps:10 avg_cycles:1.851 extra_cycle_frac:0.617 avg_stop:0.383 router_entropy:1.0870
+2560/50000 train_loss: 3.0120 train_time: 6.0m step_avg: 141.53ms tok/s: 3704460 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.318 art_entropy:1.1778 art_router_loss:-0.0430
+step:2560/50000 art_probe window_steps:10 avg_cycles:1.819 extra_cycle_frac:0.606 avg_stop:0.394 router_entropy:1.0837
+2570/50000 train_loss: 2.9734 train_time: 6.1m step_avg: 141.89ms tok/s: 3694909 art_cycles:1.926 extra_cycle_frac:0.642 art_continue:cycle1=0.957,cycle2=0.653,cycle3=0.550 art_entropy:1.1601 art_router_loss:-0.0320
+step:2570/50000 art_probe window_steps:10 avg_cycles:1.683 extra_cycle_frac:0.561 avg_stop:0.439 router_entropy:1.0286
+2580/50000 train_loss: 3.0606 train_time: 6.1m step_avg: 142.27ms tok/s: 3685179 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.406,cycle3=0.615 art_entropy:1.0232 art_router_loss:-0.0394
+step:2580/50000 art_probe window_steps:10 avg_cycles:1.752 extra_cycle_frac:0.584 avg_stop:0.416 router_entropy:1.0876
+2590/50000 train_loss: 3.0558 train_time: 6.2m step_avg: 142.63ms tok/s: 3675784 art_cycles:1.625 extra_cycle_frac:0.542 art_continue:cycle1=0.938,cycle2=0.467,cycle3=0.571 art_entropy:1.0763 art_router_loss:-0.0270
+step:2590/50000 art_probe window_steps:10 avg_cycles:1.696 extra_cycle_frac:0.565 avg_stop:0.435 router_entropy:1.0954
+2600/50000 train_loss: 3.0772 train_time: 6.2m step_avg: 143.01ms tok/s: 3666221 art_cycles:1.594 extra_cycle_frac:0.531 art_continue:cycle1=1.000,cycle2=0.375,cycle3=0.583 art_entropy:0.9959 art_router_loss:-0.0152
+step:2600/50000 art_probe window_steps:10 avg_cycles:1.759 extra_cycle_frac:0.586 avg_stop:0.414 router_entropy:1.1208
+2610/50000 train_loss: 3.0752 train_time: 6.2m step_avg: 143.36ms tok/s: 3657086 art_cycles:1.625 extra_cycle_frac:0.542 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.429 art_entropy:1.0603 art_router_loss:-0.0043
+step:2610/50000 art_probe window_steps:10 avg_cycles:1.703 extra_cycle_frac:0.568 avg_stop:0.432 router_entropy:1.0886
+2620/50000 train_loss: 3.0308 train_time: 6.3m step_avg: 143.72ms tok/s: 3647891 art_cycles:1.938 extra_cycle_frac:0.646 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.364 art_entropy:1.3423 art_router_loss:-0.0356
+step:2620/50000 art_probe window_steps:10 avg_cycles:1.720 extra_cycle_frac:0.573 avg_stop:0.427 router_entropy:1.1609
+2630/50000 train_loss: 3.0093 train_time: 6.3m step_avg: 144.09ms tok/s: 3638622 art_cycles:1.879 extra_cycle_frac:0.626 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.480 art_entropy:1.1857 art_router_loss:-0.0158
+step:2630/50000 art_probe window_steps:10 avg_cycles:1.764 extra_cycle_frac:0.588 avg_stop:0.412 router_entropy:1.1846
+2640/50000 train_loss: 2.9128 train_time: 6.4m step_avg: 144.46ms tok/s: 3629292 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.714 art_entropy:1.0261 art_router_loss:-0.0394
+step:2640/50000 art_probe window_steps:10 avg_cycles:1.824 extra_cycle_frac:0.608 avg_stop:0.392 router_entropy:1.1175
+2650/50000 train_loss: 2.9967 train_time: 6.4m step_avg: 144.81ms tok/s: 3620560 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.562 art_entropy:1.0538 art_router_loss:-0.0456
+step:2650/50000 art_probe window_steps:10 avg_cycles:1.726 extra_cycle_frac:0.575 avg_stop:0.425 router_entropy:1.0493
+2660/50000 train_loss: 3.0611 train_time: 6.4m step_avg: 145.18ms tok/s: 3611383 art_cycles:2.121 extra_cycle_frac:0.707 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.631 art_entropy:1.2611 art_router_loss:-0.0238
+step:2660/50000 art_probe window_steps:10 avg_cycles:1.853 extra_cycle_frac:0.618 avg_stop:0.382 router_entropy:1.1054
+2670/50000 train_loss: 3.0738 train_time: 6.5m step_avg: 145.53ms tok/s: 3602729 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=0.930,cycle2=0.710,cycle3=0.384 art_entropy:1.3731 art_router_loss:-0.0459
+step:2670/50000 art_probe window_steps:10 avg_cycles:1.699 extra_cycle_frac:0.566 avg_stop:0.434 router_entropy:1.2250
+2680/50000 train_loss: 3.1129 train_time: 6.5m step_avg: 145.86ms tok/s: 3594433 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.643 art_entropy:1.0113 art_router_loss:-0.0114
+step:2680/50000 art_probe window_steps:10 avg_cycles:1.661 extra_cycle_frac:0.554 avg_stop:0.446 router_entropy:1.1042
+2690/50000 train_loss: 3.1260 train_time: 6.6m step_avg: 146.20ms tok/s: 3586071 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.706 art_entropy:1.0685 art_router_loss:0.0074
+step:2690/50000 art_probe window_steps:10 avg_cycles:1.736 extra_cycle_frac:0.579 avg_stop:0.421 router_entropy:1.0474
+2700/50000 train_loss: 2.9295 train_time: 6.6m step_avg: 146.54ms tok/s: 3577890 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0660 art_router_loss:-0.0127
+step:2700/50000 art_probe window_steps:10 avg_cycles:1.716 extra_cycle_frac:0.572 avg_stop:0.428 router_entropy:1.0302
+2710/50000 train_loss: 3.1306 train_time: 6.6m step_avg: 146.88ms tok/s: 3569613 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.562 art_entropy:1.0621 art_router_loss:-0.0187
+step:2710/50000 art_probe window_steps:10 avg_cycles:1.768 extra_cycle_frac:0.589 avg_stop:0.411 router_entropy:1.0481
+2720/50000 train_loss: 3.2711 train_time: 6.7m step_avg: 147.22ms tok/s: 3561308 art_cycles:1.789 extra_cycle_frac:0.596 art_continue:cycle1=0.973,cycle2=0.518,cycle3=0.620 art_entropy:1.0551 art_router_loss:0.0812
+step:2720/50000 art_probe window_steps:10 avg_cycles:1.788 extra_cycle_frac:0.596 avg_stop:0.404 router_entropy:1.0942
+2730/50000 train_loss: 3.0256 train_time: 6.7m step_avg: 147.55ms tok/s: 3553337 art_cycles:2.031 extra_cycle_frac:0.677 art_continue:cycle1=0.973,cycle2=0.707,cycle3=0.540 art_entropy:1.2074 art_router_loss:-0.0787
+step:2730/50000 art_probe window_steps:10 avg_cycles:1.725 extra_cycle_frac:0.575 avg_stop:0.425 router_entropy:1.0625
+2740/50000 train_loss: 2.9439 train_time: 6.8m step_avg: 147.88ms tok/s: 3545446 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.500 art_entropy:1.1565 art_router_loss:-0.0249
+step:2740/50000 art_probe window_steps:10 avg_cycles:1.717 extra_cycle_frac:0.572 avg_stop:0.428 router_entropy:1.1083
+2750/50000 train_loss: 3.0180 train_time: 6.8m step_avg: 148.21ms tok/s: 3537426 art_cycles:1.703 extra_cycle_frac:0.568 art_continue:cycle1=0.992,cycle2=0.464,cycle3=0.543 art_entropy:1.0587 art_router_loss:0.0039
+step:2750/50000 art_probe window_steps:10 avg_cycles:1.759 extra_cycle_frac:0.586 avg_stop:0.414 router_entropy:1.0927
+2760/50000 train_loss: 3.1452 train_time: 6.8m step_avg: 148.54ms tok/s: 3529520 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.625 art_entropy:1.0800 art_router_loss:0.0005
+step:2760/50000 art_probe window_steps:10 avg_cycles:1.775 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.1078
+2770/50000 train_loss: 2.9823 train_time: 6.9m step_avg: 148.87ms tok/s: 3521771 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.375 art_entropy:1.0503 art_router_loss:-0.0141
+step:2770/50000 art_probe window_steps:10 avg_cycles:1.763 extra_cycle_frac:0.588 avg_stop:0.412 router_entropy:1.0669
+2780/50000 train_loss: 3.0546 train_time: 6.9m step_avg: 149.19ms tok/s: 3514198 art_cycles:1.938 extra_cycle_frac:0.646 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.765 art_entropy:1.0769 art_router_loss:-0.0178
+step:2780/50000 art_probe window_steps:10 avg_cycles:1.759 extra_cycle_frac:0.586 avg_stop:0.414 router_entropy:1.0415
+2790/50000 train_loss: 2.9999 train_time: 7.0m step_avg: 149.53ms tok/s: 3506280 art_cycles:1.707 extra_cycle_frac:0.569 art_continue:cycle1=0.996,cycle2=0.467,cycle3=0.529 art_entropy:1.0552 art_router_loss:-0.0253
+step:2790/50000 art_probe window_steps:10 avg_cycles:1.860 extra_cycle_frac:0.620 avg_stop:0.380 router_entropy:1.1175
+2800/50000 train_loss: 2.9831 train_time: 7.0m step_avg: 149.86ms tok/s: 3498560 art_cycles:1.820 extra_cycle_frac:0.607 art_continue:cycle1=0.977,cycle2=0.512,cycle3=0.688 art_entropy:1.1343 art_router_loss:-0.0637
+step:2800/50000 art_probe window_steps:10 avg_cycles:1.815 extra_cycle_frac:0.605 avg_stop:0.395 router_entropy:1.1418
+2810/50000 train_loss: 2.9671 train_time: 7.0m step_avg: 150.18ms tok/s: 3491065 art_cycles:1.836 extra_cycle_frac:0.612 art_continue:cycle1=0.980,cycle2=0.554,cycle3=0.575 art_entropy:1.1351 art_router_loss:-0.0072
+step:2810/50000 art_probe window_steps:10 avg_cycles:1.767 extra_cycle_frac:0.589 avg_stop:0.411 router_entropy:1.1510
+2820/50000 train_loss: 3.2788 train_time: 7.1m step_avg: 150.49ms tok/s: 3483769 art_cycles:1.688 extra_cycle_frac:0.563 art_continue:cycle1=0.977,cycle2=0.472,cycle3=0.543 art_entropy:1.0878 art_router_loss:-0.0054
+step:2820/50000 art_probe window_steps:10 avg_cycles:1.744 extra_cycle_frac:0.581 avg_stop:0.419 router_entropy:1.1140
+2830/50000 train_loss: 3.0442 train_time: 7.1m step_avg: 150.80ms tok/s: 3476660 art_cycles:1.715 extra_cycle_frac:0.572 art_continue:cycle1=0.996,cycle2=0.502,cycle3=0.438 art_entropy:1.1153 art_router_loss:-0.0136
+step:2830/50000 art_probe window_steps:10 avg_cycles:1.706 extra_cycle_frac:0.569 avg_stop:0.431 router_entropy:1.1207
+2840/50000 train_loss: 3.0309 train_time: 7.2m step_avg: 151.12ms tok/s: 3469330 art_cycles:1.930 extra_cycle_frac:0.643 art_continue:cycle1=0.977,cycle2=0.648,cycle3=0.506 art_entropy:1.2180 art_router_loss:-0.0461
+step:2840/50000 art_probe window_steps:10 avg_cycles:1.806 extra_cycle_frac:0.602 avg_stop:0.398 router_entropy:1.1393
+2850/50000 train_loss: 3.0090 train_time: 7.2m step_avg: 151.42ms tok/s: 3462422 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.667 art_entropy:1.0780 art_router_loss:-0.0097
+step:2850/50000 art_probe window_steps:10 avg_cycles:1.703 extra_cycle_frac:0.568 avg_stop:0.432 router_entropy:1.0616
+2860/50000 train_loss: 2.9151 train_time: 7.2m step_avg: 151.73ms tok/s: 3455296 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.688 art_entropy:1.1522 art_router_loss:-0.0265
+step:2860/50000 art_probe window_steps:10 avg_cycles:1.773 extra_cycle_frac:0.591 avg_stop:0.409 router_entropy:1.1241
+2870/50000 train_loss: 3.0101 train_time: 7.3m step_avg: 152.04ms tok/s: 3448298 art_cycles:1.867 extra_cycle_frac:0.622 art_continue:cycle1=0.961,cycle2=0.585,cycle3=0.611 art_entropy:1.1612 art_router_loss:-0.0697
+step:2870/50000 art_probe window_steps:10 avg_cycles:1.754 extra_cycle_frac:0.585 avg_stop:0.415 router_entropy:1.1614
+2880/50000 train_loss: 3.0625 train_time: 7.3m step_avg: 152.35ms tok/s: 3441367 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.444 art_entropy:1.0989 art_router_loss:0.0044
+step:2880/50000 art_probe window_steps:10 avg_cycles:1.775 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.0918
+2890/50000 train_loss: 2.9612 train_time: 7.4m step_avg: 152.64ms tok/s: 3434705 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.500 art_entropy:1.0499 art_router_loss:-0.0147
+step:2890/50000 art_probe window_steps:10 avg_cycles:1.751 extra_cycle_frac:0.584 avg_stop:0.416 router_entropy:1.0544
+2900/50000 train_loss: 2.9693 train_time: 7.4m step_avg: 152.96ms tok/s: 3427669 art_cycles:1.879 extra_cycle_frac:0.626 art_continue:cycle1=0.992,cycle2=0.599,cycle3=0.493 art_entropy:1.1102 art_router_loss:-0.0384
+step:2900/50000 art_probe window_steps:10 avg_cycles:1.867 extra_cycle_frac:0.622 avg_stop:0.378 router_entropy:1.0897
+2910/50000 train_loss: 2.8937 train_time: 7.4m step_avg: 153.27ms tok/s: 3420721 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.500 art_entropy:1.0407 art_router_loss:0.0007
+step:2910/50000 art_probe window_steps:10 avg_cycles:1.870 extra_cycle_frac:0.623 avg_stop:0.377 router_entropy:1.0854
+2920/50000 train_loss: 2.9453 train_time: 7.5m step_avg: 153.57ms tok/s: 3414019 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.647 art_entropy:1.0617 art_router_loss:-0.0095
+step:2920/50000 art_probe window_steps:10 avg_cycles:1.822 extra_cycle_frac:0.607 avg_stop:0.393 router_entropy:1.0618
+2930/50000 train_loss: 2.9641 train_time: 7.5m step_avg: 153.88ms tok/s: 3407227 art_cycles:1.883 extra_cycle_frac:0.628 art_continue:cycle1=0.992,cycle2=0.527,cycle3=0.701 art_entropy:1.0522 art_router_loss:0.0044
+step:2930/50000 art_probe window_steps:10 avg_cycles:1.860 extra_cycle_frac:0.620 avg_stop:0.380 router_entropy:1.0916
+2940/50000 train_loss: 3.1193 train_time: 7.6m step_avg: 154.17ms tok/s: 3400671 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.389 art_entropy:1.0833 art_router_loss:0.0113
+step:2940/50000 art_probe window_steps:10 avg_cycles:1.819 extra_cycle_frac:0.606 avg_stop:0.394 router_entropy:1.0726
+2950/50000 train_loss: 3.1013 train_time: 7.6m step_avg: 154.46ms tok/s: 3394356 art_cycles:1.938 extra_cycle_frac:0.646 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.500 art_entropy:1.1282 art_router_loss:-0.0227
+step:2950/50000 art_probe window_steps:10 avg_cycles:1.775 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.0472
+2960/50000 train_loss: 2.9846 train_time: 7.6m step_avg: 154.76ms tok/s: 3387809 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.750 art_entropy:1.0510 art_router_loss:-0.0132
+step:2960/50000 art_probe window_steps:10 avg_cycles:1.857 extra_cycle_frac:0.619 avg_stop:0.381 router_entropy:1.1044
+2970/50000 train_loss: 3.0887 train_time: 7.7m step_avg: 155.04ms tok/s: 3381538 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.312 art_entropy:1.0487 art_router_loss:-0.0004
+step:2970/50000 art_probe window_steps:10 avg_cycles:1.790 extra_cycle_frac:0.597 avg_stop:0.403 router_entropy:1.0570
+2980/50000 train_loss: 3.0750 train_time: 7.7m step_avg: 155.34ms tok/s: 3375137 art_cycles:2.000 extra_cycle_frac:0.667 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.600 art_entropy:1.1293 art_router_loss:-0.0113
+step:2980/50000 art_probe window_steps:10 avg_cycles:1.840 extra_cycle_frac:0.613 avg_stop:0.387 router_entropy:1.0723
+2990/50000 train_loss: 3.0592 train_time: 7.8m step_avg: 155.63ms tok/s: 3368818 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.611 art_entropy:1.0830 art_router_loss:0.0056
+step:2990/50000 art_probe window_steps:10 avg_cycles:1.849 extra_cycle_frac:0.616 avg_stop:0.384 router_entropy:1.0761
+3000/50000 train_loss: 2.9696 train_time: 7.8m step_avg: 155.92ms tok/s: 3362566 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.444 art_entropy:1.0829 art_router_loss:-0.0209
+step:3000/50000 art_probe window_steps:10 avg_cycles:1.847 extra_cycle_frac:0.616 avg_stop:0.384 router_entropy:1.0894
+3010/50000 train_loss: 3.0039 train_time: 7.8m step_avg: 156.19ms tok/s: 3356663 art_cycles:1.766 extra_cycle_frac:0.589 art_continue:cycle1=0.992,cycle2=0.496,cycle3=0.572 art_entropy:1.0301 art_router_loss:-0.0101
+step:3010/50000 art_probe window_steps:10 avg_cycles:1.751 extra_cycle_frac:0.584 avg_stop:0.416 router_entropy:1.0609
+3020/50000 train_loss: 3.0282 train_time: 7.9m step_avg: 156.47ms tok/s: 3350666 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.667 art_entropy:1.0252 art_router_loss:-0.0073
+step:3020/50000 art_probe window_steps:10 avg_cycles:1.813 extra_cycle_frac:0.604 avg_stop:0.396 router_entropy:1.0613
+3030/50000 train_loss: 2.9656 train_time: 7.9m step_avg: 156.74ms tok/s: 3345033 art_cycles:1.969 extra_cycle_frac:0.656 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.550 art_entropy:1.1394 art_router_loss:-0.0004
+step:3030/50000 art_probe window_steps:10 avg_cycles:1.719 extra_cycle_frac:0.573 avg_stop:0.427 router_entropy:1.0366
+3040/50000 train_loss: 2.9652 train_time: 8.0m step_avg: 157.01ms tok/s: 3339098 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.588 art_entropy:1.0787 art_router_loss:-0.0177
+step:3040/50000 art_probe window_steps:10 avg_cycles:1.823 extra_cycle_frac:0.608 avg_stop:0.392 router_entropy:1.0944
+3050/50000 train_loss: 3.0202 train_time: 8.0m step_avg: 157.29ms tok/s: 3333227 art_cycles:1.934 extra_cycle_frac:0.645 art_continue:cycle1=1.000,cycle2=0.590,cycle3=0.583 art_entropy:1.1106 art_router_loss:-0.0195
+step:3050/50000 art_probe window_steps:10 avg_cycles:1.821 extra_cycle_frac:0.607 avg_stop:0.393 router_entropy:1.0753
+3060/50000 train_loss: 2.9996 train_time: 8.0m step_avg: 157.56ms tok/s: 3327647 art_cycles:1.902 extra_cycle_frac:0.634 art_continue:cycle1=1.000,cycle2=0.559,cycle3=0.616 art_entropy:1.0860 art_router_loss:-0.0234
+step:3060/50000 art_probe window_steps:10 avg_cycles:1.747 extra_cycle_frac:0.582 avg_stop:0.418 router_entropy:1.0534
+3070/50000 train_loss: 3.0127 train_time: 8.1m step_avg: 157.82ms tok/s: 3321980 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.562 art_entropy:1.0431 art_router_loss:-0.0269
+step:3070/50000 art_probe window_steps:10 avg_cycles:1.796 extra_cycle_frac:0.599 avg_stop:0.401 router_entropy:1.0547
+3080/50000 train_loss: 3.0324 train_time: 8.1m step_avg: 158.09ms tok/s: 3316428 art_cycles:1.742 extra_cycle_frac:0.581 art_continue:cycle1=1.000,cycle2=0.449,cycle3=0.652 art_entropy:1.0062 art_router_loss:-0.0132
+step:3080/50000 art_probe window_steps:10 avg_cycles:1.770 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0494
+3090/50000 train_loss: 2.9204 train_time: 8.2m step_avg: 158.35ms tok/s: 3310999 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.500 art_entropy:0.9964 art_router_loss:-0.0066
+step:3090/50000 art_probe window_steps:10 avg_cycles:1.762 extra_cycle_frac:0.587 avg_stop:0.413 router_entropy:1.0401
+3100/50000 train_loss: 2.9689 train_time: 8.2m step_avg: 158.63ms tok/s: 3305120 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.412 art_entropy:1.0611 art_router_loss:-0.0359
+step:3100/50000 art_probe window_steps:10 avg_cycles:1.919 extra_cycle_frac:0.640 avg_stop:0.360 router_entropy:1.0884
+3110/50000 train_loss: 2.9711 train_time: 8.2m step_avg: 158.89ms tok/s: 3299787 art_cycles:2.375 extra_cycle_frac:0.792 art_continue:cycle1=1.000,cycle2=0.750,cycle3=0.833 art_entropy:1.2134 art_router_loss:0.0241
+step:3110/50000 art_probe window_steps:10 avg_cycles:1.762 extra_cycle_frac:0.587 avg_stop:0.413 router_entropy:1.0440
+3120/50000 train_loss: 2.8650 train_time: 8.3m step_avg: 159.14ms tok/s: 3294452 art_cycles:1.625 extra_cycle_frac:0.542 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.333 art_entropy:1.0196 art_router_loss:0.0039
+step:3120/50000 art_probe window_steps:10 avg_cycles:1.763 extra_cycle_frac:0.588 avg_stop:0.412 router_entropy:1.0436
+3130/50000 train_loss: 2.9662 train_time: 8.3m step_avg: 159.41ms tok/s: 3289004 art_cycles:2.031 extra_cycle_frac:0.677 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.737 art_entropy:1.1042 art_router_loss:-0.0224
+step:3130/50000 art_probe window_steps:10 avg_cycles:1.836 extra_cycle_frac:0.612 avg_stop:0.388 router_entropy:1.0724
+3140/50000 train_loss: 3.0106 train_time: 8.4m step_avg: 159.66ms tok/s: 3283780 art_cycles:1.938 extra_cycle_frac:0.646 art_continue:cycle1=1.000,cycle2=0.656,cycle3=0.429 art_entropy:1.1470 art_router_loss:0.0095
+step:3140/50000 art_probe window_steps:10 avg_cycles:1.776 extra_cycle_frac:0.592 avg_stop:0.408 router_entropy:1.0592
+3150/50000 train_loss: 2.9984 train_time: 8.4m step_avg: 159.92ms tok/s: 3278535 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.421 art_entropy:1.1041 art_router_loss:-0.0102
+step:3150/50000 art_probe window_steps:10 avg_cycles:1.802 extra_cycle_frac:0.601 avg_stop:0.399 router_entropy:1.0576
+3160/50000 train_loss: 2.9480 train_time: 8.4m step_avg: 160.17ms tok/s: 3273386 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0625 art_router_loss:0.0182
+step:3160/50000 art_probe window_steps:10 avg_cycles:1.788 extra_cycle_frac:0.596 avg_stop:0.404 router_entropy:1.0509
+3170/50000 train_loss: 2.9463 train_time: 8.5m step_avg: 160.41ms tok/s: 3268327 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.444 art_entropy:1.0839 art_router_loss:-0.0205
+step:3170/50000 art_probe window_steps:10 avg_cycles:1.760 extra_cycle_frac:0.587 avg_stop:0.413 router_entropy:1.0570
+3180/50000 train_loss: 2.9667 train_time: 8.5m step_avg: 160.66ms tok/s: 3263326 art_cycles:1.906 extra_cycle_frac:0.635 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.706 art_entropy:1.0610 art_router_loss:0.0137
+step:3180/50000 art_probe window_steps:10 avg_cycles:1.769 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0461
+3190/50000 train_loss: 3.0525 train_time: 8.6m step_avg: 160.91ms tok/s: 3258256 art_cycles:1.797 extra_cycle_frac:0.599 art_continue:cycle1=0.984,cycle2=0.540,cycle3=0.529 art_entropy:1.0504 art_router_loss:0.0970
+step:3190/50000 art_probe window_steps:10 avg_cycles:1.796 extra_cycle_frac:0.599 avg_stop:0.401 router_entropy:1.0688
+3200/50000 train_loss: 2.8944 train_time: 8.6m step_avg: 161.16ms tok/s: 3253311 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.471 art_entropy:1.0624 art_router_loss:-0.0075
+step:3200/50000 art_probe window_steps:10 avg_cycles:1.780 extra_cycle_frac:0.593 avg_stop:0.407 router_entropy:1.0570
+3210/50000 train_loss: 2.9555 train_time: 8.6m step_avg: 161.39ms tok/s: 3248487 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.474 art_entropy:1.1080 art_router_loss:-0.0322
+step:3210/50000 art_probe window_steps:10 avg_cycles:1.759 extra_cycle_frac:0.586 avg_stop:0.414 router_entropy:1.0481
+3220/50000 train_loss: 2.9120 train_time: 8.7m step_avg: 161.65ms tok/s: 3243405 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0684 art_router_loss:-0.0081
+step:3220/50000 art_probe window_steps:10 avg_cycles:1.849 extra_cycle_frac:0.616 avg_stop:0.384 router_entropy:1.0661
+3230/50000 train_loss: 3.0492 train_time: 8.7m step_avg: 161.90ms tok/s: 3238444 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0628 art_router_loss:0.0290
+step:3230/50000 art_probe window_steps:10 avg_cycles:1.836 extra_cycle_frac:0.612 avg_stop:0.388 router_entropy:1.0796
+3240/50000 train_loss: 3.0167 train_time: 8.8m step_avg: 162.12ms tok/s: 3233948 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.375 art_entropy:1.0380 art_router_loss:-0.0124
+step:3240/50000 art_probe window_steps:10 avg_cycles:1.683 extra_cycle_frac:0.561 avg_stop:0.439 router_entropy:1.0204
+3250/50000 train_loss: 2.9252 train_time: 8.8m step_avg: 162.38ms tok/s: 3228811 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.714 art_entropy:0.9943 art_router_loss:0.0061
+step:3250/50000 art_probe window_steps:10 avg_cycles:1.922 extra_cycle_frac:0.641 avg_stop:0.359 router_entropy:1.1092
+3260/50000 train_loss: 2.9596 train_time: 8.8m step_avg: 162.62ms tok/s: 3223932 art_cycles:2.062 extra_cycle_frac:0.688 art_continue:cycle1=1.000,cycle2=0.719,cycle3=0.478 art_entropy:1.1894 art_router_loss:0.0034
+step:3260/50000 art_probe window_steps:10 avg_cycles:1.853 extra_cycle_frac:0.618 avg_stop:0.382 router_entropy:1.0789
+3270/50000 train_loss: 3.0449 train_time: 8.9m step_avg: 162.86ms tok/s: 3219234 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.421 art_entropy:1.1035 art_router_loss:-0.0093
+step:3270/50000 art_probe window_steps:10 avg_cycles:1.806 extra_cycle_frac:0.602 avg_stop:0.398 router_entropy:1.0707
+3280/50000 train_loss: 2.9584 train_time: 8.9m step_avg: 163.09ms tok/s: 3214735 art_cycles:1.867 extra_cycle_frac:0.622 art_continue:cycle1=0.969,cycle2=0.625,cycle3=0.484 art_entropy:1.0906 art_router_loss:-0.0239
+step:3280/50000 art_probe window_steps:10 avg_cycles:1.734 extra_cycle_frac:0.578 avg_stop:0.422 router_entropy:1.0388
+3290/50000 train_loss: 3.0564 train_time: 9.0m step_avg: 163.33ms tok/s: 3209926 art_cycles:1.875 extra_cycle_frac:0.625 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.556 art_entropy:1.0807 art_router_loss:0.0174
+step:3290/50000 art_probe window_steps:10 avg_cycles:1.866 extra_cycle_frac:0.622 avg_stop:0.378 router_entropy:1.0832
+3300/50000 train_loss: 2.9455 train_time: 9.0m step_avg: 163.56ms tok/s: 3205447 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0585 art_router_loss:-0.0108
+step:3300/50000 art_probe window_steps:10 avg_cycles:1.769 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0457
+3310/50000 train_loss: 2.9548 train_time: 9.0m step_avg: 163.79ms tok/s: 3200905 art_cycles:1.625 extra_cycle_frac:0.542 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.429 art_entropy:0.9935 art_router_loss:0.0019
+step:3310/50000 art_probe window_steps:10 avg_cycles:1.809 extra_cycle_frac:0.603 avg_stop:0.397 router_entropy:1.0650
+3320/50000 train_loss: 2.8769 train_time: 9.1m step_avg: 164.03ms tok/s: 3196241 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.600 art_entropy:1.0151 art_router_loss:-0.0095
+step:3320/50000 art_probe window_steps:10 avg_cycles:1.867 extra_cycle_frac:0.622 avg_stop:0.378 router_entropy:1.0792
+3330/50000 train_loss: 3.0007 train_time: 9.1m step_avg: 164.27ms tok/s: 3191608 art_cycles:2.156 extra_cycle_frac:0.719 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.682 art_entropy:1.1665 art_router_loss:-0.0012
+step:3330/50000 art_probe window_steps:10 avg_cycles:1.855 extra_cycle_frac:0.618 avg_stop:0.382 router_entropy:1.0819
+3340/50000 train_loss: 2.8840 train_time: 9.2m step_avg: 164.50ms tok/s: 3187159 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.688 art_entropy:1.0368 art_router_loss:-0.0380
+step:3340/50000 art_probe window_steps:10 avg_cycles:1.819 extra_cycle_frac:0.606 avg_stop:0.394 router_entropy:1.0681
+3350/50000 train_loss: 2.9822 train_time: 9.2m step_avg: 164.74ms tok/s: 3182613 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.412 art_entropy:1.0586 art_router_loss:0.0180
+step:3350/50000 art_probe window_steps:10 avg_cycles:1.869 extra_cycle_frac:0.623 avg_stop:0.377 router_entropy:1.0866
+3360/50000 train_loss: 2.9383 train_time: 9.2m step_avg: 164.96ms tok/s: 3178244 art_cycles:1.969 extra_cycle_frac:0.656 art_continue:cycle1=1.000,cycle2=0.625,cycle3=0.550 art_entropy:1.1235 art_router_loss:0.0121
+step:3360/50000 art_probe window_steps:10 avg_cycles:1.816 extra_cycle_frac:0.605 avg_stop:0.395 router_entropy:1.0677
+3370/50000 train_loss: 2.9608 train_time: 9.3m step_avg: 165.19ms tok/s: 3173913 art_cycles:1.656 extra_cycle_frac:0.552 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.500 art_entropy:0.9936 art_router_loss:0.0365
+step:3370/50000 art_probe window_steps:10 avg_cycles:1.818 extra_cycle_frac:0.606 avg_stop:0.394 router_entropy:1.0626
+3380/50000 train_loss: 3.0095 train_time: 9.3m step_avg: 165.41ms tok/s: 3169676 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.471 art_entropy:1.0588 art_router_loss:-0.0216
+step:3380/50000 art_probe window_steps:10 avg_cycles:1.796 extra_cycle_frac:0.599 avg_stop:0.401 router_entropy:1.0585
+3390/50000 train_loss: 2.9271 train_time: 9.4m step_avg: 165.63ms tok/s: 3165374 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.714 art_entropy:0.9944 art_router_loss:-0.0035
+step:3390/50000 art_probe window_steps:10 avg_cycles:1.834 extra_cycle_frac:0.611 avg_stop:0.389 router_entropy:1.0570
+3400/50000 train_loss: 2.8190 train_time: 9.4m step_avg: 165.85ms tok/s: 3161161 art_cycles:2.000 extra_cycle_frac:0.667 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.455 art_entropy:1.1678 art_router_loss:0.0010
+step:3400/50000 art_probe window_steps:10 avg_cycles:1.816 extra_cycle_frac:0.605 avg_stop:0.395 router_entropy:1.0768
+3410/50000 train_loss: 2.9205 train_time: 9.4m step_avg: 166.08ms tok/s: 3156787 art_cycles:1.941 extra_cycle_frac:0.647 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.674 art_entropy:1.0807 art_router_loss:-0.0097
+step:3410/50000 art_probe window_steps:10 avg_cycles:1.886 extra_cycle_frac:0.629 avg_stop:0.371 router_entropy:1.0923
+3420/50000 train_loss: 2.9313 train_time: 9.5m step_avg: 166.31ms tok/s: 3152393 art_cycles:1.750 extra_cycle_frac:0.583 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.500 art_entropy:1.0370 art_router_loss:-0.0163
+step:3420/50000 art_probe window_steps:10 avg_cycles:1.915 extra_cycle_frac:0.638 avg_stop:0.362 router_entropy:1.0931
+3430/50000 train_loss: 2.8782 train_time: 9.5m step_avg: 166.52ms tok/s: 3148409 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.500,cycle3=0.562 art_entropy:1.0370 art_router_loss:-0.0155
+step:3430/50000 art_probe window_steps:10 avg_cycles:1.769 extra_cycle_frac:0.590 avg_stop:0.410 router_entropy:1.0457
+3440/50000 train_loss: 3.0498 train_time: 9.6m step_avg: 166.74ms tok/s: 3144252 art_cycles:1.969 extra_cycle_frac:0.656 art_continue:cycle1=1.000,cycle2=0.656,cycle3=0.476 art_entropy:1.1455 art_router_loss:0.0030
+step:3440/50000 art_probe window_steps:10 avg_cycles:1.839 extra_cycle_frac:0.613 avg_stop:0.387 router_entropy:1.0658
+3450/50000 train_loss: 2.8635 train_time: 9.6m step_avg: 166.97ms tok/s: 3140047 art_cycles:2.156 extra_cycle_frac:0.719 art_continue:cycle1=1.000,cycle2=0.750,cycle3=0.542 art_entropy:1.2106 art_router_loss:-0.0080
+step:3450/50000 art_probe window_steps:10 avg_cycles:1.880 extra_cycle_frac:0.627 avg_stop:0.373 router_entropy:1.0998
+3460/50000 train_loss: 2.9805 train_time: 9.6m step_avg: 167.19ms tok/s: 3135813 art_cycles:2.125 extra_cycle_frac:0.708 art_continue:cycle1=1.000,cycle2=0.719,cycle3=0.565 art_entropy:1.1892 art_router_loss:0.0054
+step:3460/50000 art_probe window_steps:10 avg_cycles:1.903 extra_cycle_frac:0.634 avg_stop:0.366 router_entropy:1.0894
+3470/50000 train_loss: 2.8912 train_time: 9.7m step_avg: 167.40ms tok/s: 3131890 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.588 art_entropy:1.0587 art_router_loss:0.0053
+step:3470/50000 art_probe window_steps:10 avg_cycles:1.793 extra_cycle_frac:0.598 avg_stop:0.402 router_entropy:1.0649
+3480/50000 train_loss: 2.9667 train_time: 9.7m step_avg: 167.62ms tok/s: 3127922 art_cycles:2.031 extra_cycle_frac:0.677 art_continue:cycle1=1.000,cycle2=0.688,cycle3=0.500 art_entropy:1.1669 art_router_loss:-0.0105
+step:3480/50000 art_probe window_steps:10 avg_cycles:1.825 extra_cycle_frac:0.608 avg_stop:0.392 router_entropy:1.0804
+3490/50000 train_loss: 2.8447 train_time: 9.8m step_avg: 167.83ms tok/s: 3123947 art_cycles:2.188 extra_cycle_frac:0.729 art_continue:cycle1=1.000,cycle2=0.719,cycle3=0.652 art_entropy:1.1887 art_router_loss:-0.0217
+step:3490/50000 art_probe window_steps:10 avg_cycles:1.847 extra_cycle_frac:0.616 avg_stop:0.384 router_entropy:1.0608
+3500/50000 train_loss: 2.9085 train_time: 9.8m step_avg: 168.03ms tok/s: 3120154 art_cycles:1.781 extra_cycle_frac:0.594 art_continue:cycle1=1.000,cycle2=0.438,cycle3=0.786 art_entropy:0.9938 art_router_loss:-0.0145
+step:3500/50000 art_probe window_steps:10 avg_cycles:1.778 extra_cycle_frac:0.593 avg_stop:0.407 router_entropy:1.0414
+3510/50000 train_loss: 3.0405 train_time: 9.8m step_avg: 168.24ms tok/s: 3116369 art_cycles:1.688 extra_cycle_frac:0.562 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.467 art_entropy:1.0154 art_router_loss:-0.0010
+step:3510/50000 art_probe window_steps:10 avg_cycles:1.791 extra_cycle_frac:0.597 avg_stop:0.403 router_entropy:1.0588
+3520/50000 train_loss: 2.9785 train_time: 9.9m step_avg: 168.44ms tok/s: 3112598 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.469,cycle3=0.533 art_entropy:1.0156 art_router_loss:-0.0124
+step:3520/50000 art_probe window_steps:10 avg_cycles:1.797 extra_cycle_frac:0.599 avg_stop:0.401 router_entropy:1.0567
+3530/50000 train_loss: 2.9271 train_time: 9.9m step_avg: 168.65ms tok/s: 3108806 art_cycles:1.844 extra_cycle_frac:0.615 art_continue:cycle1=1.000,cycle2=0.594,cycle3=0.421 art_entropy:1.1022 art_router_loss:0.0027
+step:3530/50000 art_probe window_steps:10 avg_cycles:1.821 extra_cycle_frac:0.607 avg_stop:0.393 router_entropy:1.0683
+3540/50000 train_loss: 2.9651 train_time: 10.0m step_avg: 168.84ms tok/s: 3105146 art_cycles:1.719 extra_cycle_frac:0.573 art_continue:cycle1=1.000,cycle2=0.562,cycle3=0.278 art_entropy:1.0807 art_router_loss:-0.0082
+step:3540/50000 art_probe window_steps:10 avg_cycles:1.767 extra_cycle_frac:0.589 avg_stop:0.411 router_entropy:1.0532
+3550/50000 train_loss: 2.8818 train_time: 10.0m step_avg: 169.05ms tok/s: 3101313 art_cycles:1.812 extra_cycle_frac:0.604 art_continue:cycle1=1.000,cycle2=0.531,cycle3=0.529 art_entropy:1.0591 art_router_loss:0.0211
+step:3550/50000 art_probe window_steps:10 avg_cycles:1.866 extra_cycle_frac:0.622 avg_stop:0.378 router_entropy:1.0785
+3550/50000 val_loss: 2.9098 val_bpb: 1.1265
+stopping_early: wallclock_cap train_time: 600146ms step: 3550/50000
+peak memory allocated: 41861 MiB reserved: 45262 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:2.91385294 val_bpb:1.12804328 eval_time:6027ms
+pre-quantization post-ema_art_routes avg_cycles:1.788 extra_cycle_frac:0.596 art_entropy:1.0583 art_continue:cycle1=1.000,cycle2=0.529,cycle3=0.490
+Serialized model: 136234857 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:calibration path fixed_full
+GPTQ:collected 67 Hessians in 9.0s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): art_router.fc.bias, art_router.fc.weight, art_router.proj.bias, art_router.proj.weight, art_router_early.fc.bias, art_router_early.fc.weight, art_router_early.proj.bias, art_router_early.proj.weight, art_router_first.fc.bias, art_router_first.fc.weight, art_router_first.proj.bias, art_router_first.proj.weight, blocks.attn.attn_out_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, embed_scale, skip_gates, skip_weights
+Serialized model quantized+brotli: 16322006 bytes
+quantized val_loss:2.93618860 val_bpb:1.13669011 eval_time:6020ms
+quantized_art_routes avg_cycles:1.804 extra_cycle_frac:0.601 art_entropy:1.0635 art_continue:cycle1=1.000,cycle2=0.537,cycle3=0.499
+ttt:start chunks=619 windows=633409 ttt_lr=0.005 ttt_epochs=4
+quantized_ttt val_loss:2.88862455 val_bpb:1.11827658 eval_time:357058ms

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1855_simple_art_dashboard_20260430_224429_ad4a36d5.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1855_simple_art_dashboard_20260430_224429_ad4a36d5.stdout.log
@@ -1,0 +1,123 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260430_224429_ad4a36d5.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+  art_router_hidden_dim: 64
+  grad_accum_steps: 8
+  quantized_model_path: final_model.int6.ptz
+  world_size: 1
+model_params:36010266
+simple_art:enabled:1 enable_at:0.45 router_hidden:64 router_lr:0.0005 cycle_penalty:0.002 entropy:0.02->0.002 eval_mode:sample
+warmup_step: 1/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup_step: 1/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/20000 train_loss: 9.0247 train_time: 0.0m tok/s: 1159242
+2/20000 train_loss: 12.8638 train_time: 0.0m tok/s: 1142880
+3/20000 train_loss: 10.2122 train_time: 0.0m tok/s: 1132087
+4/20000 train_loss: 8.6768 train_time: 0.0m tok/s: 1127246
+5/20000 train_loss: 7.8743 train_time: 0.1m tok/s: 1117891
+10/20000 train_loss: 6.2745 train_time: 0.1m tok/s: 1119936
+20/20000 train_loss: 4.8344 train_time: 0.2m tok/s: 1120456
+30/20000 train_loss: 4.5192 train_time: 0.4m tok/s: 1122261
+40/20000 train_loss: 4.3365 train_time: 0.5m tok/s: 1122380
+50/20000 train_loss: 4.1732 train_time: 0.6m tok/s: 1122607
+60/20000 train_loss: 4.0473 train_time: 0.7m tok/s: 1122830
+70/20000 train_loss: 3.9026 train_time: 0.8m tok/s: 1123472
+80/20000 train_loss: 3.7741 train_time: 0.9m tok/s: 1123464
+90/20000 train_loss: 3.5805 train_time: 1.1m tok/s: 1122986
+100/20000 train_loss: 3.4914 train_time: 1.2m tok/s: 1122978
+110/20000 train_loss: 3.4533 train_time: 1.3m tok/s: 1122885
+120/20000 train_loss: 3.4093 train_time: 1.4m tok/s: 1122958
+130/20000 train_loss: 3.2586 train_time: 1.5m tok/s: 1121848
+140/20000 train_loss: 3.2422 train_time: 1.6m tok/s: 1120986
+150/20000 train_loss: 3.2266 train_time: 1.8m tok/s: 1120728
+160/20000 train_loss: 3.1612 train_time: 1.9m tok/s: 1119153
+170/20000 train_loss: 3.1102 train_time: 2.0m tok/s: 1118004
+180/20000 train_loss: 3.0357 train_time: 2.1m tok/s: 1116397
+190/20000 train_loss: 3.0795 train_time: 2.2m tok/s: 1116007
+200/20000 train_loss: 3.1048 train_time: 2.3m tok/s: 1116201
+210/20000 train_loss: 3.0523 train_time: 2.5m tok/s: 1116559
+220/20000 train_loss: 2.9483 train_time: 2.6m tok/s: 1116759
+230/20000 train_loss: 3.0044 train_time: 2.7m tok/s: 1117156
+240/20000 train_loss: 2.9959 train_time: 2.8m tok/s: 1117391
+250/20000 train_loss: 2.8992 train_time: 2.9m tok/s: 1117596
+260/20000 train_loss: 2.9975 train_time: 3.1m tok/s: 1117310
+270/20000 train_loss: 3.0359 train_time: 3.2m tok/s: 1117096
+280/20000 train_loss: 2.9101 train_time: 3.3m tok/s: 1115891
+290/20000 train_loss: 2.9290 train_time: 3.4m tok/s: 1116081
+300/20000 train_loss: 2.9230 train_time: 3.5m tok/s: 1110235
+310/20000 train_loss: 2.9365 train_time: 3.7m tok/s: 1093024
+320/20000 train_loss: 2.8800 train_time: 3.9m tok/s: 1077676
+330/20000 train_loss: 2.8599 train_time: 4.1m tok/s: 1063329
+340/20000 train_loss: 2.9867 train_time: 4.2m tok/s: 1050350
+350/20000 train_loss: 2.8518 train_time: 4.4m tok/s: 1038390
+simple_art:enabled step:353 frac:0.450
+simple_art:sync_done
+360/20000 train_loss: 2.9224 train_time: 4.6m tok/s: 1030382
+370/20000 train_loss: 2.7812 train_time: 4.7m tok/s: 1025292
+380/20000 train_loss: 2.8470 train_time: 4.9m tok/s: 1019587
+390/20000 train_loss: 2.7683 train_time: 5.0m tok/s: 1015659
+400/20000 train_loss: 2.7192 train_time: 5.2m tok/s: 1012955
+simple_art_probe step:400 samples:376 continue_action:0.404 continue_prob:0.412 entropy:0.6713 policy_loss:0.014397 baseline:2.7714
+410/20000 train_loss: 2.7818 train_time: 5.3m tok/s: 1008750
+420/20000 train_loss: 2.7371 train_time: 5.5m tok/s: 1004310
+430/20000 train_loss: 2.7681 train_time: 5.6m tok/s: 1000059
+440/20000 train_loss: 2.6848 train_time: 5.8m tok/s: 996283
+450/20000 train_loss: 2.7360 train_time: 5.9m tok/s: 992096
+simple_art_probe step:450 samples:400 continue_action:0.485 continue_prob:0.494 entropy:0.6913 policy_loss:-0.005241 baseline:2.7636
+460/20000 train_loss: 2.7148 train_time: 6.1m tok/s: 988765
+470/20000 train_loss: 2.8252 train_time: 6.2m tok/s: 985827
+480/20000 train_loss: 2.6719 train_time: 6.4m tok/s: 982024
+490/20000 train_loss: 2.7284 train_time: 6.6m tok/s: 978968
+500/20000 train_loss: 2.6405 train_time: 6.7m tok/s: 976931
+simple_art_probe step:500 samples:400 continue_action:0.512 continue_prob:0.518 entropy:0.6924 policy_loss:-0.002367 baseline:2.7158
+510/20000 train_loss: 2.7358 train_time: 6.9m tok/s: 972916
+520/20000 train_loss: 2.7648 train_time: 7.0m tok/s: 970441
+530/20000 train_loss: 2.7539 train_time: 7.2m tok/s: 967301
+540/20000 train_loss: 2.7079 train_time: 7.3m tok/s: 964045
+550/20000 train_loss: 2.6369 train_time: 7.5m tok/s: 961083
+simple_art_probe step:550 samples:400 continue_action:0.585 continue_prob:0.580 entropy:0.6791 policy_loss:-0.003125 baseline:2.6862
+560/20000 train_loss: 2.9367 train_time: 7.7m tok/s: 958357
+570/20000 train_loss: 2.6722 train_time: 7.8m tok/s: 956317
+580/20000 train_loss: 2.6813 train_time: 8.0m tok/s: 954241
+590/20000 train_loss: 2.6113 train_time: 8.1m tok/s: 951975
+600/20000 train_loss: 2.6323 train_time: 8.3m tok/s: 949218
+simple_art_probe step:600 samples:400 continue_action:0.598 continue_prob:0.609 entropy:0.6687 policy_loss:-0.003524 baseline:2.6664
+610/20000 train_loss: 2.6718 train_time: 8.4m tok/s: 947134
+620/20000 train_loss: 2.6462 train_time: 8.6m tok/s: 944549
+630/20000 train_loss: 2.6449 train_time: 8.8m tok/s: 941899
+640/20000 train_loss: 2.6163 train_time: 8.9m tok/s: 939902
+650/20000 train_loss: 2.6746 train_time: 9.1m tok/s: 937701
+simple_art_probe step:650 samples:400 continue_action:0.635 continue_prob:0.656 entropy:0.6433 policy_loss:-0.002594 baseline:2.6516
+660/20000 train_loss: 2.5707 train_time: 9.2m tok/s: 935503
+670/20000 train_loss: 2.6207 train_time: 9.4m tok/s: 933227
+680/20000 train_loss: 2.6490 train_time: 9.6m tok/s: 931037
+690/20000 train_loss: 2.5628 train_time: 9.7m tok/s: 929095
+700/20000 train_loss: 2.6664 train_time: 9.9m tok/s: 927546
+simple_art_probe step:700 samples:400 continue_action:0.685 continue_prob:0.677 entropy:0.6288 policy_loss:-0.001232 baseline:2.6153
+703/20000 val_loss: 2.6071 val_bpb: 1.1913
+stopping_early: wallclock_cap train_time: 596418ms step: 703/20000
+peak memory allocated: 42204 MiB reserved: 47322 MiB
+ema:applying EMA weights
+Serialized model: 135672498 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 4.5s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int6)+lqer_asym: blocks.mlp.fc.weight
+  gptq (int8)+lqer_asym: tok_emb.weight
+  passthrough (float16): art_router_fc.weight, art_router_proj.weight, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+GPTQ:quantized in 52.4s
+GPTQ:compressed+saved in 50.9s
+Serialized model quantized+brotli: 17032456 bytes
+artifact_production_wallclock: 967.399s (must be < 600.0)
+diagnostic pre-quantization post-ema val_loss:2.65239130 val_bpb:1.21201812 eval_time:26354ms
+diagnostic quantized val_loss:2.66041854 val_bpb:1.21568619 eval_time:41849ms
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (175.6s)
+quantized_ttt_phased val_loss:2.62586001 val_bpb:1.19991555 eval_time:2834007ms
+total_eval_time:2834.0s

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1855_soft_art_dashboard_20260430_204203_abf0ec8e.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/pr1855_soft_art_dashboard_20260430_204203_abf0ec8e.stdout.log
@@ -1,0 +1,591 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260430_204203_abf0ec8e.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+  art_delta_probe_every: 50
+  art_delta_probe_tokens: 2048
+  grad_accum_steps: 1
+  quantized_model_path: final_model.int6.ptz
+  world_size: 8
+model_params:35944680
+art_delta_gate:enabled:1 mode:tanh_sitegain window:12 scale:1 site_gates:1 tanh_range:1 init_alpha:1 repeated_only:1 probe_every:50 probe_tokens:2048
+warmup_step: 1/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup_step: 1/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/20000 train_loss: 9.0142 train_time: 0.0m tok/s: 6427004
+2/20000 train_loss: 12.8436 train_time: 0.0m tok/s: 7363207
+3/20000 train_loss: 10.1199 train_time: 0.0m tok/s: 7716534
+4/20000 train_loss: 8.5642 train_time: 0.0m tok/s: 7909997
+5/20000 train_loss: 7.8111 train_time: 0.0m tok/s: 8050589
+10/20000 train_loss: 6.3341 train_time: 0.0m tok/s: 8300168
+20/20000 train_loss: 4.8798 train_time: 0.0m tok/s: 8430476
+30/20000 train_loss: 4.6076 train_time: 0.0m tok/s: 8470778
+40/20000 train_loss: 4.3048 train_time: 0.1m tok/s: 8476418
+50/20000 train_loss: 4.0821 train_time: 0.1m tok/s: 8487201
+60/20000 train_loss: 4.0419 train_time: 0.1m tok/s: 8494470
+70/20000 train_loss: 3.9852 train_time: 0.1m tok/s: 8502205
+80/20000 train_loss: 3.8497 train_time: 0.1m tok/s: 8506515
+90/20000 train_loss: 3.5454 train_time: 0.1m tok/s: 8511455
+100/20000 train_loss: 3.5550 train_time: 0.2m tok/s: 8512299
+110/20000 train_loss: 3.4848 train_time: 0.2m tok/s: 8510749
+120/20000 train_loss: 3.4294 train_time: 0.2m tok/s: 8509568
+130/20000 train_loss: 3.2624 train_time: 0.2m tok/s: 8334370
+140/20000 train_loss: 3.1255 train_time: 0.2m tok/s: 8348872
+150/20000 train_loss: 3.1960 train_time: 0.2m tok/s: 8358676
+160/20000 train_loss: 3.1242 train_time: 0.3m tok/s: 8370886
+170/20000 train_loss: 3.0285 train_time: 0.3m tok/s: 8377484
+180/20000 train_loss: 2.9951 train_time: 0.3m tok/s: 8386592
+190/20000 train_loss: 3.1328 train_time: 0.3m tok/s: 8394446
+200/20000 train_loss: 3.1496 train_time: 0.3m tok/s: 8400707
+210/20000 train_loss: 3.0320 train_time: 0.3m tok/s: 8406623
+220/20000 train_loss: 2.9000 train_time: 0.3m tok/s: 8411669
+230/20000 train_loss: 3.0975 train_time: 0.4m tok/s: 8416609
+240/20000 train_loss: 2.9971 train_time: 0.4m tok/s: 8419235
+250/20000 train_loss: 2.9340 train_time: 0.4m tok/s: 8423568
+260/20000 train_loss: 3.0274 train_time: 0.4m tok/s: 8340809
+270/20000 train_loss: 3.2167 train_time: 0.4m tok/s: 8346367
+280/20000 train_loss: 2.9351 train_time: 0.4m tok/s: 8351419
+290/20000 train_loss: 3.0122 train_time: 0.5m tok/s: 8356840
+300/20000 train_loss: 2.9235 train_time: 0.5m tok/s: 8361052
+310/20000 train_loss: 2.9949 train_time: 0.5m tok/s: 8364939
+320/20000 train_loss: 2.8644 train_time: 0.5m tok/s: 8369047
+330/20000 train_loss: 2.9469 train_time: 0.5m tok/s: 8372935
+340/20000 train_loss: 2.9861 train_time: 0.5m tok/s: 8376456
+350/20000 train_loss: 2.9154 train_time: 0.5m tok/s: 8378878
+360/20000 train_loss: 2.9386 train_time: 0.6m tok/s: 8382372
+370/20000 train_loss: 2.7387 train_time: 0.6m tok/s: 8384584
+380/20000 train_loss: 2.9397 train_time: 0.6m tok/s: 8386009
+390/20000 train_loss: 2.8909 train_time: 0.6m tok/s: 8333091
+400/20000 train_loss: 2.5920 train_time: 0.6m tok/s: 8335640
+410/20000 train_loss: 2.8694 train_time: 0.6m tok/s: 8339565
+420/20000 train_loss: 2.8586 train_time: 0.7m tok/s: 8342728
+430/20000 train_loss: 2.8887 train_time: 0.7m tok/s: 8345965
+440/20000 train_loss: 2.7573 train_time: 0.7m tok/s: 8349065
+450/20000 train_loss: 2.8408 train_time: 0.7m tok/s: 8351590
+460/20000 train_loss: 2.7162 train_time: 0.7m tok/s: 8353796
+470/20000 train_loss: 2.8842 train_time: 0.7m tok/s: 8355527
+480/20000 train_loss: 2.6888 train_time: 0.8m tok/s: 8357644
+490/20000 train_loss: 2.7876 train_time: 0.8m tok/s: 8360354
+500/20000 train_loss: 2.5852 train_time: 0.8m tok/s: 8362387
+510/20000 train_loss: 2.7836 train_time: 0.8m tok/s: 8320119
+520/20000 train_loss: 2.7835 train_time: 0.8m tok/s: 8322837
+530/20000 train_loss: 2.7249 train_time: 0.8m tok/s: 8325266
+540/20000 train_loss: 2.7467 train_time: 0.8m tok/s: 8328187
+550/20000 train_loss: 2.7379 train_time: 0.9m tok/s: 8330848
+560/20000 train_loss: 3.3228 train_time: 0.9m tok/s: 8333986
+570/20000 train_loss: 2.6518 train_time: 0.9m tok/s: 8336346
+580/20000 train_loss: 2.7685 train_time: 0.9m tok/s: 8338349
+590/20000 train_loss: 2.6574 train_time: 0.9m tok/s: 8340046
+600/20000 train_loss: 2.6820 train_time: 0.9m tok/s: 8342676
+610/20000 train_loss: 3.0132 train_time: 1.0m tok/s: 8344761
+620/20000 train_loss: 2.7686 train_time: 1.0m tok/s: 8346927
+630/20000 train_loss: 2.7526 train_time: 1.0m tok/s: 8349117
+640/20000 train_loss: 2.6592 train_time: 1.0m tok/s: 8317367
+650/20000 train_loss: 2.7111 train_time: 1.0m tok/s: 8319171
+660/20000 train_loss: 2.7693 train_time: 1.0m tok/s: 8320756
+670/20000 train_loss: 2.8040 train_time: 1.1m tok/s: 8323187
+680/20000 train_loss: 2.7716 train_time: 1.1m tok/s: 8325309
+690/20000 train_loss: 2.6236 train_time: 1.1m tok/s: 8327081
+700/20000 train_loss: 2.8839 train_time: 1.1m tok/s: 8329059
+710/20000 train_loss: 2.8000 train_time: 1.1m tok/s: 8331086
+720/20000 train_loss: 2.8081 train_time: 1.1m tok/s: 8332441
+730/20000 train_loss: 2.7711 train_time: 1.1m tok/s: 8334710
+740/20000 train_loss: 2.9064 train_time: 1.2m tok/s: 8336606
+750/20000 train_loss: 2.7425 train_time: 1.2m tok/s: 8338256
+760/20000 train_loss: 2.6780 train_time: 1.2m tok/s: 8340018
+770/20000 train_loss: 2.8110 train_time: 1.2m tok/s: 8313539
+780/20000 train_loss: 2.8207 train_time: 1.2m tok/s: 8314987
+790/20000 train_loss: 2.7900 train_time: 1.2m tok/s: 8316901
+800/20000 train_loss: 2.7216 train_time: 1.3m tok/s: 8318387
+810/20000 train_loss: 2.7781 train_time: 1.3m tok/s: 8320196
+820/20000 train_loss: 2.6647 train_time: 1.3m tok/s: 8321680
+830/20000 train_loss: 2.7415 train_time: 1.3m tok/s: 8323141
+840/20000 train_loss: 2.9691 train_time: 1.3m tok/s: 8324952
+850/20000 train_loss: 2.8358 train_time: 1.3m tok/s: 8326895
+860/20000 train_loss: 2.7562 train_time: 1.4m tok/s: 8328739
+870/20000 train_loss: 2.3836 train_time: 1.4m tok/s: 8329623
+880/20000 train_loss: 2.9304 train_time: 1.4m tok/s: 8331376
+890/20000 train_loss: 2.8136 train_time: 1.4m tok/s: 8307362
+900/20000 train_loss: 2.5736 train_time: 1.4m tok/s: 8308898
+910/20000 train_loss: 2.7502 train_time: 1.4m tok/s: 8310062
+920/20000 train_loss: 2.7203 train_time: 1.5m tok/s: 8311505
+930/20000 train_loss: 2.9370 train_time: 1.5m tok/s: 8313324
+940/20000 train_loss: 2.7268 train_time: 1.5m tok/s: 8314876
+950/20000 train_loss: 2.7596 train_time: 1.5m tok/s: 8316067
+960/20000 train_loss: 2.7366 train_time: 1.5m tok/s: 8317346
+970/20000 train_loss: 2.7889 train_time: 1.5m tok/s: 8318878
+980/20000 train_loss: 2.8001 train_time: 1.5m tok/s: 8320143
+990/20000 train_loss: 2.7395 train_time: 1.6m tok/s: 8321680
+1000/20000 train_loss: 2.9804 train_time: 1.6m tok/s: 8322408
+1010/20000 train_loss: 2.7172 train_time: 1.6m tok/s: 8323796
+1020/20000 train_loss: 2.7120 train_time: 1.6m tok/s: 8304287
+1030/20000 train_loss: 2.6094 train_time: 1.6m tok/s: 8305762
+1040/20000 train_loss: 2.7493 train_time: 1.6m tok/s: 8307138
+1050/20000 train_loss: 2.7404 train_time: 1.7m tok/s: 8309045
+1060/20000 train_loss: 2.7035 train_time: 1.7m tok/s: 8310524
+1070/20000 train_loss: 2.7360 train_time: 1.7m tok/s: 8312007
+1080/20000 train_loss: 2.7561 train_time: 1.7m tok/s: 8313465
+1090/20000 train_loss: 2.6660 train_time: 1.7m tok/s: 8314771
+1100/20000 train_loss: 2.6837 train_time: 1.7m tok/s: 8316479
+1110/20000 train_loss: 2.7340 train_time: 1.7m tok/s: 8317545
+1120/20000 train_loss: 2.6415 train_time: 1.8m tok/s: 8318615
+1130/20000 train_loss: 2.7303 train_time: 1.8m tok/s: 8319912
+1140/20000 train_loss: 2.7296 train_time: 1.8m tok/s: 8321319
+1150/20000 train_loss: 2.6047 train_time: 1.8m tok/s: 8303713
+1160/20000 train_loss: 2.8121 train_time: 1.8m tok/s: 8305049
+1170/20000 train_loss: 2.6741 train_time: 1.8m tok/s: 8306341
+1180/20000 train_loss: 2.6513 train_time: 1.9m tok/s: 8307726
+1190/20000 train_loss: 2.7914 train_time: 1.9m tok/s: 8308956
+1200/20000 train_loss: 2.6612 train_time: 1.9m tok/s: 8310356
+1210/20000 train_loss: 2.6997 train_time: 1.9m tok/s: 8311451
+1220/20000 train_loss: 2.6783 train_time: 1.9m tok/s: 8312791
+1230/20000 train_loss: 2.7277 train_time: 1.9m tok/s: 8314145
+1240/20000 train_loss: 2.7517 train_time: 2.0m tok/s: 8315162
+1250/20000 train_loss: 2.7195 train_time: 2.0m tok/s: 8316360
+1260/20000 train_loss: 3.3058 train_time: 2.0m tok/s: 8317236
+1270/20000 train_loss: 2.8234 train_time: 2.0m tok/s: 8318136
+1280/20000 train_loss: 2.6414 train_time: 2.0m tok/s: 8302797
+1290/20000 train_loss: 2.5711 train_time: 2.0m tok/s: 8304211
+1300/20000 train_loss: 2.7097 train_time: 2.1m tok/s: 8305335
+1310/20000 train_loss: 2.7723 train_time: 2.1m tok/s: 8306803
+1320/20000 train_loss: 2.6629 train_time: 2.1m tok/s: 8307849
+1330/20000 train_loss: 2.8084 train_time: 2.1m tok/s: 8309189
+1340/20000 train_loss: 2.7149 train_time: 2.1m tok/s: 8310404
+1350/20000 train_loss: 2.7031 train_time: 2.1m tok/s: 8311167
+1360/20000 train_loss: 2.7647 train_time: 2.1m tok/s: 8312370
+1370/20000 train_loss: 2.7083 train_time: 2.2m tok/s: 8313582
+1380/20000 train_loss: 2.9098 train_time: 2.2m tok/s: 8314863
+1390/20000 train_loss: 2.7107 train_time: 2.2m tok/s: 8315904
+1400/20000 train_loss: 2.5335 train_time: 2.2m tok/s: 8301578
+1410/20000 train_loss: 2.7985 train_time: 2.2m tok/s: 8302634
+1420/20000 train_loss: 2.6982 train_time: 2.2m tok/s: 8303917
+1430/20000 train_loss: 2.6335 train_time: 2.3m tok/s: 8305071
+1440/20000 train_loss: 2.6778 train_time: 2.3m tok/s: 8306123
+1450/20000 train_loss: 2.5661 train_time: 2.3m tok/s: 8307059
+1460/20000 train_loss: 2.7026 train_time: 2.3m tok/s: 8308051
+1470/20000 train_loss: 2.5721 train_time: 2.3m tok/s: 8309091
+1480/20000 train_loss: 2.5578 train_time: 2.3m tok/s: 8310258
+1490/20000 train_loss: 2.6728 train_time: 2.3m tok/s: 8311224
+1500/20000 train_loss: 2.7073 train_time: 2.4m tok/s: 8312087
+1510/20000 train_loss: 2.6932 train_time: 2.4m tok/s: 8313201
+1520/20000 train_loss: 2.7073 train_time: 2.4m tok/s: 8314147
+1530/20000 train_loss: 2.6297 train_time: 2.4m tok/s: 8300860
+1540/20000 train_loss: 2.7724 train_time: 2.4m tok/s: 8301987
+1550/20000 train_loss: 2.6790 train_time: 2.4m tok/s: 8302968
+1560/20000 train_loss: 2.7146 train_time: 2.5m tok/s: 8304065
+1570/20000 train_loss: 2.6861 train_time: 2.5m tok/s: 8305136
+1580/20000 train_loss: 2.8693 train_time: 2.5m tok/s: 8306282
+1590/20000 train_loss: 2.7260 train_time: 2.5m tok/s: 8307409
+1600/20000 train_loss: 2.7257 train_time: 2.5m tok/s: 8308403
+1610/20000 train_loss: 2.9136 train_time: 2.5m tok/s: 8309355
+1620/20000 train_loss: 2.5772 train_time: 2.6m tok/s: 8310435
+1630/20000 train_loss: 2.6652 train_time: 2.6m tok/s: 8311375
+1640/20000 train_loss: 2.7244 train_time: 2.6m tok/s: 8312447
+1650/20000 train_loss: 2.6238 train_time: 2.6m tok/s: 8313073
+1660/20000 train_loss: 2.6554 train_time: 2.6m tok/s: 8301038
+1670/20000 train_loss: 2.7601 train_time: 2.6m tok/s: 8301827
+1680/20000 train_loss: 2.5241 train_time: 2.7m tok/s: 8302460
+1690/20000 train_loss: 3.0541 train_time: 2.7m tok/s: 8303581
+1700/20000 train_loss: 2.6769 train_time: 2.7m tok/s: 8304731
+1710/20000 train_loss: 2.7169 train_time: 2.7m tok/s: 8305874
+1720/20000 train_loss: 2.5458 train_time: 2.7m tok/s: 8306710
+1730/20000 train_loss: 2.7068 train_time: 2.7m tok/s: 8307729
+1740/20000 train_loss: 2.7879 train_time: 2.7m tok/s: 8308621
+1750/20000 train_loss: 2.6779 train_time: 2.8m tok/s: 8309696
+1760/20000 train_loss: 2.6013 train_time: 2.8m tok/s: 8310621
+1770/20000 train_loss: 2.5073 train_time: 2.8m tok/s: 8311446
+1780/20000 train_loss: 2.6441 train_time: 2.8m tok/s: 8300401
+1790/20000 train_loss: 2.7945 train_time: 2.8m tok/s: 8301322
+1800/20000 train_loss: 2.8017 train_time: 2.8m tok/s: 8302494
+1810/20000 train_loss: 2.7869 train_time: 2.9m tok/s: 8303608
+1820/20000 train_loss: 2.7206 train_time: 2.9m tok/s: 8304710
+1830/20000 train_loss: 2.6700 train_time: 2.9m tok/s: 8305575
+1840/20000 train_loss: 2.5896 train_time: 2.9m tok/s: 8306482
+1850/20000 train_loss: 2.7248 train_time: 2.9m tok/s: 8307495
+1860/20000 train_loss: 2.6496 train_time: 2.9m tok/s: 8308440
+1870/20000 train_loss: 2.6661 train_time: 2.9m tok/s: 8309552
+1880/20000 train_loss: 2.5856 train_time: 3.0m tok/s: 8310376
+1890/20000 train_loss: 2.6435 train_time: 3.0m tok/s: 8311349
+1900/20000 train_loss: 2.6693 train_time: 3.0m tok/s: 8312106
+1910/20000 train_loss: 2.4837 train_time: 3.0m tok/s: 8301605
+1920/20000 train_loss: 2.6543 train_time: 3.0m tok/s: 8302284
+1930/20000 train_loss: 2.7299 train_time: 3.0m tok/s: 8303162
+1940/20000 train_loss: 2.8124 train_time: 3.1m tok/s: 8303930
+1950/20000 train_loss: 2.6399 train_time: 3.1m tok/s: 8304836
+1960/20000 train_loss: 2.6508 train_time: 3.1m tok/s: 8305888
+1970/20000 train_loss: 2.6281 train_time: 3.1m tok/s: 8306789
+1980/20000 train_loss: 2.6800 train_time: 3.1m tok/s: 8307599
+1990/20000 train_loss: 2.6295 train_time: 3.1m tok/s: 8308390
+2000/20000 train_loss: 2.7023 train_time: 3.2m tok/s: 8309129
+2010/20000 train_loss: 2.5388 train_time: 3.2m tok/s: 8310072
+2020/20000 train_loss: 2.7092 train_time: 3.2m tok/s: 8310911
+2030/20000 train_loss: 2.4877 train_time: 3.2m tok/s: 8311607
+2040/20000 train_loss: 2.6190 train_time: 3.2m tok/s: 8302064
+2050/20000 train_loss: 2.7744 train_time: 3.2m tok/s: 8302742
+2060/20000 train_loss: 2.5937 train_time: 3.3m tok/s: 8303553
+2070/20000 train_loss: 2.4593 train_time: 3.3m tok/s: 8304287
+2080/20000 train_loss: 2.6371 train_time: 3.3m tok/s: 8304990
+2090/20000 train_loss: 2.5961 train_time: 3.3m tok/s: 8305860
+2100/20000 train_loss: 2.6939 train_time: 3.3m tok/s: 8306597
+2110/20000 train_loss: 2.7085 train_time: 3.3m tok/s: 8307302
+2120/20000 train_loss: 2.5575 train_time: 3.3m tok/s: 8308146
+2130/20000 train_loss: 2.5709 train_time: 3.4m tok/s: 8308832
+2140/20000 train_loss: 2.6773 train_time: 3.4m tok/s: 8309396
+2150/20000 train_loss: 2.6186 train_time: 3.4m tok/s: 8310196
+2160/20000 train_loss: 2.5904 train_time: 3.4m tok/s: 8300885
+2170/20000 train_loss: 2.5814 train_time: 3.4m tok/s: 8301730
+2180/20000 train_loss: 2.7684 train_time: 3.4m tok/s: 8302595
+2190/20000 train_loss: 2.7062 train_time: 3.5m tok/s: 8303540
+2200/20000 train_loss: 2.6928 train_time: 3.5m tok/s: 8304359
+2210/20000 train_loss: 2.5782 train_time: 3.5m tok/s: 8292208
+2220/20000 train_loss: 2.7304 train_time: 3.5m tok/s: 8275297
+2230/20000 train_loss: 2.6156 train_time: 3.5m tok/s: 8258640
+2240/20000 train_loss: 2.5594 train_time: 3.6m tok/s: 8241991
+2250/20000 train_loss: 2.5913 train_time: 3.6m tok/s: 8225651
+art_delta_probe step:2250 sites:6 alpha_mean:0.2194 alpha_std:0.0793 alpha_min:0.0000 alpha_max:1.3203 logit_mean:-1.9263 logit_std:0.7961 delta_rms:2.16830 gated_delta_rms:0.54063 gate_w_rms:0.146795 gate_w_max:0.220246 gate_b_mean:-0.171764 gate_b_min:-0.224890 gate_b_max:-0.101248 sites:s0:b3o2:a0.039/r0.116,s2:b4o2:a0.019/r0.047,s4:b5o2:a0.075/r0.139,s1:b3o3:a0.091/r0.120,s3:b4o3:a0.345/r0.360,s5:b5o3:a0.748/r0.754
+2260/20000 train_loss: 2.5261 train_time: 3.6m tok/s: 8203341
+2270/20000 train_loss: 2.6352 train_time: 3.6m tok/s: 8187328
+2280/20000 train_loss: 2.8505 train_time: 3.7m tok/s: 8171003
+2290/20000 train_loss: 2.5981 train_time: 3.7m tok/s: 8149681
+2300/20000 train_loss: 2.6477 train_time: 3.7m tok/s: 8134103
+art_delta_probe step:2300 sites:6 alpha_mean:0.6326 alpha_std:0.2160 alpha_min:0.0000 alpha_max:1.9062 logit_mean:-0.4382 logit_std:0.3247 delta_rms:1.95583 gated_delta_rms:1.31856 gate_w_rms:0.086948 gate_w_max:0.189043 gate_b_mean:-0.145615 gate_b_min:-0.302090 gate_b_max:-0.077108 sites:s0:b3o2:a0.428/r0.489,s2:b4o2:a0.730/r0.841,s4:b5o2:a0.779/r0.917,s1:b3o3:a0.453/r0.468,s3:b4o3:a0.569/r0.576,s5:b5o3:a0.837/r0.842
+2310/20000 train_loss: 2.6416 train_time: 3.7m tok/s: 8118296
+2320/20000 train_loss: 2.6833 train_time: 3.8m tok/s: 8103086
+2330/20000 train_loss: 2.4890 train_time: 3.8m tok/s: 8088169
+2340/20000 train_loss: 2.5532 train_time: 3.8m tok/s: 8073429
+2350/20000 train_loss: 2.6422 train_time: 3.8m tok/s: 8058938
+art_delta_probe step:2350 sites:6 alpha_mean:0.8872 alpha_std:0.1618 alpha_min:0.0000 alpha_max:1.8438 logit_mean:-0.1209 logit_std:0.1923 delta_rms:1.85252 gated_delta_rms:1.67440 gate_w_rms:0.047264 gate_w_max:0.145002 gate_b_mean:-0.123360 gate_b_min:-0.313544 gate_b_max:0.000790 sites:s0:b3o2:a0.799/r0.813,s2:b4o2:a1.217/r1.252,s4:b5o2:a1.238/r1.279,s1:b3o3:a0.562/r0.586,s3:b4o3:a0.654/r0.669,s5:b5o3:a0.854/r0.862
+2360/20000 train_loss: 2.6016 train_time: 3.8m tok/s: 8043945
+2370/20000 train_loss: 2.6331 train_time: 3.9m tok/s: 8029745
+2380/20000 train_loss: 2.4796 train_time: 3.9m tok/s: 8015764
+2390/20000 train_loss: 2.5946 train_time: 3.9m tok/s: 8001943
+2400/20000 train_loss: 2.6556 train_time: 3.9m tok/s: 7988013
+art_delta_probe step:2400 sites:6 alpha_mean:0.9453 alpha_std:0.1612 alpha_min:0.0078 alpha_max:1.8594 logit_mean:-0.0550 logit_std:0.1844 delta_rms:1.78592 gated_delta_rms:1.71661 gate_w_rms:0.037132 gate_w_max:0.134402 gate_b_mean:-0.093784 gate_b_min:-0.267610 gate_b_max:0.080415 sites:s0:b3o2:a0.893/r0.904,s2:b4o2:a1.228/r1.257,s4:b5o2:a1.313/r1.351,s1:b3o3:a0.633/r0.655,s3:b4o3:a0.735/r0.755,s5:b5o3:a0.870/r0.879
+2410/20000 train_loss: 2.5277 train_time: 4.0m tok/s: 7973679
+2420/20000 train_loss: 2.5932 train_time: 4.0m tok/s: 7955257
+2430/20000 train_loss: 2.5653 train_time: 4.0m tok/s: 7941974
+2440/20000 train_loss: 2.5887 train_time: 4.0m tok/s: 7929122
+2450/20000 train_loss: 2.5940 train_time: 4.1m tok/s: 7916225
+art_delta_probe step:2450 sites:6 alpha_mean:0.9976 alpha_std:0.1526 alpha_min:0.0273 alpha_max:1.8281 logit_mean:0.0019 logit_std:0.1708 delta_rms:1.72277 gated_delta_rms:1.74894 gate_w_rms:0.034894 gate_w_max:0.137354 gate_b_mean:-0.071317 gate_b_min:-0.218052 gate_b_max:0.127998 sites:s0:b3o2:a0.941/r0.955,s2:b4o2:a1.303/r1.325,s4:b5o2:a1.350/r1.372,s1:b3o3:a0.723/r0.745,s3:b4o3:a0.774/r0.799,s5:b5o3:a0.895/r0.911
+2460/20000 train_loss: 2.4701 train_time: 4.1m tok/s: 7903027
+2470/20000 train_loss: 2.5317 train_time: 4.1m tok/s: 7890604
+2480/20000 train_loss: 2.6042 train_time: 4.1m tok/s: 7878010
+2490/20000 train_loss: 2.5698 train_time: 4.1m tok/s: 7865738
+2500/20000 train_loss: 2.5958 train_time: 4.2m tok/s: 7853601
+art_delta_probe step:2500 sites:6 alpha_mean:1.0132 alpha_std:0.1512 alpha_min:0.0742 alpha_max:1.8438 logit_mean:0.0199 logit_std:0.1677 delta_rms:1.66986 gated_delta_rms:1.72227 gate_w_rms:0.032483 gate_w_max:0.137990 gate_b_mean:-0.054223 gate_b_min:-0.191481 gate_b_max:0.163510 sites:s0:b3o2:a0.984/r0.996,s2:b4o2:a1.282/r1.306,s4:b5o2:a1.388/r1.411,s1:b3o3:a0.758/r0.783,s3:b4o3:a0.802/r0.826,s5:b5o3:a0.865/r0.880
+2510/20000 train_loss: 2.7007 train_time: 4.2m tok/s: 7840943
+2520/20000 train_loss: 2.4839 train_time: 4.2m tok/s: 7829121
+2530/20000 train_loss: 2.5348 train_time: 4.2m tok/s: 7817418
+2540/20000 train_loss: 2.5349 train_time: 4.3m tok/s: 7805756
+2550/20000 train_loss: 2.4977 train_time: 4.3m tok/s: 7789488
+art_delta_probe step:2550 sites:6 alpha_mean:1.0381 alpha_std:0.1446 alpha_min:0.0391 alpha_max:1.8359 logit_mean:0.0456 logit_std:0.1595 delta_rms:1.64396 gated_delta_rms:1.73327 gate_w_rms:0.030360 gate_w_max:0.128675 gate_b_mean:-0.037283 gate_b_min:-0.172251 gate_b_max:0.190502 sites:s0:b3o2:a1.003/r1.011,s2:b4o2:a1.324/r1.336,s4:b5o2:a1.376/r1.392,s1:b3o3:a0.827/r0.849,s3:b4o3:a0.845/r0.871,s5:b5o3:a0.854/r0.867
+2560/20000 train_loss: 2.5543 train_time: 4.3m tok/s: 7777385
+2570/20000 train_loss: 2.5750 train_time: 4.3m tok/s: 7766236
+2580/20000 train_loss: 2.4804 train_time: 4.4m tok/s: 7755314
+2590/20000 train_loss: 2.6060 train_time: 4.4m tok/s: 7744418
+2600/20000 train_loss: 2.5737 train_time: 4.4m tok/s: 7733551
+art_delta_probe step:2600 sites:6 alpha_mean:1.0484 alpha_std:0.1394 alpha_min:0.0469 alpha_max:1.8438 logit_mean:0.0569 logit_std:0.1544 delta_rms:1.58536 gated_delta_rms:1.68815 gate_w_rms:0.030245 gate_w_max:0.138738 gate_b_mean:-0.027503 gate_b_min:-0.178017 gate_b_max:0.210681 sites:s0:b3o2:a1.059/r1.066,s2:b4o2:a1.287/r1.300,s4:b5o2:a1.410/r1.429,s1:b3o3:a0.830/r0.850,s3:b4o3:a0.849/r0.874,s5:b5o3:a0.855/r0.869
+2610/20000 train_loss: 2.6960 train_time: 4.4m tok/s: 7722092
+2620/20000 train_loss: 2.6451 train_time: 4.5m tok/s: 7711233
+2630/20000 train_loss: 2.6987 train_time: 4.5m tok/s: 7700473
+2640/20000 train_loss: 2.4504 train_time: 4.5m tok/s: 7689978
+2650/20000 train_loss: 2.5274 train_time: 4.5m tok/s: 7679689
+art_delta_probe step:2650 sites:6 alpha_mean:1.0614 alpha_std:0.1483 alpha_min:0.0391 alpha_max:1.7969 logit_mean:0.0698 logit_std:0.1632 delta_rms:1.54572 gated_delta_rms:1.67179 gate_w_rms:0.030959 gate_w_max:0.125153 gate_b_mean:-0.017565 gate_b_min:-0.157280 gate_b_max:0.228508 sites:s0:b3o2:a1.036/r1.047,s2:b4o2:a1.373/r1.389,s4:b5o2:a1.364/r1.382,s1:b3o3:a0.864/r0.887,s3:b4o3:a0.869/r0.898,s5:b5o3:a0.862/r0.880
+2660/20000 train_loss: 2.6285 train_time: 4.5m tok/s: 7668854
+2670/20000 train_loss: 2.6246 train_time: 4.6m tok/s: 7654367
+2680/20000 train_loss: 2.4549 train_time: 4.6m tok/s: 7644405
+2690/20000 train_loss: 2.4991 train_time: 4.6m tok/s: 7634432
+2700/20000 train_loss: 2.4411 train_time: 4.6m tok/s: 7624661
+art_delta_probe step:2700 sites:6 alpha_mean:1.0504 alpha_std:0.1506 alpha_min:0.0156 alpha_max:1.8203 logit_mean:0.0562 logit_std:0.1650 delta_rms:1.53191 gated_delta_rms:1.63941 gate_w_rms:0.030767 gate_w_max:0.129760 gate_b_mean:-0.013738 gate_b_min:-0.154926 gate_b_max:0.230109 sites:s0:b3o2:a1.050/r1.057,s2:b4o2:a1.311/r1.329,s4:b5o2:a1.339/r1.350,s1:b3o3:a0.881/r0.906,s3:b4o3:a0.878/r0.911,s5:b5o3:a0.843/r0.860
+2710/20000 train_loss: 2.4310 train_time: 4.7m tok/s: 7614467
+2720/20000 train_loss: 2.5514 train_time: 4.7m tok/s: 7604721
+2730/20000 train_loss: 2.6255 train_time: 4.7m tok/s: 7595300
+2740/20000 train_loss: 2.5626 train_time: 4.7m tok/s: 7585779
+2750/20000 train_loss: 2.5385 train_time: 4.8m tok/s: 7576469
+art_delta_probe step:2750 sites:6 alpha_mean:1.0704 alpha_std:0.1485 alpha_min:0.0469 alpha_max:1.7969 logit_mean:0.0783 logit_std:0.1622 delta_rms:1.49403 gated_delta_rms:1.62673 gate_w_rms:0.031232 gate_w_max:0.122327 gate_b_mean:-0.006704 gate_b_min:-0.133069 gate_b_max:0.234472 sites:s0:b3o2:a1.070/r1.076,s2:b4o2:a1.328/r1.343,s4:b5o2:a1.375/r1.378,s1:b3o3:a0.907/r0.935,s3:b4o3:a0.889/r0.918,s5:b5o3:a0.854/r0.875
+2760/20000 train_loss: 2.6222 train_time: 4.8m tok/s: 7566721
+2770/20000 train_loss: 2.5881 train_time: 4.8m tok/s: 7557545
+2780/20000 train_loss: 2.6261 train_time: 4.8m tok/s: 7548509
+2790/20000 train_loss: 2.4503 train_time: 4.9m tok/s: 7539406
+2800/20000 train_loss: 2.5813 train_time: 4.9m tok/s: 7526697
+art_delta_probe step:2800 sites:6 alpha_mean:1.0628 alpha_std:0.1514 alpha_min:0.0273 alpha_max:1.7812 logit_mean:0.0693 logit_std:0.1650 delta_rms:1.44093 gated_delta_rms:1.55599 gate_w_rms:0.030919 gate_w_max:0.114675 gate_b_mean:-0.004967 gate_b_min:-0.129152 gate_b_max:0.237934 sites:s0:b3o2:a1.056/r1.062,s2:b4o2:a1.297/r1.319,s4:b5o2:a1.357/r1.355,s1:b3o3:a0.936/r0.958,s3:b4o3:a0.885/r0.917,s5:b5o3:a0.845/r0.858
+2810/20000 train_loss: 2.5114 train_time: 4.9m tok/s: 7517434
+2820/20000 train_loss: 2.5352 train_time: 4.9m tok/s: 7508766
+2830/20000 train_loss: 2.6140 train_time: 4.9m tok/s: 7500172
+2840/20000 train_loss: 2.5769 train_time: 5.0m tok/s: 7491574
+2850/20000 train_loss: 2.5882 train_time: 5.0m tok/s: 7482992
+art_delta_probe step:2850 sites:6 alpha_mean:1.0689 alpha_std:0.1472 alpha_min:0.0234 alpha_max:1.8125 logit_mean:0.0758 logit_std:0.1610 delta_rms:1.39366 gated_delta_rms:1.51871 gate_w_rms:0.031072 gate_w_max:0.123104 gate_b_mean:-0.004319 gate_b_min:-0.133872 gate_b_max:0.233213 sites:s0:b3o2:a1.115/r1.123,s2:b4o2:a1.299/r1.321,s4:b5o2:a1.364/r1.373,s1:b3o3:a0.918/r0.939,s3:b4o3:a0.883/r0.914,s5:b5o3:a0.833/r0.854
+2860/20000 train_loss: 2.6193 train_time: 5.0m tok/s: 7474226
+2870/20000 train_loss: 2.4736 train_time: 5.0m tok/s: 7465983
+2880/20000 train_loss: 2.6052 train_time: 5.1m tok/s: 7457890
+2890/20000 train_loss: 2.4654 train_time: 5.1m tok/s: 7449795
+2900/20000 train_loss: 2.5557 train_time: 5.1m tok/s: 7441792
+art_delta_probe step:2900 sites:6 alpha_mean:1.0742 alpha_std:0.1440 alpha_min:0.0430 alpha_max:1.7891 logit_mean:0.0812 logit_std:0.1569 delta_rms:1.36323 gated_delta_rms:1.49297 gate_w_rms:0.031629 gate_w_max:0.119413 gate_b_mean:-0.002457 gate_b_min:-0.140109 gate_b_max:0.229292 sites:s0:b3o2:a1.088/r1.093,s2:b4o2:a1.347/r1.363,s4:b5o2:a1.337/r1.349,s1:b3o3:a0.947/r0.969,s3:b4o3:a0.893/r0.925,s5:b5o3:a0.833/r0.857
+2910/20000 train_loss: 2.6067 train_time: 5.1m tok/s: 7433341
+2920/20000 train_loss: 2.4156 train_time: 5.2m tok/s: 7425188
+2930/20000 train_loss: 2.5044 train_time: 5.2m tok/s: 7413748
+2940/20000 train_loss: 2.5823 train_time: 5.2m tok/s: 7406064
+2950/20000 train_loss: 2.6334 train_time: 5.2m tok/s: 7398263
+art_delta_probe step:2950 sites:6 alpha_mean:1.0662 alpha_std:0.1474 alpha_min:0.0469 alpha_max:1.7500 logit_mean:0.0716 logit_std:0.1595 delta_rms:1.32759 gated_delta_rms:1.44153 gate_w_rms:0.031825 gate_w_max:0.118788 gate_b_mean:-0.003205 gate_b_min:-0.150340 gate_b_max:0.233486 sites:s0:b3o2:a1.096/r1.100,s2:b4o2:a1.299/r1.316,s4:b5o2:a1.327/r1.337,s1:b3o3:a0.932/r0.952,s3:b4o3:a0.914/r0.947,s5:b5o3:a0.829/r0.852
+2960/20000 train_loss: 2.4629 train_time: 5.2m tok/s: 7390258
+2970/20000 train_loss: 2.5776 train_time: 5.3m tok/s: 7382539
+2980/20000 train_loss: 2.4619 train_time: 5.3m tok/s: 7375147
+2990/20000 train_loss: 2.5156 train_time: 5.3m tok/s: 7367686
+3000/20000 train_loss: 2.3740 train_time: 5.3m tok/s: 7360419
+art_delta_probe step:3000 sites:6 alpha_mean:1.0732 alpha_std:0.1454 alpha_min:0.0312 alpha_max:1.7812 logit_mean:0.0793 logit_std:0.1581 delta_rms:1.30412 gated_delta_rms:1.42682 gate_w_rms:0.031346 gate_w_max:0.121850 gate_b_mean:-0.001620 gate_b_min:-0.155907 gate_b_max:0.238955 sites:s0:b3o2:a1.104/r1.109,s2:b4o2:a1.325/r1.342,s4:b5o2:a1.329/r1.342,s1:b3o3:a0.958/r0.980,s3:b4o3:a0.894/r0.925,s5:b5o3:a0.829/r0.850
+3010/20000 train_loss: 2.5374 train_time: 5.4m tok/s: 7352632
+3020/20000 train_loss: 2.5080 train_time: 5.4m tok/s: 7345421
+3030/20000 train_loss: 2.6331 train_time: 5.4m tok/s: 7338236
+3040/20000 train_loss: 2.4534 train_time: 5.4m tok/s: 7331167
+3050/20000 train_loss: 2.5799 train_time: 5.5m tok/s: 7320700
+art_delta_probe step:3050 sites:6 alpha_mean:1.0743 alpha_std:0.1440 alpha_min:0.0156 alpha_max:1.7656 logit_mean:0.0811 logit_std:0.1578 delta_rms:1.26608 gated_delta_rms:1.38248 gate_w_rms:0.031380 gate_w_max:0.125871 gate_b_mean:-0.000925 gate_b_min:-0.164190 gate_b_max:0.237039 sites:s0:b3o2:a1.103/r1.106,s2:b4o2:a1.322/r1.335,s4:b5o2:a1.346/r1.349,s1:b3o3:a0.960/r0.977,s3:b4o3:a0.887/r0.918,s5:b5o3:a0.828/r0.849
+3060/20000 train_loss: 2.5970 train_time: 5.5m tok/s: 7314495
+3070/20000 train_loss: 2.3899 train_time: 5.5m tok/s: 7307444
+3080/20000 train_loss: 2.5204 train_time: 5.5m tok/s: 7300476
+3090/20000 train_loss: 2.4558 train_time: 5.6m tok/s: 7293522
+3100/20000 train_loss: 2.6046 train_time: 5.6m tok/s: 7286381
+art_delta_probe step:3100 sites:6 alpha_mean:1.0717 alpha_std:0.1458 alpha_min:0.0195 alpha_max:1.7578 logit_mean:0.0772 logit_std:0.1590 delta_rms:1.22281 gated_delta_rms:1.33219 gate_w_rms:0.031886 gate_w_max:0.117173 gate_b_mean:-0.001578 gate_b_min:-0.173609 gate_b_max:0.228330 sites:s0:b3o2:a1.115/r1.117,s2:b4o2:a1.295/r1.306,s4:b5o2:a1.324/r1.332,s1:b3o3:a0.972/r0.989,s3:b4o3:a0.898/r0.926,s5:b5o3:a0.827/r0.853
+3110/20000 train_loss: 2.5131 train_time: 5.6m tok/s: 7278296
+3120/20000 train_loss: 2.5840 train_time: 5.6m tok/s: 7271458
+3130/20000 train_loss: 2.5446 train_time: 5.6m tok/s: 7264860
+3140/20000 train_loss: 2.5753 train_time: 5.7m tok/s: 7258321
+3150/20000 train_loss: 2.5470 train_time: 5.7m tok/s: 7251880
+art_delta_probe step:3150 sites:6 alpha_mean:1.0748 alpha_std:0.1484 alpha_min:0.0195 alpha_max:1.7500 logit_mean:0.0801 logit_std:0.1610 delta_rms:1.19160 gated_delta_rms:1.30077 gate_w_rms:0.033123 gate_w_max:0.120978 gate_b_mean:-0.003233 gate_b_min:-0.176879 gate_b_max:0.224159 sites:s0:b3o2:a1.131/r1.134,s2:b4o2:a1.297/r1.309,s4:b5o2:a1.317/r1.322,s1:b3o3:a0.987/r1.003,s3:b4o3:a0.890/r0.919,s5:b5o3:a0.828/r0.848
+3160/20000 train_loss: 2.6006 train_time: 5.7m tok/s: 7245138
+3170/20000 train_loss: 2.6112 train_time: 5.7m tok/s: 7238742
+3180/20000 train_loss: 2.6634 train_time: 5.8m tok/s: 7229357
+3190/20000 train_loss: 2.5505 train_time: 5.8m tok/s: 7222929
+3200/20000 train_loss: 2.4418 train_time: 5.8m tok/s: 7216484
+art_delta_probe step:3200 sites:6 alpha_mean:1.0826 alpha_std:0.1468 alpha_min:0.0469 alpha_max:1.7734 logit_mean:0.0892 logit_std:0.1597 delta_rms:1.15336 gated_delta_rms:1.26781 gate_w_rms:0.033636 gate_w_max:0.123950 gate_b_mean:-0.001615 gate_b_min:-0.183363 gate_b_max:0.223163 sites:s0:b3o2:a1.119/r1.120,s2:b4o2:a1.307/r1.322,s4:b5o2:a1.335/r1.341,s1:b3o3:a1.007/r1.022,s3:b4o3:a0.904/r0.933,s5:b5o3:a0.824/r0.842
+3210/20000 train_loss: 2.4662 train_time: 5.8m tok/s: 7210010
+3220/20000 train_loss: 2.4514 train_time: 5.9m tok/s: 7203758
+3230/20000 train_loss: 2.5836 train_time: 5.9m tok/s: 7197505
+3240/20000 train_loss: 2.3589 train_time: 5.9m tok/s: 7191341
+3250/20000 train_loss: 2.1510 train_time: 5.9m tok/s: 7185132
+art_delta_probe step:3250 sites:6 alpha_mean:1.0751 alpha_std:0.1466 alpha_min:0.0273 alpha_max:1.7500 logit_mean:0.0802 logit_std:0.1587 delta_rms:1.13178 gated_delta_rms:1.23682 gate_w_rms:0.034151 gate_w_max:0.117749 gate_b_mean:-0.003616 gate_b_min:-0.191478 gate_b_max:0.214567 sites:s0:b3o2:a1.125/r1.126,s2:b4o2:a1.281/r1.294,s4:b5o2:a1.310/r1.319,s1:b3o3:a1.000/r1.017,s3:b4o3:a0.913/r0.941,s5:b5o3:a0.822/r0.846
+3260/20000 train_loss: 2.4953 train_time: 6.0m tok/s: 7178840
+3270/20000 train_loss: 2.7609 train_time: 6.0m tok/s: 7172775
+3280/20000 train_loss: 2.4845 train_time: 6.0m tok/s: 7166919
+3290/20000 train_loss: 2.5475 train_time: 6.0m tok/s: 7161158
+3300/20000 train_loss: 2.4778 train_time: 6.0m tok/s: 7155359
+art_delta_probe step:3300 sites:6 alpha_mean:1.0710 alpha_std:0.1498 alpha_min:0.0391 alpha_max:1.7578 logit_mean:0.0757 logit_std:0.1612 delta_rms:1.10601 gated_delta_rms:1.20727 gate_w_rms:0.034459 gate_w_max:0.120134 gate_b_mean:-0.002676 gate_b_min:-0.190041 gate_b_max:0.216514 sites:s0:b3o2:a1.108/r1.112,s2:b4o2:a1.272/r1.288,s4:b5o2:a1.300/r1.311,s1:b3o3:a1.010/r1.028,s3:b4o3:a0.910/r0.939,s5:b5o3:a0.827/r0.856
+3310/20000 train_loss: 2.4039 train_time: 6.1m tok/s: 7146270
+3320/20000 train_loss: 2.5350 train_time: 6.1m tok/s: 7140609
+3330/20000 train_loss: 2.5466 train_time: 6.1m tok/s: 7134915
+3340/20000 train_loss: 2.5278 train_time: 6.1m tok/s: 7129301
+3350/20000 train_loss: 2.5017 train_time: 6.2m tok/s: 7123798
+art_delta_probe step:3350 sites:6 alpha_mean:1.0785 alpha_std:0.1482 alpha_min:0.0469 alpha_max:1.7500 logit_mean:0.0833 logit_std:0.1604 delta_rms:1.06355 gated_delta_rms:1.16929 gate_w_rms:0.035173 gate_w_max:0.118567 gate_b_mean:-0.005528 gate_b_min:-0.200367 gate_b_max:0.214628 sites:s0:b3o2:a1.132/r1.134,s2:b4o2:a1.281/r1.296,s4:b5o2:a1.309/r1.323,s1:b3o3:a1.020/r1.037,s3:b4o3:a0.913/r0.943,s5:b5o3:a0.815/r0.843
+3360/20000 train_loss: 2.5915 train_time: 6.2m tok/s: 7118102
+3370/20000 train_loss: 2.4377 train_time: 6.2m tok/s: 7112600
+3380/20000 train_loss: 2.5479 train_time: 6.2m tok/s: 7107216
+3390/20000 train_loss: 2.4868 train_time: 6.3m tok/s: 7101727
+3400/20000 train_loss: 2.4220 train_time: 6.3m tok/s: 7096555
+art_delta_probe step:3400 sites:6 alpha_mean:1.0875 alpha_std:0.1397 alpha_min:0.0898 alpha_max:1.7500 logit_mean:0.0923 logit_std:0.1500 delta_rms:1.03405 gated_delta_rms:1.14468 gate_w_rms:0.035508 gate_w_max:0.121675 gate_b_mean:-0.007677 gate_b_min:-0.207519 gate_b_max:0.201760 sites:s0:b3o2:a1.138/r1.141,s2:b4o2:a1.298/r1.311,s4:b5o2:a1.307/r1.308,s1:b3o3:a1.043/r1.059,s3:b4o3:a0.912/r0.943,s5:b5o3:a0.828/r0.857
+3410/20000 train_loss: 2.5373 train_time: 6.3m tok/s: 7090952
+3420/20000 train_loss: 2.4559 train_time: 6.3m tok/s: 7085663
+3430/20000 train_loss: 2.5031 train_time: 6.4m tok/s: 7077606
+3440/20000 train_loss: 2.6087 train_time: 6.4m tok/s: 7072513
+3450/20000 train_loss: 2.3786 train_time: 6.4m tok/s: 7067368
+art_delta_probe step:3450 sites:6 alpha_mean:1.0816 alpha_std:0.1462 alpha_min:0.0430 alpha_max:1.7500 logit_mean:0.0865 logit_std:0.1581 delta_rms:1.01226 gated_delta_rms:1.11514 gate_w_rms:0.035982 gate_w_max:0.123135 gate_b_mean:-0.007757 gate_b_min:-0.208823 gate_b_max:0.205683 sites:s0:b3o2:a1.134/r1.137,s2:b4o2:a1.297/r1.310,s4:b5o2:a1.307/r1.317,s1:b3o3:a1.030/r1.043,s3:b4o3:a0.909/r0.942,s5:b5o3:a0.812/r0.841
+3460/20000 train_loss: 2.5551 train_time: 6.4m tok/s: 7061866
+3470/20000 train_loss: 2.6514 train_time: 6.5m tok/s: 7036622
+3480/20000 train_loss: 2.4527 train_time: 6.5m tok/s: 6991405
+3490/20000 train_loss: 2.5511 train_time: 6.5m tok/s: 6986709
+3500/20000 train_loss: 2.5626 train_time: 6.6m tok/s: 6982155
+art_delta_probe step:3500 sites:6 alpha_mean:1.0786 alpha_std:0.1413 alpha_min:0.0547 alpha_max:1.7656 logit_mean:0.0829 logit_std:0.1516 delta_rms:0.97057 gated_delta_rms:1.06531 gate_w_rms:0.036408 gate_w_max:0.125151 gate_b_mean:-0.007034 gate_b_min:-0.212636 gate_b_max:0.201854 sites:s0:b3o2:a1.129/r1.130,s2:b4o2:a1.277/r1.289,s4:b5o2:a1.285/r1.294,s1:b3o3:a1.044/r1.060,s3:b4o3:a0.921/r0.950,s5:b5o3:a0.815/r0.843
+3510/20000 train_loss: 2.5062 train_time: 6.6m tok/s: 6977216
+3520/20000 train_loss: 2.4665 train_time: 6.6m tok/s: 6972703
+3530/20000 train_loss: 2.5367 train_time: 6.6m tok/s: 6968128
+3540/20000 train_loss: 2.3545 train_time: 6.7m tok/s: 6963635
+3550/20000 train_loss: 2.4882 train_time: 6.7m tok/s: 6959100
+art_delta_probe step:3550 sites:6 alpha_mean:1.0865 alpha_std:0.1422 alpha_min:0.0938 alpha_max:1.7969 logit_mean:0.0914 logit_std:0.1528 delta_rms:0.93423 gated_delta_rms:1.03315 gate_w_rms:0.037841 gate_w_max:0.129741 gate_b_mean:-0.008200 gate_b_min:-0.215591 gate_b_max:0.201316 sites:s0:b3o2:a1.142/r1.142,s2:b4o2:a1.284/r1.296,s4:b5o2:a1.306/r1.312,s1:b3o3:a1.046/r1.059,s3:b4o3:a0.920/r0.953,s5:b5o3:a0.821/r0.850
+3560/20000 train_loss: 2.5967 train_time: 6.7m tok/s: 6951824
+3570/20000 train_loss: 2.6537 train_time: 6.7m tok/s: 6947206
+3580/20000 train_loss: 2.4186 train_time: 6.8m tok/s: 6942722
+3590/20000 train_loss: 2.5277 train_time: 6.8m tok/s: 6938398
+3600/20000 train_loss: 2.4243 train_time: 6.8m tok/s: 6934062
+art_delta_probe step:3600 sites:6 alpha_mean:1.0778 alpha_std:0.1428 alpha_min:0.0664 alpha_max:1.7500 logit_mean:0.0819 logit_std:0.1535 delta_rms:0.91590 gated_delta_rms:1.00590 gate_w_rms:0.038186 gate_w_max:0.128683 gate_b_mean:-0.009961 gate_b_min:-0.215680 gate_b_max:0.198469 sites:s0:b3o2:a1.137/r1.139,s2:b4o2:a1.283/r1.296,s4:b5o2:a1.287/r1.294,s1:b3o3:a1.035/r1.051,s3:b4o3:a0.913/r0.945,s5:b5o3:a0.811/r0.843
+3610/20000 train_loss: 2.3861 train_time: 6.8m tok/s: 6929408
+3620/20000 train_loss: 2.5933 train_time: 6.9m tok/s: 6925030
+3630/20000 train_loss: 2.5471 train_time: 6.9m tok/s: 6920692
+3640/20000 train_loss: 2.3541 train_time: 6.9m tok/s: 6916475
+3650/20000 train_loss: 2.5665 train_time: 6.9m tok/s: 6912293
+art_delta_probe step:3650 sites:6 alpha_mean:1.0840 alpha_std:0.1398 alpha_min:0.0898 alpha_max:1.7656 logit_mean:0.0880 logit_std:0.1497 delta_rms:0.88422 gated_delta_rms:0.97666 gate_w_rms:0.038912 gate_w_max:0.131246 gate_b_mean:-0.010401 gate_b_min:-0.220713 gate_b_max:0.196791 sites:s0:b3o2:a1.151/r1.151,s2:b4o2:a1.282/r1.293,s4:b5o2:a1.277/r1.283,s1:b3o3:a1.043/r1.057,s3:b4o3:a0.922/r0.956,s5:b5o3:a0.829/r0.869
+3660/20000 train_loss: 2.6137 train_time: 6.9m tok/s: 6907632
+3670/20000 train_loss: 2.6441 train_time: 7.0m tok/s: 6903478
+3680/20000 train_loss: 2.4013 train_time: 7.0m tok/s: 6899376
+3690/20000 train_loss: 2.4425 train_time: 7.0m tok/s: 6892982
+3700/20000 train_loss: 2.4064 train_time: 7.0m tok/s: 6888909
+art_delta_probe step:3700 sites:6 alpha_mean:1.0813 alpha_std:0.1407 alpha_min:0.0703 alpha_max:1.7578 logit_mean:0.0855 logit_std:0.1510 delta_rms:0.84771 gated_delta_rms:0.93444 gate_w_rms:0.039528 gate_w_max:0.137856 gate_b_mean:-0.010824 gate_b_min:-0.225955 gate_b_max:0.196975 sites:s0:b3o2:a1.148/r1.150,s2:b4o2:a1.286/r1.300,s4:b5o2:a1.284/r1.289,s1:b3o3:a1.047/r1.061,s3:b4o3:a0.916/r0.947,s5:b5o3:a0.806/r0.845
+3710/20000 train_loss: 2.4575 train_time: 7.1m tok/s: 6884672
+3720/20000 train_loss: 2.5372 train_time: 7.1m tok/s: 6880613
+3730/20000 train_loss: 2.3742 train_time: 7.1m tok/s: 6876703
+3740/20000 train_loss: 2.5079 train_time: 7.1m tok/s: 6872697
+3750/20000 train_loss: 2.4374 train_time: 7.2m tok/s: 6868778
+art_delta_probe step:3750 sites:6 alpha_mean:1.0876 alpha_std:0.1418 alpha_min:0.0586 alpha_max:1.7344 logit_mean:0.0922 logit_std:0.1527 delta_rms:0.83600 gated_delta_rms:0.92489 gate_w_rms:0.041102 gate_w_max:0.135167 gate_b_mean:-0.009212 gate_b_min:-0.226985 gate_b_max:0.192995 sites:s0:b3o2:a1.139/r1.139,s2:b4o2:a1.287/r1.299,s4:b5o2:a1.299/r1.298,s1:b3o3:a1.063/r1.079,s3:b4o3:a0.927/r0.955,s5:b5o3:a0.810/r0.848
+3760/20000 train_loss: 2.3100 train_time: 7.2m tok/s: 6864492
+3770/20000 train_loss: 2.5820 train_time: 7.2m tok/s: 6860618
+3780/20000 train_loss: 2.4704 train_time: 7.2m tok/s: 6856794
+3790/20000 train_loss: 2.5813 train_time: 7.2m tok/s: 6852754
+3800/20000 train_loss: 2.4415 train_time: 7.3m tok/s: 6848928
+art_delta_probe step:3800 sites:6 alpha_mean:1.0849 alpha_std:0.1390 alpha_min:0.0898 alpha_max:1.7812 logit_mean:0.0893 logit_std:0.1489 delta_rms:0.80513 gated_delta_rms:0.88732 gate_w_rms:0.041624 gate_w_max:0.133641 gate_b_mean:-0.012483 gate_b_min:-0.233291 gate_b_max:0.188884 sites:s0:b3o2:a1.152/r1.149,s2:b4o2:a1.280/r1.292,s4:b5o2:a1.292/r1.294,s1:b3o3:a1.049/r1.062,s3:b4o3:a0.932/r0.962,s5:b5o3:a0.806/r0.831
+3810/20000 train_loss: 2.4062 train_time: 7.3m tok/s: 6844893
+3820/20000 train_loss: 2.5663 train_time: 7.3m tok/s: 6838734
+3830/20000 train_loss: 2.3262 train_time: 7.3m tok/s: 6835006
+3840/20000 train_loss: 2.4557 train_time: 7.4m tok/s: 6831267
+3850/20000 train_loss: 2.4559 train_time: 7.4m tok/s: 6827603
+art_delta_probe step:3850 sites:6 alpha_mean:1.0818 alpha_std:0.1375 alpha_min:0.1172 alpha_max:1.7344 logit_mean:0.0857 logit_std:0.1465 delta_rms:0.77834 gated_delta_rms:0.85702 gate_w_rms:0.042083 gate_w_max:0.134577 gate_b_mean:-0.015657 gate_b_min:-0.235516 gate_b_max:0.182726 sites:s0:b3o2:a1.146/r1.146,s2:b4o2:a1.267/r1.281,s4:b5o2:a1.279/r1.279,s1:b3o3:a1.056/r1.071,s3:b4o3:a0.930/r0.960,s5:b5o3:a0.813/r0.850
+3860/20000 train_loss: 2.4259 train_time: 7.4m tok/s: 6823758
+3870/20000 train_loss: 2.5549 train_time: 7.4m tok/s: 6820213
+3880/20000 train_loss: 3.0786 train_time: 7.5m tok/s: 6816520
+3890/20000 train_loss: 2.5089 train_time: 7.5m tok/s: 6813029
+3900/20000 train_loss: 2.4726 train_time: 7.5m tok/s: 6809407
+art_delta_probe step:3900 sites:6 alpha_mean:1.0873 alpha_std:0.1384 alpha_min:0.0664 alpha_max:1.7344 logit_mean:0.0921 logit_std:0.1488 delta_rms:0.75243 gated_delta_rms:0.83105 gate_w_rms:0.043765 gate_w_max:0.141669 gate_b_mean:-0.014673 gate_b_min:-0.234476 gate_b_max:0.181767 sites:s0:b3o2:a1.145/r1.143,s2:b4o2:a1.276/r1.288,s4:b5o2:a1.303/r1.305,s1:b3o3:a1.056/r1.069,s3:b4o3:a0.926/r0.953,s5:b5o3:a0.818/r0.849
+3910/20000 train_loss: 2.4601 train_time: 7.5m tok/s: 6805555
+3920/20000 train_loss: 2.4881 train_time: 7.6m tok/s: 6802073
+3930/20000 train_loss: 2.6699 train_time: 7.6m tok/s: 6798555
+3940/20000 train_loss: 2.4994 train_time: 7.6m tok/s: 6792848
+3950/20000 train_loss: 2.6196 train_time: 7.6m tok/s: 6789393
+art_delta_probe step:3950 sites:6 alpha_mean:1.0824 alpha_std:0.1360 alpha_min:0.0781 alpha_max:1.6875 logit_mean:0.0860 logit_std:0.1451 delta_rms:0.73278 gated_delta_rms:0.80663 gate_w_rms:0.044129 gate_w_max:0.139788 gate_b_mean:-0.016694 gate_b_min:-0.240216 gate_b_max:0.176583 sites:s0:b3o2:a1.149/r1.146,s2:b4o2:a1.257/r1.268,s4:b5o2:a1.283/r1.282,s1:b3o3:a1.055/r1.068,s3:b4o3:a0.934/r0.964,s5:b5o3:a0.816/r0.857
+3960/20000 train_loss: 2.3711 train_time: 7.6m tok/s: 6785621
+3970/20000 train_loss: 2.4172 train_time: 7.7m tok/s: 6782212
+3980/20000 train_loss: 2.5226 train_time: 7.7m tok/s: 6778837
+3990/20000 train_loss: 2.4939 train_time: 7.7m tok/s: 6775481
+4000/20000 train_loss: 2.3532 train_time: 7.7m tok/s: 6772099
+art_delta_probe step:4000 sites:6 alpha_mean:1.0871 alpha_std:0.1389 alpha_min:0.1445 alpha_max:1.6875 logit_mean:0.0912 logit_std:0.1481 delta_rms:0.70732 gated_delta_rms:0.78351 gate_w_rms:0.046235 gate_w_max:0.149619 gate_b_mean:-0.017293 gate_b_min:-0.241172 gate_b_max:0.178960 sites:s0:b3o2:a1.155/r1.154,s2:b4o2:a1.275/r1.288,s4:b5o2:a1.278/r1.280,s1:b3o3:a1.064/r1.078,s3:b4o3:a0.938/r0.967,s5:b5o3:a0.812/r0.861
+4010/20000 train_loss: 2.5226 train_time: 7.8m tok/s: 6768535
+4020/20000 train_loss: 2.4948 train_time: 7.8m tok/s: 6765367
+4030/20000 train_loss: 2.4348 train_time: 7.8m tok/s: 6762124
+4040/20000 train_loss: 2.7314 train_time: 7.8m tok/s: 6758768
+4050/20000 train_loss: 2.4509 train_time: 7.9m tok/s: 6755625
+art_delta_probe step:4050 sites:6 alpha_mean:1.0843 alpha_std:0.1371 alpha_min:0.1016 alpha_max:1.7031 logit_mean:0.0880 logit_std:0.1461 delta_rms:0.68995 gated_delta_rms:0.76211 gate_w_rms:0.046445 gate_w_max:0.148995 gate_b_mean:-0.018545 gate_b_min:-0.244225 gate_b_max:0.173306 sites:s0:b3o2:a1.162/r1.161,s2:b4o2:a1.263/r1.275,s4:b5o2:a1.276/r1.275,s1:b3o3:a1.056/r1.069,s3:b4o3:a0.930/r0.960,s5:b5o3:a0.818/r0.867
+4060/20000 train_loss: 2.4654 train_time: 7.9m tok/s: 6752096
+4070/20000 train_loss: 2.5067 train_time: 7.9m tok/s: 6746849
+4080/20000 train_loss: 2.6056 train_time: 7.9m tok/s: 6743546
+4090/20000 train_loss: 2.5842 train_time: 8.0m tok/s: 6740342
+4100/20000 train_loss: 2.4904 train_time: 8.0m tok/s: 6737237
+art_delta_probe step:4100 sites:6 alpha_mean:1.0845 alpha_std:0.1359 alpha_min:0.0859 alpha_max:1.7031 logit_mean:0.0882 logit_std:0.1451 delta_rms:0.66830 gated_delta_rms:0.73740 gate_w_rms:0.047001 gate_w_max:0.147627 gate_b_mean:-0.019148 gate_b_min:-0.246908 gate_b_max:0.170304 sites:s0:b3o2:a1.160/r1.159,s2:b4o2:a1.266/r1.279,s4:b5o2:a1.277/r1.276,s1:b3o3:a1.075/r1.087,s3:b4o3:a0.922/r0.950,s5:b5o3:a0.806/r0.849
+4110/20000 train_loss: 2.4445 train_time: 8.0m tok/s: 6733799
+4120/20000 train_loss: 2.4117 train_time: 8.0m tok/s: 6730792
+4130/20000 train_loss: 2.4557 train_time: 8.0m tok/s: 6727681
+4140/20000 train_loss: 2.4977 train_time: 8.1m tok/s: 6724643
+4150/20000 train_loss: 2.3950 train_time: 8.1m tok/s: 6721594
+art_delta_probe step:4150 sites:6 alpha_mean:1.0818 alpha_std:0.1364 alpha_min:0.1211 alpha_max:1.6953 logit_mean:0.0854 logit_std:0.1453 delta_rms:0.64408 gated_delta_rms:0.71016 gate_w_rms:0.048657 gate_w_max:0.157997 gate_b_mean:-0.019307 gate_b_min:-0.243899 gate_b_max:0.169450 sites:s0:b3o2:a1.150/r1.149,s2:b4o2:a1.252/r1.264,s4:b5o2:a1.277/r1.278,s1:b3o3:a1.070/r1.081,s3:b4o3:a0.928/r0.956,s5:b5o3:a0.814/r0.864
+4160/20000 train_loss: 2.4393 train_time: 8.1m tok/s: 6718296
+4170/20000 train_loss: 2.4293 train_time: 8.1m tok/s: 6715358
+4180/20000 train_loss: 2.5293 train_time: 8.2m tok/s: 6712204
+4190/20000 train_loss: 2.4047 train_time: 8.2m tok/s: 6709232
+4200/20000 train_loss: 2.3969 train_time: 8.2m tok/s: 6704124
+art_delta_probe step:4200 sites:6 alpha_mean:1.0864 alpha_std:0.1341 alpha_min:0.1367 alpha_max:1.7031 logit_mean:0.0899 logit_std:0.1424 delta_rms:0.62363 gated_delta_rms:0.69115 gate_w_rms:0.050337 gate_w_max:0.153459 gate_b_mean:-0.020168 gate_b_min:-0.241041 gate_b_max:0.171001 sites:s0:b3o2:a1.160/r1.158,s2:b4o2:a1.259/r1.270,s4:b5o2:a1.268/r1.273,s1:b3o3:a1.074/r1.083,s3:b4o3:a0.935/r0.963,s5:b5o3:a0.822/r0.881
+4210/20000 train_loss: 2.3970 train_time: 8.2m tok/s: 6700972
+4220/20000 train_loss: 2.4277 train_time: 8.3m tok/s: 6698038
+4230/20000 train_loss: 2.5206 train_time: 8.3m tok/s: 6695105
+4240/20000 train_loss: 2.3750 train_time: 8.3m tok/s: 6692199
+4250/20000 train_loss: 2.4062 train_time: 8.3m tok/s: 6689355
+art_delta_probe step:4250 sites:6 alpha_mean:1.0915 alpha_std:0.1345 alpha_min:0.2812 alpha_max:1.6875 logit_mean:0.0957 logit_std:0.1428 delta_rms:0.60828 gated_delta_rms:0.67842 gate_w_rms:0.051244 gate_w_max:0.160590 gate_b_mean:-0.021858 gate_b_min:-0.248505 gate_b_max:0.166791 sites:s0:b3o2:a1.147/r1.147,s2:b4o2:a1.264/r1.278,s4:b5o2:a1.289/r1.300,s1:b3o3:a1.086/r1.096,s3:b4o3:a0.941/r0.970,s5:b5o3:a0.822/r0.875
+4260/20000 train_loss: 2.4996 train_time: 8.4m tok/s: 6686239
+4270/20000 train_loss: 2.3666 train_time: 8.4m tok/s: 6683416
+4280/20000 train_loss: 2.5128 train_time: 8.4m tok/s: 6680559
+4290/20000 train_loss: 2.3294 train_time: 8.4m tok/s: 6677736
+4300/20000 train_loss: 2.2751 train_time: 8.4m tok/s: 6674884
+art_delta_probe step:4300 sites:6 alpha_mean:1.0832 alpha_std:0.1344 alpha_min:0.2266 alpha_max:1.7188 logit_mean:0.0864 logit_std:0.1426 delta_rms:0.58608 gated_delta_rms:0.64839 gate_w_rms:0.051461 gate_w_max:0.160045 gate_b_mean:-0.022348 gate_b_min:-0.253616 gate_b_max:0.162294 sites:s0:b3o2:a1.157/r1.156,s2:b4o2:a1.246/r1.258,s4:b5o2:a1.268/r1.274,s1:b3o3:a1.079/r1.088,s3:b4o3:a0.939/r0.968,s5:b5o3:a0.811/r0.870
+4310/20000 train_loss: 2.4606 train_time: 8.5m tok/s: 6671921
+4320/20000 train_loss: 2.4331 train_time: 8.5m tok/s: 6667148
+4330/20000 train_loss: 2.9305 train_time: 8.5m tok/s: 6664508
+4340/20000 train_loss: 2.3851 train_time: 8.5m tok/s: 6661792
+4350/20000 train_loss: 2.4596 train_time: 8.6m tok/s: 6659107
+art_delta_probe step:4350 sites:6 alpha_mean:1.0887 alpha_std:0.1334 alpha_min:0.1875 alpha_max:1.7344 logit_mean:0.0923 logit_std:0.1418 delta_rms:0.56866 gated_delta_rms:0.63071 gate_w_rms:0.052792 gate_w_max:0.169846 gate_b_mean:-0.019699 gate_b_min:-0.250693 gate_b_max:0.165583 sites:s0:b3o2:a1.158/r1.156,s2:b4o2:a1.253/r1.263,s4:b5o2:a1.272/r1.272,s1:b3o3:a1.096/r1.107,s3:b4o3:a0.940/r0.967,s5:b5o3:a0.813/r0.867
+4360/20000 train_loss: 2.3592 train_time: 8.6m tok/s: 6656113
+4370/20000 train_loss: 2.3065 train_time: 8.6m tok/s: 6653454
+4380/20000 train_loss: 2.2479 train_time: 8.6m tok/s: 6650696
+4390/20000 train_loss: 2.3301 train_time: 8.7m tok/s: 6648157
+4400/20000 train_loss: 2.4022 train_time: 8.7m tok/s: 6645589
+art_delta_probe step:4400 sites:6 alpha_mean:1.0844 alpha_std:0.1324 alpha_min:0.2109 alpha_max:1.6719 logit_mean:0.0879 logit_std:0.1405 delta_rms:0.55623 gated_delta_rms:0.61490 gate_w_rms:0.054396 gate_w_max:0.171778 gate_b_mean:-0.020907 gate_b_min:-0.249584 gate_b_max:0.165887 sites:s0:b3o2:a1.147/r1.147,s2:b4o2:a1.264/r1.276,s4:b5o2:a1.266/r1.271,s1:b3o3:a1.078/r1.087,s3:b4o3:a0.940/r0.967,s5:b5o3:a0.811/r0.862
+4410/20000 train_loss: 2.4529 train_time: 8.7m tok/s: 6642634
+4420/20000 train_loss: 2.4691 train_time: 8.7m tok/s: 6639978
+4430/20000 train_loss: 2.4098 train_time: 8.7m tok/s: 6637414
+4440/20000 train_loss: 2.3945 train_time: 8.8m tok/s: 6634759
+4450/20000 train_loss: 2.3964 train_time: 8.8m tok/s: 6630270
+art_delta_probe step:4450 sites:6 alpha_mean:1.0789 alpha_std:0.1271 alpha_min:0.1719 alpha_max:1.6562 logit_mean:0.0817 logit_std:0.1347 delta_rms:0.53717 gated_delta_rms:0.59155 gate_w_rms:0.054285 gate_w_max:0.166914 gate_b_mean:-0.022313 gate_b_min:-0.252837 gate_b_max:0.165038 sites:s0:b3o2:a1.152/r1.151,s2:b4o2:a1.253/r1.264,s4:b5o2:a1.258/r1.264,s1:b3o3:a1.073/r1.080,s3:b4o3:a0.930/r0.956,s5:b5o3:a0.807/r0.867
+4460/20000 train_loss: 2.3733 train_time: 8.8m tok/s: 6627560
+4470/20000 train_loss: 2.3972 train_time: 8.8m tok/s: 6625044
+4480/20000 train_loss: 2.4379 train_time: 8.9m tok/s: 6622507
+4490/20000 train_loss: 2.4692 train_time: 8.9m tok/s: 6620069
+4500/20000 train_loss: 2.3143 train_time: 8.9m tok/s: 6617490
+art_delta_probe step:4500 sites:6 alpha_mean:1.0858 alpha_std:0.1291 alpha_min:0.2070 alpha_max:1.6875 logit_mean:0.0892 logit_std:0.1369 delta_rms:0.52474 gated_delta_rms:0.58089 gate_w_rms:0.055533 gate_w_max:0.173715 gate_b_mean:-0.021302 gate_b_min:-0.252320 gate_b_max:0.160833 sites:s0:b3o2:a1.158/r1.155,s2:b4o2:a1.254/r1.264,s4:b5o2:a1.269/r1.273,s1:b3o3:a1.080/r1.088,s3:b4o3:a0.943/r0.970,s5:b5o3:a0.811/r0.868
+4510/20000 train_loss: 2.4475 train_time: 8.9m tok/s: 6614796
+4520/20000 train_loss: 2.3122 train_time: 9.0m tok/s: 6612323
+4530/20000 train_loss: 2.5644 train_time: 9.0m tok/s: 6609751
+4540/20000 train_loss: 2.2901 train_time: 9.0m tok/s: 6607301
+4550/20000 train_loss: 2.3288 train_time: 9.0m tok/s: 6604829
+art_delta_probe step:4550 sites:6 alpha_mean:1.0853 alpha_std:0.1314 alpha_min:0.1602 alpha_max:1.6719 logit_mean:0.0885 logit_std:0.1395 delta_rms:0.51376 gated_delta_rms:0.56851 gate_w_rms:0.057392 gate_w_max:0.177462 gate_b_mean:-0.021043 gate_b_min:-0.250596 gate_b_max:0.162054 sites:s0:b3o2:a1.164/r1.162,s2:b4o2:a1.249/r1.259,s4:b5o2:a1.265/r1.269,s1:b3o3:a1.081/r1.088,s3:b4o3:a0.938/r0.965,s5:b5o3:a0.815/r0.875
+4560/20000 train_loss: 2.4493 train_time: 9.1m tok/s: 6602152
+4570/20000 train_loss: 2.4848 train_time: 9.1m tok/s: 6599796
+4580/20000 train_loss: 2.2667 train_time: 9.1m tok/s: 6595561
+4590/20000 train_loss: 2.4007 train_time: 9.1m tok/s: 6593262
+4600/20000 train_loss: 2.4518 train_time: 9.1m tok/s: 6590920
+art_delta_probe step:4600 sites:6 alpha_mean:1.0829 alpha_std:0.1280 alpha_min:0.2969 alpha_max:1.6719 logit_mean:0.0860 logit_std:0.1353 delta_rms:0.50078 gated_delta_rms:0.55303 gate_w_rms:0.057659 gate_w_max:0.175619 gate_b_mean:-0.023052 gate_b_min:-0.252434 gate_b_max:0.157659 sites:s0:b3o2:a1.159/r1.156,s2:b4o2:a1.249/r1.260,s4:b5o2:a1.257/r1.260,s1:b3o3:a1.081/r1.086,s3:b4o3:a0.937/r0.962,s5:b5o3:a0.816/r0.878
+4610/20000 train_loss: 2.3490 train_time: 9.2m tok/s: 6588265
+4620/20000 train_loss: 2.3059 train_time: 9.2m tok/s: 6585992
+4630/20000 train_loss: 2.4244 train_time: 9.2m tok/s: 6583590
+4640/20000 train_loss: 2.5589 train_time: 9.2m tok/s: 6581259
+4650/20000 train_loss: 2.3477 train_time: 9.3m tok/s: 6579014
+art_delta_probe step:4650 sites:6 alpha_mean:1.0806 alpha_std:0.1272 alpha_min:0.2891 alpha_max:1.6641 logit_mean:0.0836 logit_std:0.1344 delta_rms:0.49139 gated_delta_rms:0.54160 gate_w_rms:0.058719 gate_w_max:0.176701 gate_b_mean:-0.022765 gate_b_min:-0.251413 gate_b_max:0.158939 sites:s0:b3o2:a1.148/r1.146,s2:b4o2:a1.256/r1.268,s4:b5o2:a1.252/r1.257,s1:b3o3:a1.081/r1.086,s3:b4o3:a0.936/r0.962,s5:b5o3:a0.810/r0.872
+4660/20000 train_loss: 2.3842 train_time: 9.3m tok/s: 6576520
+4670/20000 train_loss: 2.4267 train_time: 9.3m tok/s: 6574179
+4680/20000 train_loss: 2.4206 train_time: 9.3m tok/s: 6571844
+4690/20000 train_loss: 2.3525 train_time: 9.4m tok/s: 6569621
+4700/20000 train_loss: 2.3800 train_time: 9.4m tok/s: 6565485
+art_delta_probe step:4700 sites:6 alpha_mean:1.0857 alpha_std:0.1279 alpha_min:0.3008 alpha_max:1.6719 logit_mean:0.0889 logit_std:0.1353 delta_rms:0.47988 gated_delta_rms:0.53193 gate_w_rms:0.059887 gate_w_max:0.182491 gate_b_mean:-0.021379 gate_b_min:-0.250956 gate_b_max:0.157816 sites:s0:b3o2:a1.157/r1.155,s2:b4o2:a1.249/r1.260,s4:b5o2:a1.263/r1.272,s1:b3o3:a1.085/r1.090,s3:b4o3:a0.944/r0.970,s5:b5o3:a0.815/r0.880
+4710/20000 train_loss: 2.4036 train_time: 9.4m tok/s: 6562993
+4720/20000 train_loss: 2.2610 train_time: 9.4m tok/s: 6560782
+4730/20000 train_loss: 2.3784 train_time: 9.5m tok/s: 6558595
+4740/20000 train_loss: 2.4936 train_time: 9.5m tok/s: 6556373
+4750/20000 train_loss: 2.2448 train_time: 9.5m tok/s: 6554231
+art_delta_probe step:4750 sites:6 alpha_mean:1.0863 alpha_std:0.1268 alpha_min:0.2500 alpha_max:1.6562 logit_mean:0.0895 logit_std:0.1339 delta_rms:0.47170 gated_delta_rms:0.52161 gate_w_rms:0.060190 gate_w_max:0.184252 gate_b_mean:-0.021493 gate_b_min:-0.249452 gate_b_max:0.157388 sites:s0:b3o2:a1.156/r1.153,s2:b4o2:a1.255/r1.266,s4:b5o2:a1.252/r1.253,s1:b3o3:a1.090/r1.095,s3:b4o3:a0.948/r0.974,s5:b5o3:a0.816/r0.873
+4760/20000 train_loss: 2.4473 train_time: 9.5m tok/s: 6551886
+4770/20000 train_loss: 2.4033 train_time: 9.5m tok/s: 6549678
+4780/20000 train_loss: 2.3158 train_time: 9.6m tok/s: 6547435
+4790/20000 train_loss: 2.3242 train_time: 9.6m tok/s: 6545290
+4800/20000 train_loss: 2.4967 train_time: 9.6m tok/s: 6543173
+art_delta_probe step:4800 sites:6 alpha_mean:1.0862 alpha_std:0.1268 alpha_min:0.2969 alpha_max:1.6484 logit_mean:0.0893 logit_std:0.1339 delta_rms:0.46502 gated_delta_rms:0.51501 gate_w_rms:0.061032 gate_w_max:0.186878 gate_b_mean:-0.020606 gate_b_min:-0.248959 gate_b_max:0.157189 sites:s0:b3o2:a1.157/r1.155,s2:b4o2:a1.251/r1.262,s4:b5o2:a1.256/r1.260,s1:b3o3:a1.091/r1.095,s3:b4o3:a0.946/r0.972,s5:b5o3:a0.816/r0.878
+4810/20000 train_loss: 2.7127 train_time: 9.6m tok/s: 6540832
+4820/20000 train_loss: 2.2469 train_time: 9.7m tok/s: 6538679
+4830/20000 train_loss: 1.9396 train_time: 9.7m tok/s: 6534812
+4840/20000 train_loss: 2.3677 train_time: 9.7m tok/s: 6532850
+4850/20000 train_loss: 2.3142 train_time: 9.7m tok/s: 6530805
+art_delta_probe step:4850 sites:6 alpha_mean:1.0859 alpha_std:0.1248 alpha_min:0.2852 alpha_max:1.6406 logit_mean:0.0889 logit_std:0.1317 delta_rms:0.46004 gated_delta_rms:0.50938 gate_w_rms:0.061002 gate_w_max:0.184810 gate_b_mean:-0.020272 gate_b_min:-0.247302 gate_b_max:0.159042 sites:s0:b3o2:a1.160/r1.157,s2:b4o2:a1.257/r1.267,s4:b5o2:a1.251/r1.256,s1:b3o3:a1.088/r1.091,s3:b4o3:a0.945/r0.970,s5:b5o3:a0.816/r0.878
+4860/20000 train_loss: 2.3037 train_time: 9.8m tok/s: 6528521
+4870/20000 train_loss: 2.2295 train_time: 9.8m tok/s: 6526532
+4880/20000 train_loss: 2.4260 train_time: 9.8m tok/s: 6524459
+4890/20000 train_loss: 2.4715 train_time: 9.8m tok/s: 6522407
+4900/20000 train_loss: 2.2873 train_time: 9.8m tok/s: 6520374
+art_delta_probe step:4900 sites:6 alpha_mean:1.0868 alpha_std:0.1253 alpha_min:0.2773 alpha_max:1.6562 logit_mean:0.0899 logit_std:0.1323 delta_rms:0.45708 gated_delta_rms:0.50662 gate_w_rms:0.061473 gate_w_max:0.188177 gate_b_mean:-0.020067 gate_b_min:-0.247541 gate_b_max:0.158661 sites:s0:b3o2:a1.158/r1.155,s2:b4o2:a1.254/r1.264,s4:b5o2:a1.256/r1.261,s1:b3o3:a1.089/r1.093,s3:b4o3:a0.948/r0.973,s5:b5o3:a0.817/r0.881
+4910/20000 train_loss: 2.3996 train_time: 9.9m tok/s: 6518134
+4920/20000 train_loss: 2.3305 train_time: 9.9m tok/s: 6516180
+4930/20000 train_loss: 2.5598 train_time: 9.9m tok/s: 6514091
+4936/20000 val_loss: 2.3426 val_bpb: 1.0704
+stopping_early: wallclock_cap train_time: 596085ms step: 4936/20000
+peak memory allocated: 42138 MiB reserved: 47468 MiB
+ema:applying EMA weights
+diagnostic pre-quantization post-ema val_loss:2.34145765 val_bpb:1.06988530 eval_time:7958ms
+art_delta_probe step:prequant sites:6 alpha_mean:1.0873 alpha_std:0.1282 alpha_min:0.2266 alpha_max:1.6719 logit_mean:0.0907 logit_std:0.1357 delta_rms:0.50319 gated_delta_rms:0.55770 gate_w_rms:0.057944 gate_w_max:0.178265 gate_b_mean:-0.020664 gate_b_min:-0.248070 gate_b_max:0.161051 sites:s0:b3o2:a1.159/r1.156,s2:b4o2:a1.256/r1.267,s4:b5o2:a1.265/r1.267,s1:b3o3:a1.082/r1.088,s3:b4o3:a0.944/r0.970,s5:b5o3:a0.818/r0.880
+Serialized model: 135410098 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:collected 67 Hessians in 3.4s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int6)+lqer_asym: blocks.mlp.fc.weight
+  gptq (int8)+lqer_asym: tok_emb.weight
+  passthrough (float16): art_delta_gate.weight, art_delta_site_bias, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, parallel_post_lambdas, parallel_resid_lambdas, skip_gates, skip_weights
+Serialized model quantized+brotli: 16905820 bytes
+diagnostic quantized val_loss:2.35849711 val_bpb:1.07767116 eval_time:65251ms
+art_delta_probe step:quantized sites:6 alpha_mean:1.0880 alpha_std:0.1283 alpha_min:0.2539 alpha_max:1.6719 logit_mean:0.0914 logit_std:0.1357 delta_rms:0.50203 gated_delta_rms:0.55711 gate_w_rms:0.057941 gate_w_max:0.178223 gate_b_mean:-0.020665 gate_b_min:-0.248047 gate_b_max:0.161011 sites:s0:b3o2:a1.159/r1.157,s2:b4o2:a1.256/r1.268,s4:b5o2:a1.263/r1.269,s1:b3o3:a1.086/r1.092,s3:b4o3:a0.946/r0.972,s5:b5o3:a0.818/r0.877
+ttt_lora:warming up compile (random tokens, no val data)
+ttt_lora:compile warmup done (154.9s)
+quantized_ttt_phased val_loss:2.32898835 val_bpb:1.06425679 eval_time:461493ms
+total_eval_time:461.5s

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/triple_art_small_batch_dashboard_20260429_192817_de3b33e8.stdout.log
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/logs/triple_art_small_batch_dashboard_20260429_192817_de3b33e8.stdout.log
@@ -1,0 +1,174 @@
+# Sanitized Parameter Golf run excerpt
+# Source dashboard log: dashboard_20260429_192817_de3b33e8.stdout.log
+# Removed: shell banners, infrastructure identifiers, and full path-heavy environment dumps.
+# Preserved: hardware/world-size, ART diagnostics, serialization, quantization, TTT, and score lines.
+
+  art_router_hidden_dim: 64
+  grad_accum_steps: 8
+  quantized_model_path: ckpt/final_model.int6.ptz
+  world_size: 1
+model_params:36143382
+router_params:197190
+triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; fixed triple recurrence activates at ENABLE_LOOPING_AT; routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; route_group_size:1 cycle_penalty:0.001 shard_coherent_batches:0
+warmup_step: 1/20
+warmup_step: 10/20
+warmup_step: 20/20
+loop_warmup_step: 1/20
+loop_warmup_step: 10/20
+loop_warmup_step: 20/20
+1/50000 train_loss: 9.0084 train_time: 0.0m step_avg: 413.34ms tok/s: 1268418
+2/50000 train_loss: 12.3308 train_time: 0.0m step_avg: 415.99ms tok/s: 1260344
+3/50000 train_loss: 10.9764 train_time: 0.0m step_avg: 417.29ms tok/s: 1256419
+4/50000 train_loss: 9.4822 train_time: 0.0m step_avg: 417.91ms tok/s: 1254555
+5/50000 train_loss: 8.3495 train_time: 0.0m step_avg: 418.18ms tok/s: 1253733
+10/50000 train_loss: 6.9056 train_time: 0.1m step_avg: 419.37ms tok/s: 1250168
+20/50000 train_loss: 5.9930 train_time: 0.1m step_avg: 420.74ms tok/s: 1246121
+30/50000 train_loss: 5.5061 train_time: 0.2m step_avg: 421.24ms tok/s: 1244627
+40/50000 train_loss: 5.3149 train_time: 0.3m step_avg: 421.99ms tok/s: 1242415
+50/50000 train_loss: 5.2271 train_time: 0.4m step_avg: 422.40ms tok/s: 1241209
+60/50000 train_loss: 5.1033 train_time: 0.4m step_avg: 422.59ms tok/s: 1240645
+70/50000 train_loss: 4.9394 train_time: 0.5m step_avg: 423.63ms tok/s: 1237599
+80/50000 train_loss: 4.8069 train_time: 0.6m step_avg: 423.46ms tok/s: 1238098
+90/50000 train_loss: 4.6796 train_time: 0.6m step_avg: 423.26ms tok/s: 1238678
+100/50000 train_loss: 4.5450 train_time: 0.7m step_avg: 423.08ms tok/s: 1239216
+110/50000 train_loss: 4.4031 train_time: 0.8m step_avg: 422.80ms tok/s: 1240033
+120/50000 train_loss: 4.2531 train_time: 0.8m step_avg: 422.83ms tok/s: 1239944
+130/50000 train_loss: 4.1522 train_time: 0.9m step_avg: 422.73ms tok/s: 1240231
+140/50000 train_loss: 4.0733 train_time: 1.0m step_avg: 423.01ms tok/s: 1239430
+150/50000 train_loss: 3.9766 train_time: 1.1m step_avg: 423.03ms tok/s: 1239351
+160/50000 train_loss: 3.9539 train_time: 1.1m step_avg: 423.05ms tok/s: 1239293
+170/50000 train_loss: 3.8918 train_time: 1.2m step_avg: 422.98ms tok/s: 1239522
+180/50000 train_loss: 3.8672 train_time: 1.3m step_avg: 422.89ms tok/s: 1239771
+190/50000 train_loss: 3.8482 train_time: 1.3m step_avg: 422.81ms tok/s: 1239996
+200/50000 train_loss: 3.7795 train_time: 1.4m step_avg: 422.73ms tok/s: 1240240
+210/50000 train_loss: 3.7587 train_time: 1.5m step_avg: 422.67ms tok/s: 1240414
+220/50000 train_loss: 3.7091 train_time: 1.5m step_avg: 422.53ms tok/s: 1240834
+230/50000 train_loss: 3.7063 train_time: 1.6m step_avg: 422.48ms tok/s: 1240969
+240/50000 train_loss: 3.6774 train_time: 1.7m step_avg: 422.47ms tok/s: 1240996
+250/50000 train_loss: 3.6233 train_time: 1.8m step_avg: 422.36ms tok/s: 1241335
+260/50000 train_loss: 3.6501 train_time: 1.8m step_avg: 422.32ms tok/s: 1241436
+270/50000 train_loss: 3.6193 train_time: 1.9m step_avg: 422.27ms tok/s: 1241590
+280/50000 train_loss: 3.5912 train_time: 2.0m step_avg: 422.24ms tok/s: 1241668
+290/50000 train_loss: 3.6016 train_time: 2.0m step_avg: 422.22ms tok/s: 1241746
+300/50000 train_loss: 3.5947 train_time: 2.1m step_avg: 422.19ms tok/s: 1241831
+310/50000 train_loss: 3.5844 train_time: 2.2m step_avg: 422.16ms tok/s: 1241926
+320/50000 train_loss: 3.5602 train_time: 2.3m step_avg: 422.14ms tok/s: 1241983
+330/50000 train_loss: 3.5574 train_time: 2.3m step_avg: 422.12ms tok/s: 1242029
+340/50000 train_loss: 3.5455 train_time: 2.4m step_avg: 422.10ms tok/s: 1242098
+350/50000 train_loss: 3.5445 train_time: 2.5m step_avg: 422.06ms tok/s: 1242218
+360/50000 train_loss: 3.5578 train_time: 2.5m step_avg: 422.15ms tok/s: 1241934
+370/50000 train_loss: 3.5400 train_time: 2.6m step_avg: 422.13ms tok/s: 1242002
+380/50000 train_loss: 3.4978 train_time: 2.7m step_avg: 422.09ms tok/s: 1242112
+390/50000 train_loss: 3.4832 train_time: 2.7m step_avg: 422.06ms tok/s: 1242208
+400/50000 train_loss: 3.4855 train_time: 2.8m step_avg: 422.03ms tok/s: 1242300
+410/50000 train_loss: 3.4813 train_time: 2.9m step_avg: 422.05ms tok/s: 1242253
+420/50000 train_loss: 3.4737 train_time: 3.0m step_avg: 422.04ms tok/s: 1242278
+430/50000 train_loss: 3.5026 train_time: 3.0m step_avg: 421.97ms tok/s: 1242478
+440/50000 train_loss: 3.4553 train_time: 3.1m step_avg: 421.96ms tok/s: 1242517
+450/50000 train_loss: 3.4667 train_time: 3.2m step_avg: 421.93ms tok/s: 1242582
+460/50000 train_loss: 3.4392 train_time: 3.2m step_avg: 421.89ms tok/s: 1242726
+470/50000 train_loss: 3.4056 train_time: 3.3m step_avg: 421.86ms tok/s: 1242804
+480/50000 train_loss: 3.4492 train_time: 3.4m step_avg: 421.88ms tok/s: 1242732
+490/50000 train_loss: 3.4208 train_time: 3.4m step_avg: 421.87ms tok/s: 1242783
+500/50000 train_loss: 3.4465 train_time: 3.5m step_avg: 423.42ms tok/s: 1238235
+510/50000 train_loss: 3.4049 train_time: 3.7m step_avg: 430.86ms tok/s: 1216839
+520/50000 train_loss: 3.3897 train_time: 3.8m step_avg: 438.00ms tok/s: 1197002
+530/50000 train_loss: 3.4182 train_time: 3.9m step_avg: 444.87ms tok/s: 1178525
+540/50000 train_loss: 3.3722 train_time: 4.1m step_avg: 451.47ms tok/s: 1161294
+550/50000 train_loss: 3.3644 train_time: 4.2m step_avg: 457.83ms tok/s: 1145168
+560/50000 train_loss: 3.3780 train_time: 4.3m step_avg: 463.97ms tok/s: 1129993
+570/50000 train_loss: 3.3570 train_time: 4.5m step_avg: 469.89ms tok/s: 1115775
+580/50000 train_loss: 3.3600 train_time: 4.6m step_avg: 475.59ms tok/s: 1102403
+590/50000 train_loss: 3.3238 train_time: 4.7m step_avg: 481.08ms tok/s: 1089812
+600/50000 train_loss: 3.3600 train_time: 4.9m step_avg: 486.39ms tok/s: 1077911
+610/50000 train_loss: 3.3410 train_time: 5.0m step_avg: 491.57ms tok/s: 1066548
+620/50000 train_loss: 3.3272 train_time: 5.1m step_avg: 496.54ms tok/s: 1055875
+630/50000 train_loss: 3.3478 train_time: 5.3m step_avg: 501.35ms tok/s: 1045748
+640/50000 train_loss: 3.2980 train_time: 5.4m step_avg: 506.02ms tok/s: 1036101
+650/50000 train_loss: 3.2908 train_time: 5.7m step_avg: 527.92ms tok/s: 993111 art_cycles:1.008 extra_cycle_frac:0.336 art_continue:cycle1=0.559,cycle2=0.546,cycle3=0.477 art_entropy:1.2925 art_router_loss:-0.0272
+step:650/50000 art_probe window_steps:2 avg_cycles:0.922 extra_cycle_frac:0.307 avg_stop:0.693 router_entropy:1.2500
+660/50000 train_loss: 3.2833 train_time: 5.8m step_avg: 531.48ms tok/s: 986471 art_cycles:1.047 extra_cycle_frac:0.349 art_continue:cycle1=0.578,cycle2=0.517,cycle3=0.565 art_entropy:1.2750 art_router_loss:-0.0444
+step:660/50000 art_probe window_steps:10 avg_cycles:1.023 extra_cycle_frac:0.341 avg_stop:0.659 router_entropy:1.2901
+670/50000 train_loss: 3.3231 train_time: 6.0m step_avg: 535.24ms tok/s: 979544 art_cycles:1.219 extra_cycle_frac:0.406 art_continue:cycle1=0.738,cycle2=0.513,cycle3=0.275 art_entropy:1.2684 art_router_loss:-0.0350
+step:670/50000 art_probe window_steps:10 avg_cycles:1.169 extra_cycle_frac:0.390 avg_stop:0.610 router_entropy:1.3115
+680/50000 train_loss: 3.2937 train_time: 6.1m step_avg: 538.67ms tok/s: 973299 art_cycles:0.934 extra_cycle_frac:0.311 art_continue:cycle1=0.598,cycle2=0.462,cycle3=0.225 art_entropy:1.2229 art_router_loss:-0.0368
+step:680/50000 art_probe window_steps:10 avg_cycles:1.077 extra_cycle_frac:0.359 avg_stop:0.641 router_entropy:1.2462
+690/50000 train_loss: 3.2501 train_time: 6.2m step_avg: 541.53ms tok/s: 968152 art_cycles:0.793 extra_cycle_frac:0.264 art_continue:cycle1=0.523,cycle2=0.324,cycle3=0.541 art_entropy:1.1351 art_router_loss:-0.0329
+step:690/50000 art_probe window_steps:10 avg_cycles:0.810 extra_cycle_frac:0.270 avg_stop:0.730 router_entropy:1.1689
+700/50000 train_loss: 3.2504 train_time: 6.4m step_avg: 545.53ms tok/s: 961059 art_cycles:0.844 extra_cycle_frac:0.281 art_continue:cycle1=0.605,cycle2=0.286,cycle3=0.426 art_entropy:1.1296 art_router_loss:-0.0358
+step:700/50000 art_probe window_steps:10 avg_cycles:0.839 extra_cycle_frac:0.280 avg_stop:0.720 router_entropy:1.1441
+710/50000 train_loss: 3.2802 train_time: 6.5m step_avg: 548.21ms tok/s: 956363 art_cycles:0.801 extra_cycle_frac:0.267 art_continue:cycle1=0.535,cycle2=0.298,cycle3=0.529 art_entropy:1.1344 art_router_loss:-0.0661
+step:710/50000 art_probe window_steps:10 avg_cycles:0.811 extra_cycle_frac:0.270 avg_stop:0.730 router_entropy:1.1209
+720/50000 train_loss: 3.3024 train_time: 6.6m step_avg: 550.75ms tok/s: 951955 art_cycles:0.719 extra_cycle_frac:0.240 art_continue:cycle1=0.438,cycle2=0.475,cycle3=0.418 art_entropy:1.1054 art_router_loss:-0.0373
+step:720/50000 art_probe window_steps:10 avg_cycles:0.780 extra_cycle_frac:0.260 avg_stop:0.740 router_entropy:1.1337
+730/50000 train_loss: 3.2270 train_time: 6.7m step_avg: 552.99ms tok/s: 948097 art_cycles:0.680 extra_cycle_frac:0.227 art_continue:cycle1=0.375,cycle2=0.534,cycle3=0.548 art_entropy:1.0322 art_router_loss:0.0208
+step:730/50000 art_probe window_steps:10 avg_cycles:0.656 extra_cycle_frac:0.219 avg_stop:0.781 router_entropy:1.0350
+740/50000 train_loss: 3.2632 train_time: 6.8m step_avg: 555.20ms tok/s: 944325 art_cycles:0.660 extra_cycle_frac:0.220 art_continue:cycle1=0.324,cycle2=0.680,cycle3=0.432 art_entropy:1.0146 art_router_loss:-0.0153
+step:740/50000 art_probe window_steps:10 avg_cycles:0.662 extra_cycle_frac:0.221 avg_stop:0.779 router_entropy:1.0207
+750/50000 train_loss: 3.2698 train_time: 7.0m step_avg: 557.40ms tok/s: 940588 art_cycles:0.672 extra_cycle_frac:0.224 art_continue:cycle1=0.348,cycle2=0.598,cycle3=0.574 art_entropy:1.0416 art_router_loss:0.0141
+step:750/50000 art_probe window_steps:10 avg_cycles:0.706 extra_cycle_frac:0.235 avg_stop:0.765 router_entropy:1.0507
+760/50000 train_loss: 3.2606 train_time: 7.1m step_avg: 559.81ms tok/s: 936539 art_cycles:0.887 extra_cycle_frac:0.296 art_continue:cycle1=0.441,cycle2=0.632,cycle3=0.570 art_entropy:1.1807 art_router_loss:0.0008
+step:760/50000 art_probe window_steps:10 avg_cycles:0.866 extra_cycle_frac:0.289 avg_stop:0.711 router_entropy:1.1769
+770/50000 train_loss: 3.2636 train_time: 7.2m step_avg: 562.18ms tok/s: 932605 art_cycles:0.957 extra_cycle_frac:0.319 art_continue:cycle1=0.492,cycle2=0.582,cycle3=0.654 art_entropy:1.2201 art_router_loss:-0.0305
+step:770/50000 art_probe window_steps:10 avg_cycles:0.880 extra_cycle_frac:0.293 avg_stop:0.707 router_entropy:1.1971
+780/50000 train_loss: 3.2333 train_time: 7.3m step_avg: 564.54ms tok/s: 928696 art_cycles:1.000 extra_cycle_frac:0.333 art_continue:cycle1=0.512,cycle2=0.660,cycle3=0.496 art_entropy:1.2676 art_router_loss:0.0117
+step:780/50000 art_probe window_steps:10 avg_cycles:0.925 extra_cycle_frac:0.308 avg_stop:0.692 router_entropy:1.2290
+790/50000 train_loss: 3.2515 train_time: 7.5m step_avg: 566.88ms tok/s: 924865 art_cycles:0.969 extra_cycle_frac:0.323 art_continue:cycle1=0.539,cycle2=0.491,cycle3=0.606 art_entropy:1.2352 art_router_loss:-0.0214
+step:790/50000 art_probe window_steps:10 avg_cycles:0.946 extra_cycle_frac:0.315 avg_stop:0.685 router_entropy:1.2404
+800/50000 train_loss: 3.2116 train_time: 7.6m step_avg: 569.23ms tok/s: 921056 art_cycles:0.988 extra_cycle_frac:0.329 art_continue:cycle1=0.629,cycle2=0.402,cycle3=0.412 art_entropy:1.2640 art_router_loss:-0.0682
+step:800/50000 art_probe window_steps:10 avg_cycles:0.970 extra_cycle_frac:0.323 avg_stop:0.677 router_entropy:1.2422
+810/50000 train_loss: 3.2412 train_time: 7.7m step_avg: 571.57ms tok/s: 917276 art_cycles:0.953 extra_cycle_frac:0.318 art_continue:cycle1=0.648,cycle2=0.332,cycle3=0.414 art_entropy:1.2285 art_router_loss:-0.0161
+step:810/50000 art_probe window_steps:10 avg_cycles:1.002 extra_cycle_frac:0.334 avg_stop:0.666 router_entropy:1.2500
+820/50000 train_loss: 3.2212 train_time: 7.8m step_avg: 573.82ms tok/s: 913684 art_cycles:1.094 extra_cycle_frac:0.365 art_continue:cycle1=0.664,cycle2=0.426,cycle3=0.518 art_entropy:1.3050 art_router_loss:0.0324
+step:820/50000 art_probe window_steps:10 avg_cycles:0.972 extra_cycle_frac:0.324 avg_stop:0.676 router_entropy:1.2349
+830/50000 train_loss: 3.2238 train_time: 8.0m step_avg: 576.01ms tok/s: 910212 art_cycles:1.035 extra_cycle_frac:0.345 art_continue:cycle1=0.656,cycle2=0.381,cycle3=0.481 art_entropy:1.2936 art_router_loss:-0.0293
+step:830/50000 art_probe window_steps:10 avg_cycles:0.971 extra_cycle_frac:0.324 avg_stop:0.676 router_entropy:1.2494
+840/50000 train_loss: 3.1963 train_time: 8.1m step_avg: 578.09ms tok/s: 906926 art_cycles:0.945 extra_cycle_frac:0.315 art_continue:cycle1=0.594,cycle2=0.396,cycle3=0.446 art_entropy:1.2504 art_router_loss:0.0259
+step:840/50000 art_probe window_steps:10 avg_cycles:0.955 extra_cycle_frac:0.318 avg_stop:0.682 router_entropy:1.2520
+850/50000 train_loss: 3.1905 train_time: 8.2m step_avg: 580.11ms tok/s: 903771 art_cycles:0.855 extra_cycle_frac:0.285 art_continue:cycle1=0.531,cycle2=0.418,cycle3=0.452 art_entropy:1.2036 art_router_loss:0.1046
+step:850/50000 art_probe window_steps:10 avg_cycles:0.930 extra_cycle_frac:0.310 avg_stop:0.690 router_entropy:1.2350
+860/50000 train_loss: 3.2181 train_time: 8.3m step_avg: 582.10ms tok/s: 900676 art_cycles:0.855 extra_cycle_frac:0.285 art_continue:cycle1=0.566,cycle2=0.371,cycle3=0.396 art_entropy:1.2137 art_router_loss:-0.0049
+step:860/50000 art_probe window_steps:10 avg_cycles:0.934 extra_cycle_frac:0.311 avg_stop:0.689 router_entropy:1.2430
+870/50000 train_loss: 3.1781 train_time: 8.5m step_avg: 584.01ms tok/s: 897739 art_cycles:0.980 extra_cycle_frac:0.327 art_continue:cycle1=0.590,cycle2=0.410,cycle3=0.595 art_entropy:1.2543 art_router_loss:0.0469
+step:870/50000 art_probe window_steps:10 avg_cycles:0.913 extra_cycle_frac:0.304 avg_stop:0.696 router_entropy:1.2308
+880/50000 train_loss: 3.1679 train_time: 8.6m step_avg: 585.83ms tok/s: 894950 art_cycles:0.785 extra_cycle_frac:0.262 art_continue:cycle1=0.512,cycle2=0.365,cycle3=0.495 art_entropy:1.1502 art_router_loss:-0.0939
+step:880/50000 art_probe window_steps:10 avg_cycles:0.882 extra_cycle_frac:0.294 avg_stop:0.706 router_entropy:1.2090
+890/50000 train_loss: 3.2266 train_time: 8.7m step_avg: 587.64ms tok/s: 892192 art_cycles:0.879 extra_cycle_frac:0.293 art_continue:cycle1=0.570,cycle2=0.354,cycle3=0.517 art_entropy:1.1999 art_router_loss:0.0020
+step:890/50000 art_probe window_steps:10 avg_cycles:0.916 extra_cycle_frac:0.305 avg_stop:0.695 router_entropy:1.2255
+900/50000 train_loss: 3.1622 train_time: 8.8m step_avg: 589.54ms tok/s: 889310 art_cycles:1.184 extra_cycle_frac:0.395 art_continue:cycle1=0.684,cycle2=0.495,cycle3=0.497 art_entropy:1.3605 art_router_loss:0.0195
+step:900/50000 art_probe window_steps:10 avg_cycles:0.998 extra_cycle_frac:0.333 avg_stop:0.667 router_entropy:1.2582
+910/50000 train_loss: 3.2166 train_time: 9.0m step_avg: 592.20ms tok/s: 885327 art_cycles:1.031 extra_cycle_frac:0.344 art_continue:cycle1=0.660,cycle2=0.368,cycle3=0.463 art_entropy:1.2692 art_router_loss:0.0031
+step:910/50000 art_probe window_steps:10 avg_cycles:1.038 extra_cycle_frac:0.346 avg_stop:0.654 router_entropy:1.2737
+920/50000 train_loss: 3.1737 train_time: 9.1m step_avg: 594.05ms tok/s: 882565 art_cycles:1.035 extra_cycle_frac:0.345 art_continue:cycle1=0.625,cycle2=0.446,cycle3=0.464 art_entropy:1.2719 art_router_loss:-0.0019
+step:920/50000 art_probe window_steps:10 avg_cycles:1.027 extra_cycle_frac:0.342 avg_stop:0.658 router_entropy:1.2603
+930/50000 train_loss: 3.1763 train_time: 9.2m step_avg: 595.82ms tok/s: 879943 art_cycles:0.863 extra_cycle_frac:0.288 art_continue:cycle1=0.559,cycle2=0.360,cycle3=0.541 art_entropy:1.1750 art_router_loss:-0.0052
+step:930/50000 art_probe window_steps:10 avg_cycles:1.001 extra_cycle_frac:0.334 avg_stop:0.666 router_entropy:1.2488
+940/50000 train_loss: 3.1806 train_time: 9.4m step_avg: 597.54ms tok/s: 877409 art_cycles:0.914 extra_cycle_frac:0.305 art_continue:cycle1=0.590,cycle2=0.385,cycle3=0.406 art_entropy:1.2202 art_router_loss:-0.0028
+step:940/50000 art_probe window_steps:10 avg_cycles:0.988 extra_cycle_frac:0.329 avg_stop:0.671 router_entropy:1.2477
+950/50000 train_loss: 3.1883 train_time: 9.5m step_avg: 599.21ms tok/s: 874971 art_cycles:1.039 extra_cycle_frac:0.346 art_continue:cycle1=0.637,cycle2=0.391,cycle3=0.597 art_entropy:1.2636 art_router_loss:-0.0463
+step:950/50000 art_probe window_steps:10 avg_cycles:0.968 extra_cycle_frac:0.323 avg_stop:0.677 router_entropy:1.2347
+960/50000 train_loss: 3.1485 train_time: 9.6m step_avg: 600.79ms tok/s: 872658 art_cycles:0.969 extra_cycle_frac:0.323 art_continue:cycle1=0.605,cycle2=0.391,cycle3=0.516 art_entropy:1.2367 art_router_loss:-0.0003
+step:960/50000 art_probe window_steps:10 avg_cycles:0.941 extra_cycle_frac:0.314 avg_stop:0.686 router_entropy:1.2190
+970/50000 train_loss: 3.1712 train_time: 9.7m step_avg: 602.32ms tok/s: 870443 art_cycles:0.945 extra_cycle_frac:0.315 art_continue:cycle1=0.594,cycle2=0.386,cycle3=0.488 art_entropy:1.2267 art_router_loss:0.0325
+step:970/50000 art_probe window_steps:10 avg_cycles:0.921 extra_cycle_frac:0.307 avg_stop:0.693 router_entropy:1.2140
+980/50000 train_loss: 3.1417 train_time: 9.9m step_avg: 603.83ms tok/s: 868276 art_cycles:0.902 extra_cycle_frac:0.301 art_continue:cycle1=0.582,cycle2=0.363,cycle3=0.510 art_entropy:1.2048 art_router_loss:0.0076
+step:980/50000 art_probe window_steps:10 avg_cycles:0.929 extra_cycle_frac:0.310 avg_stop:0.690 router_entropy:1.2241
+990/50000 train_loss: 3.1656 train_time: 10.0m step_avg: 605.29ms tok/s: 866170 art_cycles:0.938 extra_cycle_frac:0.313 art_continue:cycle1=0.617,cycle2=0.360,cycle3=0.451 art_entropy:1.2343 art_router_loss:0.0154
+step:990/50000 art_probe window_steps:10 avg_cycles:0.923 extra_cycle_frac:0.308 avg_stop:0.692 router_entropy:1.2197
+992/50000 val_loss: 3.1626 val_bpb: 1.2243
+stopping_early: wallclock_cap train_time: 600749ms step: 992/50000
+peak memory allocated: 27071 MiB reserved: 32662 MiB
+ema:applying EMA weights
+pre-quantization post-ema val_loss:3.18714621 val_bpb:1.23384362 eval_time:20692ms
+pre-quantization post-ema_art_routes avg_cycles:0.932 extra_cycle_frac:0.311 art_entropy:1.2431 art_continue:cycle1=0.544,cycle2=0.474,cycle3=0.506
+Serialized model: 136234857 bytes
+GPTQ:collecting Hessians from calibration data...
+GPTQ:calibration path fixed_full
+GPTQ:collected 67 Hessians in 9.6s
+Quantized weights:
+  gptq (int6): blocks.attn.c_k.weight, blocks.attn.c_q.weight, blocks.attn.c_v.weight, blocks.attn.proj.weight, blocks.mlp.fc.weight, blocks.mlp.proj.weight
+  gptq (int8): tok_emb.weight
+  passthrough (float16): art_router.fc.bias, art_router.fc.weight, art_router.proj.bias, art_router.proj.weight, art_router_early.fc.bias, art_router_early.fc.weight, art_router_early.proj.bias, art_router_early.proj.weight, art_router_first.fc.bias, art_router_first.fc.weight, art_router_first.proj.bias, art_router_first.proj.weight, blocks.attn.attn_out_gate_w, blocks.attn.q_gain, blocks.attn_scale, blocks.mlp_scale, blocks.resid_mix, embed_scale, skip_gates, skip_weights
+Serialized model quantized+brotli: 16333382 bytes
+quantized val_loss:3.20555511 val_bpb:1.24097028 eval_time:40654ms
+quantized_art_routes avg_cycles:0.930 extra_cycle_frac:0.310 art_entropy:1.2449 art_continue:cycle1=0.545,cycle2=0.475,cycle3=0.487

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/submission.json
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/submission.json
@@ -1,0 +1,97 @@
+{
+  "author": "Kashi Tuteja",
+  "github_id": 122947991,
+  "name": "Adaptive Recurrent Transformer (ART)",
+  "blurb": "Non-record research package for learned recurrent-depth control, based on the philosophy that not all tokens deserve equal compute.",
+  "date": "2026-05-01",
+  "track": "non_record_16mb",
+  "submission_type": "non-record research contribution",
+  "core_example": "PR1855-family + Simple ART",
+  "val_loss": 2.62586001,
+  "val_bpb": 1.19991555,
+  "bytes_total": 17032456,
+  "bytes_code": null,
+  "artifact_bytes": 17032456,
+  "training_hardware": "1xH100",
+  "training_time_seconds": 596.418,
+  "evaluation_time_seconds": 2834.007,
+  "non_record_reason": "Research submission emphasizing Adaptive Recurrent Transformer architecture novelty.",
+  "results": [
+    {
+      "variation": "PR1855 + Soft ART",
+      "val_bpb": 1.06425679,
+      "hardware": "8xH100",
+      "script": "training_files/pr1855_soft_art.py",
+      "log": "logs/pr1855_soft_art_dashboard_20260430_204203_abf0ec8e.stdout.log"
+    },
+    {
+      "variation": "PR1812 + ART",
+      "val_bpb": 1.11827658,
+      "hardware": "8xH100",
+      "script": "training_files/pr1812_art.py",
+      "log": "logs/pr1812_art_dashboard_20260429_224456_a9eaabed.stdout.log"
+    },
+    {
+      "variation": "PR1855 + Simple ART",
+      "val_bpb": 1.19991555,
+      "hardware": "1xH100",
+      "script": "training_files/pr1855_simple_art.py",
+      "log": "logs/pr1855_simple_art_dashboard_20260430_224429_ad4a36d5.stdout.log"
+    },
+    {
+      "variation": "Triple-ART Small Batch",
+      "val_bpb": 1.24097028,
+      "hardware": "1xH100",
+      "script": "training_files/triple_art_small_batch.py",
+      "log": "logs/triple_art_small_batch_dashboard_20260429_192817_de3b33e8.stdout.log"
+    },
+    {
+      "variation": "ART Saved-RoPE + TTT",
+      "val_bpb": 1.24134639,
+      "hardware": "1xH100",
+      "script": "training_files/art_saved_rope_ttt.py",
+      "log": "logs/art_saved_rope_ttt_dashboard_20260429_162729_57cac6b0.stdout.log"
+    },
+    {
+      "variation": "Adaptive Recurrent Transformer 1",
+      "val_bpb": 1.316838,
+      "hardware": "1xH100",
+      "script": "training_files/art_1.py",
+      "log": "logs/art_1_dashboard_20260417_013525_a3d8aea8.stdout.log"
+    },
+    {
+      "variation": "ART-2",
+      "val_bpb": 1.32066497,
+      "hardware": "1xH100",
+      "script": "training_files/art_2.py",
+      "log": "logs/art_2_dashboard_20260419_161439_9b946387.stdout.log"
+    },
+    {
+      "variation": "ART-3",
+      "val_bpb": 1.48486805,
+      "hardware": "1xH100",
+      "script": "training_files/art_3.py",
+      "log": "logs/art_3_dashboard_20260419_225908_cf9443b3.stdout.log"
+    },
+    {
+      "variation": "ART-2.5",
+      "val_bpb": 1.52850374,
+      "hardware": "1xH100",
+      "script": "training_files/art_2_5.py",
+      "log": "logs/art_2_5_dashboard_20260420_004715_e49b5f70.stdout.log"
+    }
+  ],
+  "provenance": {
+    "core_stack_readme": "records/track_10min_16mb/2026-04-29_SmearGateBOSFix_3Seed_1.06141/README.md",
+    "core_stack": "SmearGateBOSFix / LQER / CaseOps / phased-TTT record-family stack",
+    "credited_lineage": [
+      "PR #1851 by @aquariouseworkman",
+      "PR #1787 by @nprime06",
+      "PR #1797 by @dexhunter",
+      "PR #1729 by @romeerp",
+      "PR #1394 by @clarkkev",
+      "PR #549 by @abaybektursun",
+      "BOS bug identification by @cocohearts"
+    ]
+  }
+}

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/train_gpt.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/train_gpt.py
@@ -1,0 +1,4010 @@
+import base64, collections, copy, fcntl, glob, io, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+# ===== Fused softcapped cross-entropy (Triton) — training-only path =====
+# Replaces the eager
+#     logits_softcap = softcap * tanh(logits / softcap)
+#     F.cross_entropy(logits_softcap.float(), targets, reduction="mean")
+# sequence with a single fused kernel that reads logits_proj once, applies
+# softcap in-register, and computes (LSE, loss) in one streaming pass. The
+# backward kernel mirrors the forward so there's no stored softcapped logits.
+# Numerically identical to the eager path up to fp32 accumulation differences.
+_FUSED_CE_LIBRARY = "pgsubmission1draft7fusedce"
+_FUSED_CE_BLOCK_SIZE = 1024
+_FUSED_CE_NUM_WARPS = 4
+
+
+@triton.jit
+def _softcapped_ce_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    max_val = -float("inf")
+    sum_exp = 0.0
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=-float("inf"),
+        ).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C)
+        z = tl.where(mask, z, -float("inf"))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    target_val = tl.load(logits_row_ptr + target * stride_logits_v).to(tl.float32)
+    target_z = A * tl.sigmoid(target_val * inv_C)
+    tl.store(losses_ptr + row_idx, lse - target_z)
+
+
+@triton.jit
+def _softcapped_ce_bwd_kernel(
+    grad_logits_ptr, grad_losses_ptr, lse_ptr, logits_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    stride_grad_n, stride_grad_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_logits_ptr + row_idx * stride_grad_n
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_losses_ptr + row_idx).to(tl.float32)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    dz_dx_scale = A * inv_C
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=0.0,
+        ).to(tl.float32)
+        sigmoid_u = tl.sigmoid(val * inv_C)
+        z = A * sigmoid_u
+        probs = tl.exp(z - lse)
+        grad_z = grad_loss * (probs - tl.where(cols == target, 1.0, 0.0))
+        grad_x = grad_z * (dz_dx_scale * sigmoid_u * (1.0 - sigmoid_u))
+        tl.store(grad_row_ptr + cols * stride_grad_v, grad_x, mask=mask)
+
+
+def _validate_softcapped_ce_inputs(
+    logits: Tensor, targets: Tensor, softcap: float,
+) -> tuple[Tensor, Tensor]:
+    if logits.ndim != 2:
+        raise ValueError(f"Expected logits.ndim=2, got {logits.ndim}")
+    if targets.ndim != 1:
+        raise ValueError(f"Expected targets.ndim=1, got {targets.ndim}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    if not logits.is_cuda or not targets.is_cuda:
+        raise ValueError("softcapped_cross_entropy requires CUDA tensors")
+    if softcap <= 0.0:
+        raise ValueError(f"softcap must be positive, got {softcap}")
+    if logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    logits = logits.contiguous()
+    targets = targets.contiguous()
+    if targets.dtype != torch.int64:
+        targets = targets.to(dtype=torch.int64)
+    return logits, targets
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce", mutates_args=())
+def softcapped_ce_op(logits: Tensor, targets: Tensor, softcap: float) -> tuple[Tensor, Tensor]:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    n_rows, n_cols = logits.shape
+    losses = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    lse = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    _softcapped_ce_fwd_kernel[(n_rows,)](
+        logits, losses, lse, targets,
+        logits.stride(0), logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return losses, lse
+
+
+@softcapped_ce_op.register_fake
+def _(logits: Tensor, targets: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1:
+        raise ValueError("softcapped_ce fake impl expects 2D logits and 1D targets")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    n_rows = logits.shape[0]
+    return (
+        logits.new_empty((n_rows,), dtype=torch.float32),
+        logits.new_empty((n_rows,), dtype=torch.float32),
+    )
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce_backward", mutates_args=())
+def softcapped_ce_backward_op(
+    logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float,
+) -> Tensor:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    lse = lse.contiguous()
+    grad_losses = grad_losses.contiguous().to(dtype=torch.float32)
+    if lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("Expected 1D lse and grad_losses")
+    if lse.shape[0] != logits.shape[0] or grad_losses.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"Expected row-aligned lse/grad_losses, got logits={tuple(logits.shape)} "
+            f"lse={tuple(lse.shape)} grad_losses={tuple(grad_losses.shape)}"
+        )
+    grad_logits = torch.empty_like(logits)
+    n_rows, n_cols = logits.shape
+    _softcapped_ce_bwd_kernel[(n_rows,)](
+        grad_logits, grad_losses, lse, logits, targets,
+        logits.stride(0), logits.stride(1),
+        grad_logits.stride(0), grad_logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return grad_logits
+
+
+@softcapped_ce_backward_op.register_fake
+def _(logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1 or lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("softcapped_ce_backward fake impl expects 2D logits and 1D row tensors")
+    if (
+        logits.shape[0] != targets.shape[0]
+        or logits.shape[0] != lse.shape[0]
+        or logits.shape[0] != grad_losses.shape[0]
+    ):
+        raise ValueError("softcapped_ce_backward fake impl expects row-aligned tensors")
+    return logits.new_empty(logits.shape)
+
+
+def _softcapped_ce_setup_context(
+    ctx: torch.autograd.function.FunctionCtx, inputs, output,
+) -> None:
+    logits, targets, softcap = inputs
+    _losses, lse = output
+    ctx.save_for_backward(logits, targets, lse)
+    ctx.softcap = float(softcap)
+
+
+def _softcapped_ce_backward(
+    ctx: torch.autograd.function.FunctionCtx, grad_losses: Tensor, grad_lse: "Tensor | None",
+):
+    del grad_lse
+    logits, targets, lse = ctx.saved_tensors
+    grad_logits = torch.ops.pgsubmission1draft7fusedce.softcapped_ce_backward(
+        logits, targets, lse, grad_losses, ctx.softcap
+    )
+    return grad_logits, None, None
+
+
+softcapped_ce_op.register_autograd(
+    _softcapped_ce_backward, setup_context=_softcapped_ce_setup_context,
+)
+
+
+def softcapped_cross_entropy(
+    logits: Tensor, targets: Tensor, softcap: float, reduction: str = "mean",
+) -> Tensor:
+    losses, _lse = torch.ops.pgsubmission1draft7fusedce.softcapped_ce(
+        logits, targets, float(softcap)
+    )
+    if reduction == "none":
+        return losses
+    if reduction == "sum":
+        return losses.sum()
+    if reduction == "mean":
+        return losses.mean()
+    raise ValueError(f"Unsupported reduction={reduction!r}")
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    # Fused softcapped CE (Triton). Training-only — forward_logits eval path still uses
+    # eager softcap+F.cross_entropy. Default ON since validated as at-worst neutral.
+    fused_ce_enabled = bool(int(os.environ.get("FUSED_CE_ENABLED", "1")))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    # Simple ART branch control for the record recurrence. After the normal
+    # loop phase has activated, one tiny router samples whether this batch uses
+    # the short record path or the full path with the extra six 3-4-5 blocks.
+    art_simple_enabled = bool(int(os.environ.get("ART_SIMPLE_ENABLED", "1")))
+    art_simple_enable_at = float(os.environ.get("ART_SIMPLE_ENABLE_AT", "0.45"))
+    art_router_hidden_dim = int(os.environ.get("ART_ROUTER_HIDDEN_DIM", "64"))
+    art_router_lr = float(os.environ.get("ART_ROUTER_LR", "0.0005"))
+    art_router_wd = float(os.environ.get("ART_ROUTER_WD", "0.01"))
+    art_router_entropy_start = float(os.environ.get("ART_ROUTER_ENTROPY_START", "0.02"))
+    art_router_entropy_end = float(os.environ.get("ART_ROUTER_ENTROPY_END", "0.002"))
+    art_cycle_penalty = float(os.environ.get("ART_CYCLE_PENALTY", "0.002"))
+    art_baseline_decay = float(os.environ.get("ART_BASELINE_DECAY", "0.98"))
+    art_eval_mode = os.environ.get("ART_EVAL_MODE", "sample")
+    art_probe_every = int(os.environ.get("ART_PROBE_EVERY", "50"))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_activate_at = float(os.environ.get("EMA_ACTIVATE_AT", "0.55"))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 1.0))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 1))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 10.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    # AttnOutGate (per-head multiplicative output gate, PR #1667 MarioPaerle).
+    # Zero-init weight: 2*sigmoid(0)=1 -> transparent at start. Source defaults to
+    # block input x ('proj'); 'q' uses raw Q projection output.
+    attn_out_gate_enabled = bool(int(os.environ.get("ATTN_OUT_GATE_ENABLED", "0")))
+    attn_out_gate_src = os.environ.get("ATTN_OUT_GATE_SRC", "proj")
+    # SmearGate (input-dependent forward-1 token smear, modded-nanogpt @classiclarryd
+    # via PR #1667). x_t <- x_t + lam * sigmoid(W*x_t[:gate_window]) * x_{t-1}.
+    # lam=0 + W=0 -> transparent at init.
+    smear_gate_enabled = bool(int(os.environ.get("SMEAR_GATE_ENABLED", "0")))
+    # Window: first GATE_WINDOW dims of the source feed the gate projection.
+    gate_window = int(os.environ.get("GATE_WINDOW", 12))
+    # Gated Attention (Qwen, NeurIPS 2025 Best Paper, arXiv:2505.06708;
+    # qiuzh20/gated_attention). Per-head sigmoid gate on SDPA output, BEFORE
+    # out_proj. Gate input = full block input x (paper's headwise G1 variant
+    # driven from hidden_states). W_g shape (num_heads, dim), plain sigmoid.
+    # Near-zero init gives g~0.5 at step 0 (half attention output); per-block
+    # attn_scale (init 1.0) compensates during training. Name contains
+    # "attn_gate" so CONTROL_TENSOR_NAME_PATTERNS routes it to scalar AdamW.
+    gated_attn_enabled = bool(int(os.environ.get("GATED_ATTN_ENABLED", "0")))
+    gated_attn_init_std = float(os.environ.get("GATED_ATTN_INIT_STD", 0.01))
+    # Dedicated int8-per-row quantization for `attn_gate_w` tensors. These are
+    # small ((num_heads, dim) = (8, 512) = 4096 params) and bypass GPTQ via the
+    # numel<=65536 passthrough branch -> stored as fp16 (8 KB/layer, ~65 KB total
+    # compressed). int8-per-row cuts the raw tensor in half with negligible BPB
+    # impact: scales per head (8 values), symmetric quant over [-127, 127].
+    # No Hessian needed (gate weights not in collect_hessians()).
+    gated_attn_quant_gate = bool(int(os.environ.get("GATED_ATTN_QUANT_GATE", "0")))
+    # Sparse Attention Gate (modded-nanogpt-style). Keeps dense SDPA and only
+    # swaps the output-gate input to the first GATE_WINDOW residual dims.
+    # W_g: (num_heads, gate_window) = (8, 12) = 96 params/layer (~44K total),
+    # vs dense GatedAttn's (8, 512) = 4K/layer (~44K diff). Name "attn_gate_w"
+    # is shared so quant routing and int8 gate passthrough Just Work. Gate
+    # passthrough int8 still applies via GATED_ATTN_QUANT_GATE=1.
+    # Mutually exclusive with ATTN_OUT_GATE_ENABLED and GATED_ATTN_ENABLED.
+    sparse_attn_gate_enabled = bool(int(os.environ.get("SPARSE_ATTN_GATE_ENABLED", "0")))
+    sparse_attn_gate_init_std = float(os.environ.get("SPARSE_ATTN_GATE_INIT_STD", 0.0))
+    sparse_attn_gate_scale = float(os.environ.get("SPARSE_ATTN_GATE_SCALE", 1.0))
+    # LQER asymmetric rank-k correction on top-K quant-error tensors (PR #1530 v2 port).
+    # Computes SVD of E = W_fp - W_quant, packs top-r A,B as INT2/INT4 (asym) or INTk (sym).
+    lqer_enabled = bool(int(os.environ.get("LQER_ENABLED", "1")))
+    lqer_rank = int(os.environ.get("LQER_RANK", 4))
+    lqer_top_k = int(os.environ.get("LQER_TOP_K", 3))
+    lqer_factor_bits = int(os.environ.get("LQER_FACTOR_BITS", 4))
+    lqer_asym_enabled = bool(int(os.environ.get("LQER_ASYM_ENABLED", "1")))
+    lqer_asym_group = int(os.environ.get("LQER_ASYM_GROUP", "64"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    # CaseOps integration: optional override of dataset root + tokenizer path.
+    # When CASEOPS_ENABLED=1, the wrapper loads a per-token byte sidecar
+    # (fineweb_val_bytes_*.bin, identical shard layout to val_*.bin) and uses
+    # it as the canonical raw-byte budget for BPB accounting. The sidecar
+    # REPLACES the build_sentencepiece_luts byte-counting path entirely.
+    caseops_enabled = bool(int(os.environ.get("CASEOPS_ENABLED", "0")))
+    _default_caseops_data = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "datasets",
+        "fineweb10B_sp8192_lossless_caps_caseops_v1_reserved",
+    )
+    _default_caseops_tok = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "tokenizers",
+        "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model",
+    )
+    if caseops_enabled:
+        datasets_dir = os.environ.get("DATA_PATH", _default_caseops_data)
+        tokenizer_path = os.environ.get("TOKENIZER_PATH", _default_caseops_tok)
+    else:
+        datasets_dir = os.environ.get(
+            "DATA_PATH",
+            os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}"),
+        )
+        tokenizer_path = os.environ.get(
+            "TOKENIZER_PATH",
+            os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"),
+        )
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    val_bytes_files = os.path.join(datasets_dir, "fineweb_val_bytes_*.bin")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        # CaseOps: when enabled, load per-token byte sidecar and stash it as a
+        # CPU tensor aligned 1:1 with self.val_tokens. eval_val/eval_val_ttt
+        # branches use this as the canonical raw-byte budget per token.
+        self.caseops_enabled = bool(getattr(h, "caseops_enabled", False))
+        self.val_bytes = None
+        if self.caseops_enabled:
+            self.val_bytes = load_validation_byte_sidecar(
+                h.val_bytes_files, h.eval_seq_len, self.val_tokens.numel()
+            )
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    # Filter out CaseOps byte sidecar shards which share the val_*.bin glob.
+    files = [
+        Path(p)
+        for p in sorted(glob.glob(pattern))
+        if "_bytes_" not in Path(p).name
+    ]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_byte_sidecar(pattern, seq_len, expected_len):
+    """Load CaseOps per-token byte sidecar(s). Same shard layout as token shards
+    (256 int32 header + uint16 array). Each entry = canonical raw-text byte
+    budget for that token in the corresponding val shard. Returns a CPU
+    int16 tensor sliced to match expected_len (i.e. val_tokens length)."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No byte sidecar files for pattern: {pattern}")
+    shards = [load_data_shard(file) for file in files]
+    # load_data_shard returns uint16 — that's exactly what the sidecar stores.
+    bytes_full = torch.cat(shards).contiguous()
+    if bytes_full.numel() < expected_len:
+        raise ValueError(
+            f"Byte sidecar too short: {bytes_full.numel()} < val_tokens {expected_len}"
+        )
+    return bytes_full[:expected_len].to(torch.int32)
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True,
+        attn_out_gate=False, attn_out_gate_src="proj", gate_window=12,
+        gated_attn=False, gated_attn_init_std=0.01,
+        sparse_attn_gate=False, sparse_attn_gate_init_std=0.0, sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        if int(attn_out_gate) + int(gated_attn) + int(sparse_attn_gate) > 1:
+            raise ValueError(
+                "attn_out_gate, gated_attn, and sparse_attn_gate are mutually exclusive"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+        # AttnOutGate (PR #1667 MarioPaerle): per-head multiplicative gate on attention
+        # output. CastedLinear so restore_fp32_params casts back to fp32 for GPTQ.
+        # _zero_init -> 2*sigmoid(0)=1 -> transparent at init.
+        self.attn_out_gate = attn_out_gate
+        self.attn_out_gate_src = attn_out_gate_src
+        self.gate_window = gate_window
+        if attn_out_gate:
+            self.attn_gate_proj = CastedLinear(gate_window, num_heads, bias=False)
+            self.attn_gate_proj._zero_init = True
+        # Gated Attention (arXiv:2505.06708, Qwen, NeurIPS 2025). Per-head sigmoid
+        # gate on SDPA output, BEFORE out_proj. Gate projection W_g: (num_heads, dim).
+        # Name "attn_gate_w" contains "attn_gate" substring so it matches
+        # CONTROL_TENSOR_NAME_PATTERNS and routes to the scalar AdamW group.
+        # fp32 Parameter -> restore_fp32_params path covers it via the ndim<2 OR
+        # name-pattern check (name matches "attn_gate"). Cast to x.dtype on use.
+        self.gated_attn = gated_attn
+        if gated_attn:
+            W = torch.empty(num_heads, dim, dtype=torch.float32)
+            nn.init.normal_(W, mean=0.0, std=gated_attn_init_std)
+            self.attn_gate_w = nn.Parameter(W)
+        # Sparse attention head-output gate (modded-nanogpt style). Keeps dense SDPA
+        # and only narrows the gate input to the first gate_window residual dims.
+        # W_g: (num_heads, gate_window). y_{t,h} <- sigmoid(scale * W_g_h @ x_t[:gate_window]) * y_{t,h}.
+        # Shares attn_gate_w name with dense GatedAttn so the quant routing
+        # (CONTROL_TENSOR_NAME_PATTERNS / attn_gate_w int8 passthrough) is unchanged.
+        self.sparse_attn_gate = sparse_attn_gate
+        self.sparse_attn_gate_scale = sparse_attn_gate_scale
+        if sparse_attn_gate:
+            W = torch.empty(num_heads, gate_window, dtype=torch.float32)
+            if sparse_attn_gate_init_std > 0:
+                nn.init.normal_(W, mean=0.0, std=sparse_attn_gate_init_std)
+            else:
+                nn.init.zeros_(W)
+            self.attn_gate_w = nn.Parameter(W)
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        # q_raw kept around as a tap point for attn_out_gate_src='q' (post-projection,
+        # pre-reshape, pre-RoPE).
+        q_raw = F.linear(x, q_w.to(x.dtype))
+        q = q_raw.reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        # AttnOutGate inlined (PR #1667). Inline + .contiguous() barrier so torch.compile
+        # fullgraph=True is happy (this avoids the @torch.compiler.disable trap that
+        # crashed gates v3). Per-head gate on (B,T,H,D) tensor: g shape [B,T,H], broadcast
+        # over D via [..., None]. zero-init weight -> 2*sigmoid(0)=1 -> transparent.
+        if self.attn_out_gate:
+            gate_src = q_raw if self.attn_out_gate_src == "q" else x
+            gate_in = gate_src[..., : self.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(self.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (arXiv:2505.06708 G1). Inline + .contiguous() barrier so
+        # torch.compile fullgraph=True is happy. Per-head gate on (B,T,H,D): g shape
+        # [B,T,H], broadcast over D via [..., None]. Paper: g = sigmoid(x @ W_g.T)
+        # where W_g: (H, dim). .to(x.dtype) on fp32 param before broadcast with bf16.
+        if self.gated_attn:
+            x_c = x.contiguous()
+            g = torch.sigmoid(F.linear(x_c, self.attn_gate_w.to(x.dtype)))
+            y = y * g[..., None]
+        # Sparse head-output gate: narrower (gate_window) input, same shape g as GatedAttn.
+        if self.sparse_attn_gate:
+            gate_in = x[..., : self.gate_window].contiguous()
+            g = torch.sigmoid(
+                self.sparse_attn_gate_scale
+                * F.linear(gate_in, self.attn_gate_w.to(x.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn,
+            attn_out_gate=attn_out_gate, attn_out_gate_src=attn_out_gate_src, gate_window=gate_window,
+            gated_attn=gated_attn, gated_attn_init_std=gated_attn_init_std,
+            sparse_attn_gate=sparse_attn_gate,
+            sparse_attn_gate_init_std=sparse_attn_gate_init_std,
+            sparse_attn_gate_scale=sparse_attn_gate_scale,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.fused_ce_enabled = bool(h.fused_ce_enabled)
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                    attn_out_gate=h.attn_out_gate_enabled,
+                    attn_out_gate_src=h.attn_out_gate_src,
+                    gate_window=h.gate_window,
+                    gated_attn=h.gated_attn_enabled,
+                    gated_attn_init_std=h.gated_attn_init_std,
+                    sparse_attn_gate=h.sparse_attn_gate_enabled,
+                    sparse_attn_gate_init_std=h.sparse_attn_gate_init_std,
+                    sparse_attn_gate_scale=h.sparse_attn_gate_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        self.default_encoder_indices = tuple(range(self.num_encoder_layers))
+        self.default_decoder_indices = tuple(
+            range(self.num_encoder_layers, self.num_encoder_layers + self.num_decoder_layers)
+        )
+        self.art_simple_enabled = bool(h.art_simple_enabled)
+        self.art_simple_runtime_active = True
+        self.art_last_continue_rate = 1.0
+        self.art_last_entropy = 0.0
+        self.art_last_action = 1.0
+        if self.art_simple_enabled and (
+            h.num_loops != 2 or h.loop_start != 3 or h.loop_end != 5
+        ):
+            raise ValueError(
+                "SimpleART is pinned to num_loops=2, loop_start=3, loop_end=5 "
+                f"for the current record recurrence; got {h.num_loops=}, "
+                f"{h.loop_start=}, {h.loop_end=}."
+            )
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        # SmearGate (PR #1667 / modded-nanogpt @classiclarryd):
+        #   x_t <- x_t + lam * sigmoid(W * x_t[:gate_window]) * x_{t-1}.
+        # Per-token forward-1 smear of the embedding lane. W zero-init + lam=0 ->
+        # transparent at init. Uses CastedLinear so restore_fp32_params handles dtype.
+        self.smear_gate_enabled = h.smear_gate_enabled
+        if self.smear_gate_enabled:
+            self.smear_window = h.gate_window
+            self.smear_gate = CastedLinear(self.smear_window, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        if self.art_simple_enabled:
+            self.art_router_fc = CastedLinear(
+                2 * h.model_dim, h.art_router_hidden_dim, bias=False
+            )
+            self.art_router_proj = CastedLinear(h.art_router_hidden_dim, 2, bias=False)
+            self.art_router_proj._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def _forward_hidden(self, input_ids, cu_seqlens=None, max_seqlen=0, enc_iter=None, dec_iter=None):
+        """Run the encoder/decoder stack to the final RMSNorm; returns pre-projection hidden.
+        Shared by eval (softcap+projection via forward_logits) and train (fused CE path)."""
+        x = self.tok_emb(input_ids)
+        # SmearGate (PR #1667). Inline gate compute with .contiguous() on the slice fed
+        # to the projection so torch.compile fullgraph is happy. lam=0 + W=0 -> identity
+        # at init. This block runs unconditionally on the smear path; the cat keeps
+        # position 0 untouched so causality holds.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            bos_mask = (input_ids[:, 1:] == 1).unsqueeze(-1)
+            g = g.masked_fill(bos_mask, 0.0)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        if enc_iter is None:
+            enc_iter = self.encoder_indices if self.looping_active else self.default_encoder_indices
+        if dec_iter is None:
+            dec_iter = self.decoder_indices if self.looping_active else self.default_decoder_indices
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        return x
+
+    def _forward_hidden_short(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        return self._forward_hidden(
+            input_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            enc_iter=self.default_encoder_indices,
+            dec_iter=self.default_decoder_indices,
+        )
+
+    def _forward_hidden_full(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        return self._forward_hidden(
+            input_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            enc_iter=self.encoder_indices,
+            dec_iter=self.decoder_indices,
+        )
+
+    def _project_logits(self, hidden):
+        if self.tie_embeddings:
+            return F.linear(hidden, self.tok_emb.weight)
+        return self.lm_head(hidden)
+
+    def art_route_logits(self, input_ids):
+        x = self.tok_emb(input_ids).detach()
+        x = F.rms_norm(x, (x.size(-1),))
+        last = x[:, -1, :]
+        max_pool = x.amax(dim=1)
+        feat = torch.cat([last, max_pool], dim=-1).mean(dim=0, keepdim=True)
+        h = F.silu(self.art_router_fc(feat))
+        return self.art_router_proj(h).float().squeeze(0)
+
+    def _loss_from_logits_proj(self, logits_proj, target_ids):
+        flat_targets = target_ids.reshape(-1)
+        if self.fused_ce_enabled:
+            return softcapped_cross_entropy(
+                logits_proj.reshape(-1, logits_proj.size(-1)),
+                flat_targets,
+                self.logit_softcap,
+                reduction="mean",
+            )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            flat_targets,
+            reduction="mean",
+        )
+
+    def forward_short(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_short(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return self._loss_from_logits_proj(self._project_logits(hidden), target_ids)
+
+    def forward_full(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_full(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return self._loss_from_logits_proj(self._project_logits(hidden), target_ids)
+
+    def forward_logits_short(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_short(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_logits_full(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_full(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        return self._loss_from_logits_proj(logits_proj, target_ids)
+
+    def forward_ttt(self, input_ids, target_ids, lora, enc_iter=None, dec_iter=None):
+        x = self.tok_emb(input_ids)
+        # SmearGate on the TTT path — same inline compute as forward_logits.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            bos_mask = (input_ids[:, 1:] == 1).unsqueeze(-1)
+            g = g.masked_fill(bos_mask, 0.0)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        if enc_iter is None:
+            enc_iter = self.encoder_indices if self.looping_active else self.default_encoder_indices
+        if dec_iter is None:
+            dec_iter = self.decoder_indices if self.looping_active else self.default_decoder_indices
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def forward_ttt_short(self, input_ids, target_ids, lora):
+        return self.forward_ttt(
+            input_ids,
+            target_ids,
+            lora,
+            enc_iter=self.default_encoder_indices,
+            dec_iter=self.default_decoder_indices,
+        )
+
+    def forward_ttt_full(self, input_ids, target_ids, lora):
+        return self.forward_ttt(
+            input_ids,
+            target_ids,
+            lora,
+            enc_iter=self.encoder_indices,
+            dec_iter=self.decoder_indices,
+        )
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # Keep raw Q for AttnOutGate src='q' (matches forward path semantics).
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT path) — inline + .contiguous() barrier, same as the eval path.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT path). Gate input is n (post-norm block input), same
+        # as eval path. .to(n.dtype) on fp32 param before bf16 broadcast.
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT path) — must match the eval path in
+        # forward() exactly, else training (which applied the gate) and TTT eval (which
+        # skipped it) produce mismatched representations and catastrophic BPB regression.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT parallel path) — inline + .contiguous() barrier.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT parallel path). Gate input is n (post-norm block input).
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT parallel path) — must match the
+        # eval path in forward() to keep train/eval semantics in sync.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    # PR-1767: rank-scaled output (alpha/rank), like standard LoRA. Decouples
+    # effective magnitude from rank so changing rank does not change LR scale.
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "144"))
+    # PR-1767: optionally keep A warm across per-doc resets (only B is zeroed).
+    # Accumulates useful feature directions across documents within a TTT phase.
+    _WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = self._ALPHA / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            if not self._WARM_START_A:
+                self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return ((x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+# Polar Express per-iteration minimax Newton-Schulz coefficients (PR #1344).
+# Replaces the fixed (3.4445, -4.775, 2.0315) coefficients of stock Muon.
+# Applied at backend_steps=5 — taking more than 5 iterations from this list
+# falls back to the final (converged) tuple via the slice guard below.
+_PE_COEFFS = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    coeffs = _PE_COEFFS[:steps] if steps <= len(_PE_COEFFS) else _PE_COEFFS
+    for a, b, c in coeffs:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas,attn_gate_proj,attn_gate_w,smear_gate,smear_lambda",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        # SmearGate params live on GPT root (not in .blocks), so add them by hand.
+        # Both are tiny (gate_window scalars + 1 lambda). Optimized via scalar Adam.
+        if getattr(base_model, "smear_gate_enabled", False):
+            scalar_params.append(base_model.smear_gate.weight)
+            scalar_params.append(base_model.smear_lambda)
+        router_params = []
+        if getattr(base_model, "art_simple_enabled", False):
+            router_params.extend(
+                [
+                    base_model.art_router_fc.weight,
+                    base_model.art_router_proj.weight,
+                ]
+            )
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizer_router = (
+            torch.optim.AdamW(
+                [
+                    {
+                        "params": router_params,
+                        "lr": h.art_router_lr,
+                        "base_lr": h.art_router_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                weight_decay=h.art_router_wd,
+                fused=True,
+            )
+            if router_params
+            else None
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if self.optimizer_router is not None:
+            self.optimizers.append(self.optimizer_router)
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_params.extend(router_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_router is not None:
+            self.optimizer_router.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _quantize_gate_int8_row(w):
+    # Symmetric int8-per-row quantization for small gate tensors. w shape
+    # (R, C) -> (R,) scales in fp16, int8 values in [-127, 127]. Single scale
+    # per row keeps accuracy high while halving storage vs fp16.
+    W = w.float().contiguous()
+    row_max = W.abs().amax(dim=1).clamp_min(1e-10)
+    s = (row_max / 127.0).to(torch.float16)
+    sf = s.float().view(-1, 1)
+    q = torch.clamp(torch.round(W / sf), -127, 127).to(torch.int8)
+    return q, s
+
+
+def _lqer_pack(A, B, bits):
+    rng = 2 ** (bits - 1) - 1
+    sA = (A.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    sB = (B.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    qB = torch.clamp(torch.round(B / sB.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    return qA, sA, qB, sB
+
+
+def _lqer_pack_asym(A, B, g=64):
+    # A: INT2 per-matrix scalar (signed [-2,1], scale = |A|max/1.5).
+    sA = (A.abs().amax().clamp_min(1e-10) / 1.5).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float()), -2, 1).to(torch.int8)
+    # B: INT4 groupwise g over flattened B (signed [-8,7], per-group scale).
+    Bf = B.reshape(-1, g)
+    Bmax = Bf.abs().amax(dim=-1, keepdim=True).clamp_min(1e-10)
+    sB = (Bmax / 7.5).to(torch.float16).reshape(-1)
+    qB = torch.clamp(torch.round(Bf / sB.float().reshape(-1, 1)), -8, 7).to(
+        torch.int8
+    ).reshape(B.shape)
+    return qA, sA, qB, sB
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    quant_gate = bool(getattr(h, "gated_attn_quant_gate", False))
+    lqer_on = bool(getattr(h, "lqer_enabled", False))
+    lqer_cands = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        # Dedicated int8-per-row path for attn_gate_w (bypasses both GPTQ and
+        # fp16 passthrough). Applied BEFORE the numel<=65536 passthrough check
+        # so the gate tensor is routed here instead of to fp16.
+        if (
+            quant_gate
+            and t.is_floating_point()
+            and t.ndim == 2
+            and name.endswith(".attn_gate_w")
+            # Dense GatedAttn: (num_heads, dim) = (8, 512) = 4096.
+            # Sparse gate: (num_heads, gate_window) = (8, 12) = 96.
+            # Both need int8-per-row routing; the 1024 lower bound in stock
+            # PR-1736 presumed dense-only. Widen to catch both.
+            and 32 <= t.numel() <= 8192
+        ):
+            gq, gs = _quantize_gate_int8_row(t)
+            result[name + ".gq"] = gq
+            result[name + ".gs"] = gs
+            meta[name] = "gate_int8_row"
+            continue
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+        if lqer_on:
+            W_q = q.float() * s.float().view(-1, 1)
+            E = t.float() - W_q
+            lqer_cands[name] = (E, float(E.norm()))
+    if lqer_on and lqer_cands:
+        top = sorted(lqer_cands.items(), key=lambda kv: -kv[1][1])[: h.lqer_top_k]
+        asym_on = bool(getattr(h, "lqer_asym_enabled", False))
+        asym_g = int(getattr(h, "lqer_asym_group", 64))
+        for (name, (E, _)) in top:
+            U, S, Vh = torch.linalg.svd(E, full_matrices=False)
+            r = min(h.lqer_rank, S.numel())
+            A = (U[:, :r] * S[:r]).contiguous()
+            B = Vh[:r, :].contiguous()
+            if asym_on and B.numel() % asym_g == 0:
+                qA, sA, qB, sB = _lqer_pack_asym(A, B, asym_g)
+                result[name + ".lqA_a"] = qA
+                result[name + ".lqAs_a"] = sA
+                result[name + ".lqB_a"] = qB
+                result[name + ".lqBs_a"] = sB
+                meta[name] = meta[name] + "+lqer_asym"
+            else:
+                qA, sA, qB, sB = _lqer_pack(A, B, h.lqer_factor_bits)
+                result[name + ".lqA"] = qA
+                result[name + ".lqAs"] = sA
+                result[name + ".lqB"] = qB
+                result[name + ".lqBs"] = sB
+                meta[name] = meta[name] + "+lqer"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        if info == "gate_int8_row":
+            gq = result[name + ".gq"]
+            gs = result[name + ".gs"]
+            out[name] = (gq.float() * gs.float().view(-1, 1)).to(orig_dtype)
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            W = q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+        else:
+            W = q.float() * float(s.item())
+        if "lqer_asym" in info:
+            qA_t = result[name + ".lqA_a"]
+            sA_t = result[name + ".lqAs_a"]
+            qB_t = result[name + ".lqB_a"]
+            sB_t = result[name + ".lqBs_a"]
+            qA = qA_t.float() * float(sA_t)
+            g_sz = qB_t.numel() // sB_t.numel()
+            qB = (qB_t.reshape(-1, g_sz).float() * sB_t.float().view(-1, 1)).reshape(
+                qB_t.shape
+            )
+            W = W + qA @ qB
+        elif "lqer" in info:
+            qA = result[name + ".lqA"].float() * result[name + ".lqAs"].float().view(-1, 1)
+            qB = result[name + ".lqB"].float() * result[name + ".lqBs"].float().view(-1, 1)
+            W = W + qA @ qB
+        out[name] = W.to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    try:
+        minified = subprocess.run(
+            ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+            input=code_raw, capture_output=True, check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        minified = code_raw
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    log("GPTQ:collecting Hessians from calibration data...")
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    t_quant = time.perf_counter()
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    log(f"GPTQ:quantized in {time.perf_counter()-t_quant:.1f}s")
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    t_compress = time.perf_counter()
+    quant_blob = _compress(quant_raw, h.compressor)
+    log(f"GPTQ:compressed+saved in {time.perf_counter()-t_compress:.1f}s")
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                # CaseOps: read per-token byte budget from sidecar at the same
+                # global positions as the target tokens y. raw_start/raw_end
+                # span [raw_start, raw_end), x = local[:-1], y = local[1:],
+                # so y is at sidecar positions [raw_start + 1, raw_end).
+                sidecar_slice = val_data.val_bytes[raw_start + 1 : raw_end].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                val_byte_count += sidecar_slice.to(torch.float64).sum()
+            else:
+                token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (
+                    val_data.has_leading_space_lut[tgt_ids]
+                    & ~val_data.is_boundary_token_lut[prev_ids]
+                ).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+    y_bytes=None,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if y_bytes is not None:
+        tok_bytes = y_bytes.to(torch.float64)
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            # CaseOps sidecar-driven byte budget. Mirror the index pattern
+            # used to build y from all_tokens: y[b, j] corresponds to the
+            # token at global position tok_starts[b] + 1 + j (when valid).
+            y_bytes_arg = None
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                y_idx = (
+                    tok_starts.unsqueeze(1)
+                    + 1
+                    + col_idx[:context_size].unsqueeze(0)
+                )
+                y_idx = y_idx.clamp_(max=val_data.val_bytes.numel() - 1)
+                y_bytes_arg = val_data.val_bytes[y_idx].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                # Mirror the `valid` masking used for y so out-of-range tokens
+                # contribute zero bytes (matches y=0 substitution above).
+                y_bytes_arg = torch.where(
+                    valid, y_bytes_arg, torch.zeros_like(y_bytes_arg)
+                )
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                    y_bytes=y_bytes_arg,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    if getattr(base_model, "art_simple_enabled", False) and h.art_simple_enable_at > 0.0:
+        base_model.art_simple_runtime_active = False
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    compiled_short_loss = torch.compile(
+        base_model.forward_short, dynamic=False, fullgraph=True
+    )
+    compiled_full_loss = torch.compile(
+        base_model.forward_full, dynamic=False, fullgraph=True
+    )
+    compiled_short_logits = torch.compile(
+        base_model.forward_logits_short, dynamic=False, fullgraph=True
+    )
+    compiled_full_logits = torch.compile(
+        base_model.forward_logits_full, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    log(
+        "simple_art:"
+        f"enabled:{int(getattr(base_model, 'art_simple_enabled', False))} "
+        f"enable_at:{h.art_simple_enable_at:g} "
+        f"router_hidden:{h.art_router_hidden_dim} "
+        f"router_lr:{h.art_router_lr:g} "
+        f"cycle_penalty:{h.art_cycle_penalty:g} "
+        f"entropy:{h.art_router_entropy_start:g}->{h.art_router_entropy_end:g} "
+        f"eval_mode:{h.art_eval_mode}"
+    )
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.1f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def art_entropy_coef(frac):
+        t = min(max(frac, 0.0), 1.0)
+        return h.art_router_entropy_start + (
+            h.art_router_entropy_end - h.art_router_entropy_start
+        ) * t
+
+    def select_art_action(input_ids, mode="sample"):
+        logits = base_model.art_route_logits(input_ids)
+        log_probs = F.log_softmax(logits, dim=-1)
+        probs = log_probs.exp()
+        route_probs = probs.detach().clone()
+        if h.distributed:
+            dist.all_reduce(route_probs, op=dist.ReduceOp.AVG)
+        mode = mode.lower()
+        if mode in ("full", "force_full", "continue"):
+            action_t = torch.ones((), device=device, dtype=torch.long)
+        elif mode in ("short", "force_short", "stop"):
+            action_t = torch.zeros((), device=device, dtype=torch.long)
+        elif mode == "argmax":
+            action_t = route_probs.argmax().to(dtype=torch.long)
+        elif mode == "sample":
+            if h.distributed:
+                if h.rank == 0:
+                    action_t = torch.multinomial(route_probs, 1).to(dtype=torch.long)[0]
+                else:
+                    action_t = torch.zeros((), device=device, dtype=torch.long)
+                dist.broadcast(action_t, src=0)
+            else:
+                action_t = torch.multinomial(route_probs, 1).to(dtype=torch.long)[0]
+        else:
+            raise ValueError(
+                f"Unsupported ART_EVAL_MODE={mode!r}; use sample, argmax, full, or short"
+            )
+        action = int(action_t.item())
+        entropy = -(probs * log_probs).sum()
+        base_model.art_last_continue_rate = float(route_probs[1].item())
+        base_model.art_last_entropy = float(entropy.detach().item())
+        base_model.art_last_action = float(action)
+        return action, log_probs[action], entropy, route_probs[1].detach()
+
+    art_loss_baseline = None
+    art_window = {
+        "n": 0,
+        "continue_actions": 0.0,
+        "continue_prob": 0.0,
+        "entropy": 0.0,
+        "policy": 0.0,
+    }
+
+    def step_fn(step, lr_scale, train_frac=0.0):
+        nonlocal art_loss_baseline
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                if getattr(base_model, "art_simple_enabled", False) and getattr(
+                    base_model, "art_simple_runtime_active", True
+                ):
+                    action, log_prob, entropy, continue_prob = select_art_action(
+                        x, mode="sample"
+                    )
+                    if action:
+                        loss = compiled_full_loss(
+                            x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len
+                        )
+                    else:
+                        loss = compiled_short_loss(
+                            x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len
+                        )
+                    cost = loss.detach().float() + h.art_cycle_penalty * float(action)
+                    if art_loss_baseline is None:
+                        art_loss_baseline = cost.detach()
+                    advantage = (cost - art_loss_baseline).detach()
+                    entropy_bonus = art_entropy_coef(train_frac)
+                    policy_loss = advantage * log_prob - entropy_bonus * entropy
+                    art_loss_baseline = (
+                        h.art_baseline_decay * art_loss_baseline
+                        + (1.0 - h.art_baseline_decay) * cost.detach()
+                    )
+                    loss_for_backward = loss + policy_loss.to(dtype=loss.dtype)
+                    art_window["n"] += 1
+                    art_window["continue_actions"] += float(action)
+                    art_window["continue_prob"] += float(continue_prob.item())
+                    art_window["entropy"] += float(entropy.detach().item())
+                    art_window["policy"] += float(policy_loss.detach().float().item())
+                else:
+                    loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+                    loss_for_backward = loss
+            train_loss += loss.detach()
+            (loss_for_backward / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    def eval_forward_logits(input_ids, cu_seqlens=None, max_seqlen=0):
+        if getattr(base_model, "art_simple_enabled", False) and getattr(
+            base_model, "art_simple_runtime_active", False
+        ):
+            action, _log_prob, _entropy, _continue_prob = select_art_action(
+                input_ids, mode=h.art_eval_mode
+            )
+            if action:
+                return compiled_full_logits(
+                    input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
+            return compiled_short_logits(
+                input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+        return compiled_forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        def _run_art_path_warmup():
+            if not getattr(base_model, "art_simple_enabled", False):
+                return
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for fn in (compiled_short_loss, compiled_full_loss):
+                    for _ in range(warmup_cu_iters):
+                        optimizers.zero_grad_all()
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                            wloss = fn(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                        (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            _run_art_path_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+        if getattr(base_model, "art_simple_enabled", False):
+            base_model.art_simple_runtime_active = h.art_simple_enable_at <= 0.0
+    _live_state = base_model.state_dict(keep_vars=True)
+    ema_decay = h.ema_decay
+    ema_activate_at = h.ema_activate_at
+    ema_state = None
+    _ema_pairs = None
+    ema_active = False
+
+    def _activate_ema(step, frac):
+        nonlocal ema_state, _ema_pairs, ema_active
+        ema_state = {
+            name: t.detach().float().clone() for (name, t) in _live_state.items()
+        }
+        _ema_pairs = [(ema_state[name], t) for (name, t) in _live_state.items()]
+        ema_active = True
+        log(f"ema:activated step:{step} frac:{frac:.3f} decay:{ema_decay:g}")
+
+    if ema_activate_at <= 0.0:
+        _activate_ema(0, 0.0)
+    else:
+        log(f"ema:delayed activate_at:{ema_activate_at:g} decay:{ema_decay:g}")
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, eval_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        enable_art_now = (
+            getattr(base_model, "art_simple_enabled", False)
+            and base_model.looping_active
+            and not getattr(base_model, "art_simple_runtime_active", True)
+            and frac >= h.art_simple_enable_at
+        )
+        if h.distributed and getattr(base_model, "art_simple_enabled", False) and not getattr(
+            base_model, "art_simple_runtime_active", True
+        ):
+            flag = torch.tensor(int(enable_art_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_art_now = bool(flag.item())
+        if enable_art_now:
+            base_model.art_simple_runtime_active = True
+            log(f"simple_art:enabled step:{step} frac:{frac:.3f}")
+            if h.distributed:
+                dist.barrier()
+                log("simple_art:sync_done")
+        train_loss = step_fn(step, scale, frac)
+        enable_ema_now = (not ema_active) and frac >= ema_activate_at
+        if h.distributed and not ema_active:
+            flag = torch.tensor(int(enable_ema_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_ema_now = bool(flag.item())
+        if enable_ema_now:
+            _activate_ema(step + 1, frac)
+            if h.distributed:
+                dist.barrier()
+                log("ema:sync_done")
+        if ema_active:
+            with torch.no_grad():
+                for ema_t, t in _ema_pairs:
+                    ema_t.mul_(ema_decay).add_(t.detach(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+            if (
+                h.art_probe_every > 0
+                and step % h.art_probe_every == 0
+                and art_window["n"] > 0
+            ):
+                n = max(art_window["n"], 1)
+                log(
+                    "simple_art_probe "
+                    f"step:{step} samples:{n} "
+                    f"continue_action:{art_window['continue_actions'] / n:.3f} "
+                    f"continue_prob:{art_window['continue_prob'] / n:.3f} "
+                    f"entropy:{art_window['entropy'] / n:.4f} "
+                    f"policy_loss:{art_window['policy'] / n:.6f} "
+                    f"baseline:{float(art_loss_baseline.item()) if art_loss_baseline is not None else 0.0:.4f}"
+                )
+                for key in art_window:
+                    art_window[key] = 0
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    if ema_state is not None:
+        log("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log("ema:inactive using final live weights")
+    return base_model, compiled_model, eval_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    # TTT_EVAL_ONLY: skip training + GPTQ, jump straight to TTT eval on a
+    # pre-existing quantized artifact. Used to test TTT-only improvements
+    # (e.g., PR-1767's alpha/warm-start/WD) without retraining.
+    ttt_eval_only = os.environ.get("TTT_EVAL_ONLY", "0") == "1"
+    if ttt_eval_only:
+        log("TTT_EVAL_ONLY=1 — skipping training + GPTQ, loading saved artifact for TTT eval")
+        log(f"ttt_lora_alpha: {BatchedLinearLoRA._ALPHA}")
+        log(f"ttt_warm_start_a: {BatchedLinearLoRA._WARM_START_A}")
+        log(f"ttt_weight_decay: {h.ttt_weight_decay}")
+    else:
+        t_artifact_start = time.perf_counter()
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+        torch._dynamo.reset()
+        if os.environ.get("PREQUANT_ONLY", "0") == "1":
+            timed_eval(
+                "diagnostic pre-quantization post-ema",
+                eval_val,
+                h,
+                device,
+                val_data,
+                compiled_model,
+                compiled_forward_logits,
+            )
+            log("PREQUANT_ONLY=1 — skipping serialize/GPTQ/post-quant eval/TTT")
+            return
+        t_serialize_start = time.perf_counter()
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+        serialize_seconds = time.perf_counter() - t_serialize_start
+        log(f"serialize_wallclock: {serialize_seconds:.3f}s")
+        if h.distributed:
+            dist.barrier()
+        artifact_production_seconds = time.perf_counter() - t_artifact_start
+        log(f"artifact_production_wallclock: {artifact_production_seconds:.3f}s (must be < {h.max_wallclock_seconds})")
+        timed_eval(
+            "diagnostic pre-quantization post-ema",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    if getattr(eval_model, "art_simple_enabled", False):
+        eval_model.art_simple_runtime_active = True
+    if not ttt_eval_only:
+        compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            eval_model.forward_logits, dynamic=False, fullgraph=True
+        )
+        if getattr(eval_model, "art_simple_enabled", False):
+            compiled_short_logits = torch.compile(
+                eval_model.forward_logits_short, dynamic=False, fullgraph=True
+            )
+            compiled_full_logits = torch.compile(
+                eval_model.forward_logits_full, dynamic=False, fullgraph=True
+            )
+
+            def _select_eval_art_action(input_ids):
+                logits = eval_model.art_route_logits(input_ids)
+                probs = F.softmax(logits.float(), dim=-1).detach()
+                if h.distributed:
+                    dist.all_reduce(probs, op=dist.ReduceOp.AVG)
+                mode = h.art_eval_mode.lower()
+                if mode in ("full", "force_full", "continue"):
+                    action_t = torch.ones((), device=device, dtype=torch.long)
+                elif mode in ("short", "force_short", "stop"):
+                    action_t = torch.zeros((), device=device, dtype=torch.long)
+                elif mode == "argmax":
+                    action_t = probs.argmax().to(dtype=torch.long)
+                elif mode == "sample":
+                    if h.distributed:
+                        if h.rank == 0:
+                            action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                        else:
+                            action_t = torch.zeros((), device=device, dtype=torch.long)
+                        dist.broadcast(action_t, src=0)
+                    else:
+                        action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                else:
+                    raise ValueError(
+                        f"Unsupported ART_EVAL_MODE={h.art_eval_mode!r}; use sample, argmax, full, or short"
+                    )
+                return int(action_t.item())
+
+            def compiled_forward_logits_art(input_ids, cu_seqlens=None, max_seqlen=0):
+                if _select_eval_art_action(input_ids):
+                    return compiled_full_logits(
+                        input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                    )
+                return compiled_short_logits(
+                    input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
+
+            compiled_forward_logits = compiled_forward_logits_art
+        timed_eval(
+            "diagnostic quantized",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        del eval_model
+    if h.ttt_enabled:
+        if not ttt_eval_only:
+            del compiled_model
+        if ttt_eval_only:
+            del eval_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        if getattr(ttt_model, "art_simple_enabled", False):
+            ttt_model.art_simple_runtime_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _select_ttt_art_action(input_ids):
+            logits = ttt_model.art_route_logits(input_ids)
+            probs = F.softmax(logits.float(), dim=-1).detach()
+            if h.distributed:
+                dist.all_reduce(probs, op=dist.ReduceOp.AVG)
+            mode = h.art_eval_mode.lower()
+            if mode in ("full", "force_full", "continue"):
+                action_t = torch.ones((), device=device, dtype=torch.long)
+            elif mode in ("short", "force_short", "stop"):
+                action_t = torch.zeros((), device=device, dtype=torch.long)
+            elif mode == "argmax":
+                action_t = probs.argmax().to(dtype=torch.long)
+            elif mode == "sample":
+                if h.distributed:
+                    if h.rank == 0:
+                        action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                    else:
+                        action_t = torch.zeros((), device=device, dtype=torch.long)
+                    dist.broadcast(action_t, src=0)
+                else:
+                    action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+            else:
+                raise ValueError(
+                    f"Unsupported ART_EVAL_MODE={h.art_eval_mode!r}; use sample, argmax, full, or short"
+                )
+            return int(action_t.item())
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        def _fwd_ttt_short_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt_short(input_ids, target_ids, lora=lora)
+
+        def _fwd_ttt_full_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt_full(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+        _fwd_ttt_compiled_short = None
+        _fwd_ttt_compiled_full = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner, _fwd_ttt_compiled_short, _fwd_ttt_compiled_full
+            if getattr(ttt_model, "art_simple_enabled", False):
+                if _select_ttt_art_action(input_ids):
+                    if _fwd_ttt_compiled_full is None:
+                        _fwd_ttt_compiled_full = torch.compile(
+                            _fwd_ttt_full_inner, dynamic=True
+                        )
+                    return _fwd_ttt_compiled_full(input_ids, target_ids, lora=lora)
+                if _fwd_ttt_compiled_short is None:
+                    _fwd_ttt_compiled_short = torch.compile(
+                        _fwd_ttt_short_inner, dynamic=True
+                    )
+                return _fwd_ttt_compiled_short(input_ids, target_ids, lora=lora)
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                if getattr(ttt_model, "art_simple_enabled", False):
+                    if _fwd_ttt_compiled_short is None:
+                        _fwd_ttt_compiled_short = torch.compile(
+                            _fwd_ttt_short_inner, dynamic=True
+                        )
+                    if _fwd_ttt_compiled_full is None:
+                        _fwd_ttt_compiled_full = torch.compile(
+                            _fwd_ttt_full_inner, dynamic=True
+                        )
+                    warmup_fns = (_fwd_ttt_compiled_short, _fwd_ttt_compiled_full)
+                else:
+                    warmup_fns = (fwd_ttt_compiled,)
+                for warmup_fn in warmup_fns:
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = warmup_fn(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_1.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_1.py
@@ -1,0 +1,2697 @@
+"""
+Adaptive Recurrent Transformer
+
+Three identically sized transformer blocks are reused recurrently with Fourier
+step embeddings. A sidecar Transformer Router chooses among the three blocks or
+stopping recursion from latent-state features and is trained directly from the
+final sequence loss with an entropy bonus.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from collections import deque
+from pathlib import Path
+
+# Delta vs `train_gpt.py`: prefer zstd for the final artifact when
+# the package is available, but keep a zlib fallback so the script still runs in
+# lighter local environments.
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# Delta vs baseline attention: call FlashAttention 3 directly instead of
+# `torch.scaled_dot_product_attention(...)`.
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.checkpoint import checkpoint
+
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model"
+    )
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Highest-impact defaults for short 10-minute, 8xH100 runs. The 7-hour
+    # single-H100 run kept improving through the wallclock cap, so the short-run
+    # defaults bias toward later decay, no mid-run full-val pauses, and faster
+    # router adaptation.
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 250))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 8))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    router_lr = float(os.environ.get("ROUTER_LR", 0.001))
+    router_entropy_bonus_start = float(
+        os.environ.get("ROUTER_ENTROPY_BONUS_START", 0.2)
+    )
+    router_entropy_bonus_end = float(os.environ.get("ROUTER_ENTROPY_BONUS_END", 0.02))
+    router_step_penalty = float(os.environ.get("ROUTER_STEP_PENALTY", 0.03))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 250))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 0))
+    swa_every = int(os.environ.get("SWA_EVERY", 25))
+
+    # Validation cadence and logging. Validation always uses the full
+    # fineweb_val split, so the short-run default only evaluates at the end.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+
+    # Transformer Router hyperparameters.
+    router_hidden_dim = int(os.environ.get("ROUTER_HIDDEN_DIM", 128))
+    router_wd = float(os.environ.get("ROUTER_WD", 0.01))
+    activation_checkpointing = bool(
+        int(os.environ.get("ACTIVATION_CHECKPOINTING", "0"))
+    )
+    compiled_routed_experts = bool(int(os.environ.get("COMPILED_ROUTED_EXPERTS", "0")))
+
+    # This variant keeps the longer-context training setup from the 11L
+    # experiment, but trades 11 unique blocks for 3 recurrently reused blocks.
+    # Each recurrent step routes into one of those three blocks or stops using
+    # the Transformer Router from the start of training onward.
+    # Model shape.
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 3))
+    num_recurrent_steps = int(os.environ.get("NUM_RECURRENT_STEPS", 12))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 14))
+    model_dim = int(os.environ.get("MODEL_DIM", 896))
+    num_heads = int(os.environ.get("NUM_HEADS", 28))
+    mlp_mult = float(os.environ.get("MLP_MULT", 5.0))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85)
+    )
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    muon_wd = float(os.environ.get("MUON_WD", 0.02))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.01))
+
+    # Evaluation / auxiliary training features.
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    swa_enabled = bool(int(os.environ.get("SWA_ENABLED", "1")))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # Optional carry-over from the source experiment: apply XSA only on the last
+    # N recurrent steps.
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 0))  # 0 disables XSA entirely
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+#
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+
+def zeropower_via_newtonschulz5(
+    G: Tensor, steps: int = 10, eps: float = 1e-7
+) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            # Delta vs baseline Muon: this version adds decoupled weight decay so
+            # matrix params can use MuonWD without moving them onto Adam.
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    # Delta vs baseline eval: training and evaluation sequence lengths can
+    # differ, because this stack trains at long context and also uses
+    # sliding-window evaluation later in the script.
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y, router_active=router_active).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+# Delta vs baseline export: extra control tensors from SmearGate/Bigram/XSA stay
+# out of the aggressive quantization path.
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(
+    name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]
+) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(
+            torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None]
+        )
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = (
+            torch.clamp(torch.round(clipped / scale[:, None]), -127, 127)
+            .to(torch.int8)
+            .contiguous()
+        )
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = (
+        float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item())
+        if t32.numel()
+        else 0.0
+    )
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = (
+        torch.clamp(
+            torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127
+        )
+        .to(torch.int8)
+        .contiguous()
+    )
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "int8_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (
+                (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1))))
+                .to(dtype=dtype)
+                .contiguous()
+            )
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+    def skip(self, n: int) -> None:
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            self.pos += k
+            remaining -= k
+
+
+class DistributedTokenLoader:
+    # Each call advances the shared token stream by one global batch, but each
+    # rank only materializes its local span. The extra "+1" token lets us build
+    # (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(
+        self, global_tokens: int, seq_len: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        rank_prefix = self.rank * per_rank_span
+        if rank_prefix > 0:
+            self.stream.skip(rank_prefix)
+        local = self.stream.take(per_rank_span).to(dtype=torch.int64)
+        rank_suffix = (self.world_size - self.rank - 1) * per_rank_span
+        if rank_suffix > 0:
+            self.stream.skip(rank_suffix)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        # Delta vs baseline linear layers: optional straight-through fake quant
+        # lets later experiments turn on lightweight QAT without changing module
+        # call sites or adding parallel weight copies.
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (
+                    torch.clamp(torch.round(w32 / scale[:, None]), -32, 31)
+                    * scale[:, None]
+                ).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # NTK-aware RoPE: auto-scales base frequency when seq_len exceeds train_seq_len.
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (
+                    new_base
+                    ** (
+                        torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                        / self.dim
+                    )
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+# Delta vs `train_gpt.py`:
+# - head layout matches FlashAttention 3 directly, so there are no transpose
+#   calls around the kernel invocation
+# - late recurrent steps can opt into XSA after the main attention kernel runs
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        # Reshape y into KV head groups — free view, no memory alloc
+        y_g = y.reshape(B, T, Hkv, group, D)  # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)  # [B, T, Hkv, 1, D] — broadcast ready
+        # Project out self-value component per KV head group
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, use_xsa: bool | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # Baseline uses SDPA with `enable_gqa=True`; this record uses FA3
+        # directly, then optionally applies XSA as a cheap post-processing step.
+        y = flash_attn_3_func(q, k, v, causal=True)
+        apply_xsa = self.use_xsa if use_xsa is None else use_xsa
+        if apply_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# Delta vs baseline input path: before the block stack, embeddings get a
+# one-token temporal blend (`SmearGate`) plus a cheap hashed-bigram residual.
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = (
+            CastedLinear(bigram_dim, model_dim, bias=False)
+            if bigram_dim != model_dim
+            else None
+        )
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class FourierStepEmbedding(nn.Module):
+    """Deterministic sinusoidal embedding for recurrent UT steps."""
+
+    def __init__(self, num_steps: int, dim: int):
+        super().__init__()
+        half = dim // 2
+        steps = torch.arange(num_steps, dtype=torch.float32).unsqueeze(1)
+        freqs = 1.0 / (10000.0 ** (2.0 * torch.arange(half, dtype=torch.float32) / dim))
+        angles = steps * freqs.unsqueeze(0)
+        table = torch.zeros(num_steps, dim, dtype=torch.float32)
+        table[:, 0 : 2 * half : 2] = torch.sin(angles)
+        table[:, 1 : 2 * half : 2] = torch.cos(angles)
+        self.register_buffer("table", table, persistent=False)
+
+    def forward(self, step_idx: int) -> Tensor:
+        return self.table[step_idx]
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class TransformerRouter(nn.Module):
+    """Predict routing logits over the three blocks plus stop."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, num_actions: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_actions)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, router_inputs: Tensor) -> Tensor:
+        x = F.gelu(self.fc(router_inputs.float()))
+        return self.proj(x)
+
+
+class UniversalTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        # Keep the residual path simple for recurrence: pre-norm attention,
+        # residual add, then pre-norm MLP and residual add.
+
+    def forward(self, h: Tensor, step_emb: Tensor, use_xsa: bool = False) -> Tensor:
+        x = h + step_emb[None, None, :]
+        h = h + self.attn(self.attn_norm(x), use_xsa=use_xsa)
+        h = h + self.mlp(self.mlp_norm(h))
+        return h
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_recurrent_steps: int = 8,
+        router_entropy_bonus: float = 0.01,
+        router_step_penalty: float = 0.01,
+        activation_checkpointing: bool = True,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if num_layers != 3:
+            raise ValueError(
+                f"Adaptive Recurrent Transformer expects NUM_LAYERS=3, got {num_layers}"
+            )
+        if num_recurrent_steps <= 0:
+            raise ValueError(
+                f"NUM_RECURRENT_STEPS must be positive, got {num_recurrent_steps}"
+            )
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_recurrent_steps = num_recurrent_steps
+        self.router_entropy_bonus = router_entropy_bonus
+        self.router_step_penalty = router_step_penalty
+        self.activation_checkpointing = activation_checkpointing
+        self.xsa_last_n = xsa_last_n
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.last_actual_recurrent_steps = 0.0
+        self.last_main_loss = 0.0
+        self.last_router_loss = 0.0
+        self.last_router_policy_loss = 0.0
+        self.last_router_entropy = 0.0
+        self.last_forward_action_counts = torch.zeros(
+            self.num_recurrent_steps, num_layers + 1, dtype=torch.float32
+        )
+        object.__setattr__(self, "_transformer_router", None)
+        self._last_router_log_probs: Tensor | None = None
+        self._last_router_entropies: Tensor | None = None
+        self._last_router_decision_counts: Tensor | None = None
+        self._last_router_depths: Tensor | None = None
+        self._compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+        self._unused_block_anchor_enabled = False
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = (
+            BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim)
+            if bigram_vocab_size > 0
+            else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.step_embedding = FourierStepEmbedding(num_recurrent_steps, model_dim)
+        # Keep an empty tensor attribute for compatibility with the existing
+        # trainer plumbing, but register it as a buffer, not a Parameter.
+        # Otherwise DDP sees an unused parameter and can fail on the next
+        # warmup/train forward with an unfinished reduction error.
+        self.register_buffer(
+            "skip_weights",
+            torch.empty(0, model_dim, dtype=torch.float32),
+            persistent=False,
+        )
+        self.blocks = nn.ModuleList(
+            [
+                UniversalTransformerBlock(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [
+                CastedLinear(model_dim, vocab_size, bias=False)
+                for _ in range(mtp_num_heads)
+            ]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        self._init_weights()
+
+    def xsa_step_indices(self, num_recurrent_steps: int | None = None) -> list[int]:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if self.xsa_last_n <= 0:
+            return []
+        start = max(0, steps - self.xsa_last_n)
+        return list(range(start, steps))
+
+    def _step_uses_xsa(
+        self, step_idx: int, num_recurrent_steps: int | None = None
+    ) -> bool:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        return self.xsa_last_n > 0 and step_idx >= steps - self.xsa_last_n
+
+    def set_compiled_recurrent_step_runners(
+        self, runners: dict[tuple[int, int], callable]
+    ) -> None:
+        self._compiled_recurrent_step_runners = runners
+
+    def set_unused_block_anchor_enabled(self, enabled: bool) -> None:
+        self._unused_block_anchor_enabled = enabled
+
+    def _unused_block_param_anchor(
+        self, used_block_indices: set[int], ref: Tensor
+    ) -> Tensor:
+        if len(used_block_indices) >= len(self.blocks):
+            return ref.new_zeros(())
+        # Touch parameters of blocks that were skipped so DDP can keep
+        # `find_unused_parameters=False` without changing the numerical forward.
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx, block in enumerate(self.blocks):
+            if block_idx in used_block_indices:
+                continue
+            for param in block.parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def set_transformer_router(self, router: nn.Module) -> None:
+        # The router is trained separately and should not be registered as part
+        # of the transformer module graph, otherwise DDP would expect router
+        # parameters to participate in every transformer backward pass.
+        object.__setattr__(self, "_transformer_router", router)
+
+    def _router_features(self, x: Tensor, step_idx: int) -> Tensor:
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        step_batch = step_emb.unsqueeze(0).expand(x.size(0), -1)
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled, step_batch), dim=-1)
+
+    def _router_logits(self, router_inputs: Tensor) -> Tensor:
+        router = self._transformer_router
+        if router is None:
+            raise RuntimeError("Transformer Router must be set before router use")
+        return router(router_inputs)
+
+    def _sequence_losses_from_hidden(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self._logits_from_hidden(x)
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        return token_losses.mean(dim=1)
+
+    def _recurrent_step(
+        self,
+        x: Tensor,
+        step_idx: int,
+        block_idx: int,
+        total_steps: int,
+    ) -> Tensor:
+        runner = (
+            self._compiled_recurrent_step_runners.get((step_idx, block_idx))
+            if total_steps == self.num_recurrent_steps
+            else None
+        )
+        if runner is not None:
+            if (
+                self.activation_checkpointing
+                and self.training
+                and torch.is_grad_enabled()
+            ):
+                return checkpoint(
+                    runner,
+                    x,
+                    use_reentrant=False,
+                    preserve_rng_state=False,
+                )
+            return runner(x)
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        block = self.blocks[block_idx]
+        use_xsa = self._step_uses_xsa(step_idx, total_steps)
+        if self.activation_checkpointing and self.training and torch.is_grad_enabled():
+
+            def run_block(h: Tensor) -> Tensor:
+                return block(h, step_emb, use_xsa=use_xsa)
+
+            return checkpoint(
+                run_block,
+                x,
+                use_reentrant=False,
+                preserve_rng_state=False,
+            )
+        return block(x, step_emb, use_xsa=use_xsa)
+
+    def _masked_router_probs(self, router_inputs: Tensor, allow_stop: bool) -> Tensor:
+        logits = self._router_logits(router_inputs).float()
+        if not allow_stop:
+            logits = logits.clone()
+            logits[:, len(self.blocks)] = torch.finfo(logits.dtype).min
+        return torch.softmax(logits, dim=-1)
+
+    def _recurrent_forward(
+        self,
+        input_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        target_ids: Tensor | None = None,
+        router_active: bool = False,
+    ) -> Tensor:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if steps <= 0 or steps > self.num_recurrent_steps:
+            raise ValueError(
+                f"num_recurrent_steps must be in [1, {self.num_recurrent_steps}], got {steps}"
+            )
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        # RoPE inside attention still handles token-position encoding; the
+        # recurrent addition here is per-step conditioning for whichever block
+        # the route selects next.
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        stop_enabled = num_recurrent_steps is None
+        batch_size = int(x.size(0))
+        active_indices = torch.arange(batch_size, device=x.device, dtype=torch.int64)
+        active_x = x
+        final_x = torch.empty_like(x)
+        depths = torch.zeros(batch_size, device=x.device, dtype=torch.float32)
+        router_log_prob_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_entropy_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_decision_counts = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        action_counts = torch.zeros(
+            steps, len(self.blocks) + 1, device=x.device, dtype=torch.float32
+        )
+        used_block_indices: set[int] = set()
+        for step_idx in range(steps):
+            if active_indices.numel() == 0:
+                break
+            allow_stop = stop_enabled and step_idx > 0
+            router_inputs = self._router_features(active_x, step_idx)
+            action_probs = self._masked_router_probs(router_inputs, allow_stop)
+            if self.training and torch.is_grad_enabled() and router_active:
+                action_ids = torch.multinomial(action_probs, num_samples=1).squeeze(1)
+                log_action_probs = torch.log(action_probs.clamp_min(1e-9))
+                router_log_prob_sums[active_indices] += log_action_probs.gather(
+                    1, action_ids.unsqueeze(1)
+                ).squeeze(1)
+                router_entropy_sums[active_indices] += -(
+                    action_probs * log_action_probs
+                ).sum(dim=1)
+                router_decision_counts[active_indices] += 1.0
+            else:
+                action_ids = action_probs.argmax(dim=1)
+            action_counts[step_idx] += torch.bincount(
+                action_ids, minlength=len(self.blocks) + 1
+            ).to(dtype=action_counts.dtype)
+            stop_action_idx = len(self.blocks)
+            if allow_stop:
+                stop_mask = action_ids == stop_action_idx
+                if stop_mask.any():
+                    stop_indices = active_indices[stop_mask]
+                    final_x[stop_indices] = active_x[stop_mask]
+                    active_keep_mask = ~stop_mask
+                    active_indices = active_indices[active_keep_mask]
+                    active_x = active_x[active_keep_mask]
+                    action_ids = action_ids[active_keep_mask]
+            if active_indices.numel() == 0:
+                break
+            next_active_x = torch.empty_like(active_x)
+            ran_any_block = False
+            for block_idx in range(len(self.blocks)):
+                block_mask = action_ids == block_idx
+                if not block_mask.any():
+                    continue
+                ran_any_block = True
+                used_block_indices.add(block_idx)
+                block_hidden = self._recurrent_step(
+                    active_x[block_mask], step_idx, block_idx, steps
+                )
+                next_active_x[block_mask] = block_hidden
+            if not ran_any_block:
+                break
+            depths[active_indices] = float(step_idx + 1)
+            active_x = next_active_x
+        if active_indices.numel() > 0:
+            final_x[active_indices] = active_x
+        self.last_actual_recurrent_steps = float(depths.mean().item())
+        self.last_forward_action_counts = action_counts.detach()
+        self._last_router_log_probs = router_log_prob_sums
+        self._last_router_entropies = router_entropy_sums
+        self._last_router_decision_counts = router_decision_counts
+        self._last_router_depths = depths
+        x = self.final_norm(final_x)
+        if (
+            self._unused_block_anchor_enabled
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._unused_block_param_anchor(used_block_indices, x).view(1, 1, 1)
+        return x
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        effective_depth = self.num_recurrent_steps
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    # Delta vs baseline init: large matrices use orthogonal init,
+                    # and output projections get an extra depth-aware shrink.
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * effective_depth))
+
+    def _logits_from_hidden(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _loss_from_hidden(self, x: Tensor, target_ids: Tensor) -> tuple[Tensor, Tensor]:
+        seq_losses = self._sequence_losses_from_hidden(x, target_ids)
+        main_loss = seq_losses.mean()
+
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(
+                    mtp_logits_proj / self.logit_softcap
+                )
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(
+                    mtp_logits.float(), mtp_targets, reduction="mean"
+                )
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (
+                    mtp_loss_sum / mtp_loss_count
+                )
+
+        return main_loss, seq_losses
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            target_ids=target_ids,
+            router_active=router_active,
+        )
+        main_loss, seq_losses = self._loss_from_hidden(x, target_ids)
+        self.last_main_loss = float(main_loss.detach().item())
+        total_loss = main_loss
+        router_loss = x.new_zeros(())
+        router_policy_loss = x.new_zeros(())
+        router_mean_entropy = x.new_zeros(())
+        if (
+            router_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_router_log_probs is not None
+            and self._last_router_entropies is not None
+            and self._last_router_decision_counts is not None
+            and self._last_router_depths is not None
+        ):
+            valid_mask = self._last_router_decision_counts > 0
+            if valid_mask.any():
+                router_costs = seq_losses.detach()[valid_mask] + (
+                    self.router_step_penalty * self._last_router_depths[valid_mask]
+                )
+                advantages = router_costs - router_costs.mean()
+                router_policy_loss = (
+                    advantages * self._last_router_log_probs[valid_mask]
+                ).mean()
+                # Normalize entropy by the number of routing decisions per
+                # sequence so longer trajectories do not get a larger bonus
+                # merely for avoiding the stop action.
+                router_mean_entropy = (
+                    self._last_router_entropies[valid_mask]
+                    / self._last_router_decision_counts[valid_mask].clamp_min(1.0)
+                ).mean()
+                router_loss = (
+                    router_policy_loss - self.router_entropy_bonus * router_mean_entropy
+                )
+                total_loss = total_loss + router_loss
+        self.last_router_policy_loss = float(router_policy_loss.detach().item())
+        self.last_router_entropy = float(router_mean_entropy.detach().item())
+        self.last_router_loss = float(router_loss.detach().item())
+        return total_loss
+
+    def forward_loss_at_depth(
+        self, input_ids: Tensor, target_ids: Tensor, depth: int
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=depth,
+            target_ids=target_ids,
+            router_active=True,
+        )
+        main_loss, _ = self._loss_from_hidden(x, target_ids)
+        return main_loss
+
+    def forward_logits(self, input_ids: Tensor, router_active: bool = True) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self._recurrent_forward(input_ids, router_active=router_active)
+        return self._logits_from_hidden(x)
+
+
+class TrainDepthDispatcher(nn.Module):
+    def __init__(self, base_model: GPT):
+        super().__init__()
+        self.base_model = base_model
+        self._compiled_train_depth_runners: dict[int, callable] = {}
+
+    def set_compiled_train_depth_runners(self, runners: dict[int, callable]) -> None:
+        self._compiled_train_depth_runners = runners
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        if num_recurrent_steps is not None and self.training:
+            runner = self._compiled_train_depth_runners.get(num_recurrent_steps)
+            if runner is not None:
+                return runner(input_ids, target_ids)
+        return self.base_model(
+            input_ids,
+            target_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            router_active=router_active,
+        )
+
+
+def build_compiled_train_depth_runner(base_model: GPT, depth: int):
+    # Give each compiled training entrypoint a distinct code object so Dynamo
+    # does not treat depth-specialized runners as recompiles of the same frame.
+    runner_name = f"train_depth_runner_{depth}"
+    runner_src = (
+        f"def {runner_name}(input_ids, target_ids):\n"
+        f"    return base_model(input_ids, target_ids, num_recurrent_steps={depth})\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+def build_compiled_recurrent_step_runner(
+    base_model: GPT, step_idx: int, block_idx: int
+):
+    # Random routing still loops in Python, so compile each (step, block)
+    # recurrent application separately and dispatch to the sampled route.
+    # Use shape-specialized runners here. Inductor's dynamic-shape path has been
+    # unstable for these tiny per-expert helpers, while the script already bumps
+    # Dynamo's recompile/cache budget enough to tolerate a modest number of
+    # routed batch-size specializations.
+    runner_name = f"recurrent_step_runner_{step_idx}_{block_idx}"
+    runner_src = (
+        f"def {runner_name}(hidden):\n"
+        f"    step_emb = base_model.step_embedding.table[{step_idx}].to(dtype=hidden.dtype)\n"
+        f"    return base_model.blocks[{block_idx}](\n"
+        f"        hidden,\n"
+        f"        step_emb,\n"
+        f"        use_xsa=base_model._step_uses_xsa({step_idx}, base_model.num_recurrent_steps),\n"
+        f"    )\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+# -----------------------------
+# SLIDING WINDOW EVALUATION
+# -----------------------------
+# Delta vs baseline evaluation: the default experiment script only scores
+# non-overlapping chunks. This record also computes the submission metric using
+# overlapping windows so each token is evaluated with near-max context.
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+    progress_label: str | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, stride)
+        if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    total_windows = len(window_starts)
+
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    progress_total = max(len(my_windows), 1)
+    progress_step = max(progress_total // 100, 1)
+    next_progress = progress_step
+    if progress_label is not None and rank == 0:
+        print(
+            f"final_eval_progress:0/{progress_total} label:{progress_label}", flush=True
+        )
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    compiled_logits = (
+        torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+        if not router_active
+        else None
+    )
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                if compiled_logits is not None:
+                    logits = compiled_logits(x_batch)
+                else:
+                    logits = base_model.forward_logits(
+                        x_batch, router_active=router_active
+                    )
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(
+                    torch.float64
+                )
+                byte_count += tb.sum()
+            current_done = min(bi + bsz, len(my_windows))
+            if (
+                progress_label is not None
+                and rank == 0
+                and (current_done >= next_progress or current_done >= len(my_windows))
+            ):
+                print(
+                    f"final_eval_progress:{current_done}/{progress_total} label:{progress_label}",
+                    flush=True,
+                )
+                next_progress = current_done + progress_step
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# ROUTER LOGGING
+# -----------------------------
+# The model logs the recent selected-action distribution per recurrent step and
+# the average router policy loss alongside average depth.
+
+
+def format_router_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    router_objective_sum: float,
+    router_objective_count: float,
+    router_entropy_sum: float,
+    router_entropy_count: float,
+) -> str:
+    avg_depth = depth_sum / depth_count if depth_count > 0 else 0.0
+    router_objective_text = (
+        f"{router_objective_sum / router_objective_count:.4f}"
+        if router_objective_count > 0
+        else "none"
+    )
+    router_entropy_text = (
+        f"{router_entropy_sum / router_entropy_count:.4f}"
+        if router_entropy_count > 0
+        else "none"
+    )
+    return (
+        f"step:{step}/{total_steps} router_probe "
+        f"window_steps:{window_steps} avg_depth:{avg_depth:.3f} "
+        f"router_objective:{router_objective_text} "
+        f"router_entropy:{router_entropy_text}"
+    )
+
+
+def format_router_action_matrix(
+    step: int,
+    total_steps: int,
+    total_counts: Tensor | None,
+    num_layers: int,
+) -> str:
+    if total_counts is None:
+        return f"step:{step}/{total_steps} router_matrix:none"
+    action_names = [f"b{i}" for i in range(num_layers)] + ["stop"]
+    lines = [f"step:{step}/{total_steps} router_matrix"]
+    for step_idx in range(total_counts.size(0)):
+        row = total_counts[step_idx]
+        row_total = float(row.sum().item())
+        if row_total <= 0:
+            continue
+        probs = row / row_total
+        row_text = " ".join(
+            f"{name}:{float(probs[action_idx].item()):.3f}"
+            for action_idx, name in enumerate(action_names)
+        )
+        lines.append(f"  s{step_idx + 1:02d} {row_text}")
+    return "\n".join(lines)
+
+
+# -----------------------------
+# INT6 MIXED QUANTIZATION (transplanted from working diagnostic scripts)
+# -----------------------------
+# Delta vs baseline export: attention/MLP matrices move to int6 while the
+# remaining weights use int8 or float passthrough. The baseline export path is
+# pure int8 + zlib.
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_int6_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / 31.0).clamp_min(1.0 / 31.0).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -32, 31).to(
+            torch.int8
+        )
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / 31.0 if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -32, 31).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = (
+        max(
+            (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+            default=0,
+        )
+        + 1
+    )
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        # tok_emb.weight falls through to int8 via "embed" category
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # Keep a larger Dynamo cache budget as a conservative default for the
+    # recurrent training/eval helpers used elsewhere in the script.
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                torch._dynamo.config.recompile_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "cache_size_limit"):
+            torch._dynamo.config.cache_size_limit = max(
+                torch._dynamo.config.cache_size_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "accumulated_cache_size_limit"):
+            torch._dynamo.config.accumulated_cache_size_limit = max(
+                torch._dynamo.config.accumulated_cache_size_limit,
+                16 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "fail_on_recompile_limit_hit"):
+            torch._dynamo.config.fail_on_recompile_limit_hit = False
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(
+            ["nvidia-smi"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(
+            f"Script only setup for SentencePiece .model file: {args.tokenizer_path}"
+        )
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    # Delta vs baseline data/eval setup: validation tensors are loaded long
+    # enough to support either plain non-overlapping eval or sliding-window eval
+    # at a different sequence length.
+    effective_eval_seq_len = (
+        args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    )
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = (
+        build_sentencepiece_luts(sp, args.vocab_size, device)
+    )
+    log0(
+        f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}"
+    )
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    # This global switch activates the STE fake-quant path in `CastedLinear`.
+    CastedLinear._qat_enabled = args.qat_enabled
+
+    base_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_start,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=args.mtp_num_heads,
+            mtp_loss_weight=args.mtp_loss_weight,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,
+        )
+        .to(device)
+        .bfloat16()
+    )
+    router_base_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    dispatch_model = TrainDepthDispatcher(base_model)
+    compiled_train_depth_runners: dict[int, callable] = {}
+    compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+    if args.compiled_routed_experts:
+        for step_idx in range(args.num_recurrent_steps):
+            for block_idx in range(args.num_layers):
+                compiled_recurrent_step_runners[(step_idx, block_idx)] = (
+                    build_compiled_recurrent_step_runner(
+                        base_model, step_idx, block_idx
+                    )
+                )
+    dispatch_model.set_compiled_train_depth_runners(compiled_train_depth_runners)
+    base_model.set_compiled_recurrent_step_runners(compiled_recurrent_step_runners)
+    base_model.set_unused_block_anchor_enabled(distributed)
+    model: nn.Module = (
+        DDP(
+            dispatch_model,
+            device_ids=[local_rank],
+            broadcast_buffers=False,
+        )
+        if distributed
+        else dispatch_model
+    )
+    router_model: nn.Module = (
+        DDP(router_base_model, device_ids=[local_rank], broadcast_buffers=False)
+        if distributed
+        else router_base_model
+    )
+    base_model.set_transformer_router(router_model)
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    # Delta vs baseline parameter routing:
+    # - Bigram embeddings join the token optimizer
+    # - Smear/bigram scales join the scalar optimizer
+    # - MTP heads join the matrix optimizer when enabled
+    # - AdamW/Muon weight decay is explicit instead of relying on pure Adam/Muon
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2
+        and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.mtp_num_heads > 0:
+        matrix_params.extend(
+            [p for p in base_model.mtp_heads.parameters() if p.ndim == 2]
+        )
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2
+        or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [
+        {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+    ]
+    if base_model.bigram is not None:
+        tok_params.append(
+            {
+                "params": [base_model.bigram.embed.weight],
+                "lr": token_lr,
+                "base_lr": token_lr,
+            }
+        )
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_router = torch.optim.AdamW(
+        [
+            {
+                "params": router_base_model.parameters(),
+                "lr": args.router_lr,
+                "base_lr": args.router_lr,
+            }
+        ],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.router_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [
+        optimizer_tok,
+        optimizer_muon,
+        optimizer_scalar,
+    ]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [
+                {
+                    "params": [base_model.lm_head.weight],
+                    "lr": args.head_lr,
+                    "base_lr": args.head_lr,
+                }
+            ],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    all_optimizers: list[torch.optim.Optimizer] = [*optimizers, optimizer_router]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    router_params = sum(p.numel() for p in router_base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"router_params:{router_params}")
+    log0(
+        f"unique_blocks:{len(base_model.blocks)} recurrent_steps:{base_model.num_recurrent_steps}"
+    )
+    log0(
+        f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}"
+    )
+    xsa_steps = base_model.xsa_step_indices()
+    log0(f"XSA:last_{args.xsa_last_n} active_steps:{xsa_steps}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(
+        f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}"
+    )
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"warmdown_iters:{args.warmdown_iters} val_loss_every:{args.val_loss_every} "
+        f"num_recurrent_steps:{args.num_recurrent_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"router_actions:{args.num_layers + 1} "
+        f"eval_recurrent_steps:{args.num_recurrent_steps}"
+    )
+    log0(
+        f"router_input_dim:{3 * args.model_dim} "
+        f"router_hidden_dim:{args.router_hidden_dim} "
+        f"router_lr:{args.router_lr} router_wd:{args.router_wd} "
+        f"router_entropy_bonus_start:{args.router_entropy_bonus_start} "
+        f"router_entropy_bonus_end:{args.router_entropy_bonus_end} "
+        f"router_step_penalty:{args.router_step_penalty} "
+        f"compiled_routed_experts:{int(args.compiled_routed_experts)} "
+        f"activation_checkpointing:{int(args.activation_checkpointing)} "
+        f"swa_every:{args.swa_every} "
+        f"muon_momentum_warmup_steps:{args.muon_momentum_warmup_steps}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+    router_model.train()
+    optimizer_router.zero_grad(set_to_none=True)
+
+    def zero_grad_all() -> None:
+        for opt in all_optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = (
+        1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    )
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return (
+                max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0)
+                if warmdown_start <= step < args.iterations
+                else 1.0
+            )
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return (
+            remaining_ms / max(warmdown_ms, 1e-9)
+            if remaining_ms <= warmdown_ms
+            else 1.0
+        )
+
+    def router_entropy_bonus_value(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is not None and max_wallclock_ms > 0.0:
+            progress = min(max(elapsed_ms / max_wallclock_ms, 0.0), 1.0)
+        elif args.iterations > 1:
+            progress = min(max(step / (args.iterations - 1), 0.0), 1.0)
+        else:
+            progress = 1.0
+        return (
+            1.0 - progress
+        ) * args.router_entropy_bonus_start + progress * args.router_entropy_bonus_end
+
+    # Warmup exercises the actual router-controlled training path and optimizer
+    # kernels, then we restore the initial weights/optimizer state so measured
+    # training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_router_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in router_base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in all_optimizers
+        ]
+        model.train()
+        router_model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                    router_model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(
+                    args.train_batch_tokens, args.train_seq_len, grad_accum_steps
+                )
+                with torch.autocast(
+                    device_type="cuda", dtype=torch.bfloat16, enabled=True
+                ):
+                    warmup_loss = model(x, y, router_active=True)
+                (warmup_loss * grad_scale).backward()
+            for opt in all_optimizers:
+                opt.step()
+            zero_grad_all()
+            if (
+                args.warmup_steps <= 20
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == args.warmup_steps
+            ):
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        router_base_model.load_state_dict(initial_router_state, strict=True)
+        for opt, state in zip(all_optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+            router_model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(
+            args.train_files, rank, world_size, device
+        )
+        optimizer_router.zero_grad(set_to_none=True)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    # Delta vs baseline training loop: collect uniform SWA snapshots during the
+    # low-LR tail of warmdown and optionally replace the final weights with
+    # their average before export.
+    swa_state: dict[str, Tensor] | None = None
+    swa_count = 0
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    probe_window_size = max(args.recurrence_probe_every, 1)
+    recent_depth_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_depth_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_action_counts: deque[Tensor] = deque(maxlen=probe_window_size)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+
+        should_validate = last_step or (
+            args.val_loss_every > 0 and step % args.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                router_active=True,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        base_model.router_entropy_bonus = router_entropy_bonus_value(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        router_loss = torch.zeros((), device=device)
+        router_entropy = torch.zeros((), device=device)
+        step_depth_sum = 0.0
+        step_depth_count = 0
+        step_action_counts = torch.zeros(
+            args.num_recurrent_steps,
+            args.num_layers + 1,
+            device=device,
+            dtype=torch.float32,
+        )
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                router_model.require_backward_grad_sync = (
+                    micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(
+                args.train_batch_tokens, args.train_seq_len, grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, router_active=True)
+            step_depth_sum += float(base_model.last_actual_recurrent_steps)
+            step_depth_count += 1
+            step_action_counts += base_model.last_forward_action_counts.to(
+                device=device, dtype=step_action_counts.dtype
+            )
+            train_loss += float(base_model.last_main_loss)
+            router_loss += float(base_model.last_router_loss)
+            router_entropy += float(base_model.last_router_entropy)
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        router_loss /= grad_accum_steps
+        router_entropy /= grad_accum_steps
+
+        frac = (
+            min(step / args.muon_momentum_warmup_steps, 1.0)
+            if args.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        for group in optimizer_router.param_groups:
+            group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(
+                router_base_model.parameters(), args.grad_clip_norm
+            )
+        for opt in all_optimizers:
+            opt.step()
+        zero_grad_all()
+
+        local_step_depth_sum = float(step_depth_sum)
+        local_step_depth_count = float(step_depth_count)
+        local_router_objective_sum = float(router_loss.item()) * grad_accum_steps
+        local_router_objective_count = float(grad_accum_steps)
+        local_router_entropy_sum = float(router_entropy.item()) * grad_accum_steps
+        local_router_entropy_count = float(grad_accum_steps)
+        recent_depth_sums.append(local_step_depth_sum)
+        recent_depth_counts.append(local_step_depth_count)
+        recent_router_objective_sums.append(local_router_objective_sum)
+        recent_router_objective_counts.append(local_router_objective_count)
+        recent_router_entropy_sums.append(local_router_entropy_sum)
+        recent_router_entropy_counts.append(local_router_entropy_count)
+        recent_router_action_counts.append(step_action_counts.detach().cpu())
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        should_probe_recurrence = (
+            args.recurrence_probe_every > 0 and step % args.recurrence_probe_every == 0
+        )
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10
+            or step % args.train_log_every == 0
+            or stop_after_step is not None
+        )
+        step_avg_depth = local_step_depth_sum / max(local_step_depth_count, 1.0)
+        step_avg_router_objective = (
+            local_router_objective_sum / local_router_objective_count
+            if local_router_objective_count > 0
+            else None
+        )
+        step_avg_router_entropy = (
+            local_router_entropy_sum / local_router_entropy_count
+            if local_router_entropy_count > 0
+            else None
+        )
+        if distributed and (should_probe_recurrence or should_log_train):
+            step_stats = torch.tensor(
+                [
+                    local_step_depth_sum,
+                    local_step_depth_count,
+                    local_router_objective_sum,
+                    local_router_objective_count,
+                    local_router_entropy_sum,
+                    local_router_entropy_count,
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_avg_depth = float(
+                (step_stats[0] / step_stats[1].clamp_min(1.0)).item()
+            )
+            step_avg_router_objective = (
+                float((step_stats[2] / step_stats[3]).item())
+                if step_stats[3].item() > 0
+                else None
+            )
+            step_avg_router_entropy = (
+                float((step_stats[4] / step_stats[5]).item())
+                if step_stats[5].item() > 0
+                else None
+            )
+        if should_probe_recurrence:
+            window_stats = torch.tensor(
+                [
+                    sum(recent_depth_sums),
+                    sum(recent_depth_counts),
+                    sum(recent_router_objective_sums),
+                    sum(recent_router_objective_counts),
+                    sum(recent_router_entropy_sums),
+                    sum(recent_router_entropy_counts),
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            window_action_counts: Tensor | None = (
+                torch.stack(list(recent_router_action_counts), dim=0)
+                .sum(dim=0)
+                .to(device=device, dtype=torch.float64)
+                if recent_router_action_counts
+                else None
+            )
+            if distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+                if window_action_counts is not None:
+                    dist.all_reduce(window_action_counts, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+            window_action_counts = None
+        if should_probe_recurrence and (not distributed or rank == 0):
+            log0(
+                format_router_probe_summary(
+                    step,
+                    args.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                    float(window_stats[4].item()),
+                    float(window_stats[5].item()),
+                )
+            )
+            log0(
+                format_router_action_matrix(
+                    step,
+                    args.iterations,
+                    None
+                    if window_action_counts is None
+                    else window_action_counts.cpu(),
+                    args.num_layers,
+                )
+            )
+
+        if args.swa_enabled and scale < 0.5 and step % args.swa_every == 0:
+            if swa_state is None:
+                swa_state = {
+                    name: t.detach().cpu().clone()
+                    for name, t in base_model.state_dict().items()
+                }
+                swa_count = 1
+                log0(f"swa:start step:{step}")
+            else:
+                for name, t in base_model.state_dict().items():
+                    swa_state[name] += t.detach().cpu()
+                swa_count += 1
+
+        if should_log_train:
+            router_log = (
+                f" router_objective:{step_avg_router_objective:.4f}"
+                f" router_entropy:{step_avg_router_entropy:.4f}"
+                f" router_entropy_bonus:{base_model.router_entropy_bonus:.4f}"
+            )
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+                f" router_forward:1"
+                f"{router_log}"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    if args.swa_enabled and swa_state is not None and swa_count > 1:
+        log0(f"swa:applying averaged {swa_count} checkpoints")
+        avg_state = {
+            name: (t / swa_count).to(dtype=base_model.state_dict()[name].dtype)
+            for name, t in swa_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Delta vs baseline export: MTP helps training but is not part of the final
+    # artifact, so those heads are dropped before serialization.
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    router_export_sd = router_base_model.state_dict()
+    excluded_mtp = sum(
+        int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k
+    )
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+
+    if master_process:
+        torch.save({"model": export_sd, "router": router_export_sd}, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    router_sd_cpu = {k: v.detach().cpu() for k, v in router_export_sd.items()}
+    # Baseline writes int8+zlib. This record uses mixed int6/int8 and prefers
+    # zstd-22 when available to squeeze under the 16 MB artifact limit.
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+    router_quant_result, router_quant_meta = mixed_quantize_int6(router_sd_cpu, set())
+    quant_buf = io.BytesIO()
+    torch.save(
+        {
+            "w": quant_result,
+            "m": quant_meta,
+            "rw": router_quant_result,
+            "rm": router_quant_meta,
+        },
+        quant_buf,
+    )
+    quant_raw = quant_buf.getvalue()
+    quant_blob = (
+        zstandard.ZstdCompressor(level=22).compress(quant_raw)
+        if _COMPRESSOR == "zstd"
+        else zlib.compress(quant_raw, 9)
+    )
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(
+            f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes"
+        )
+
+    # Roundtrip: rebuild a fresh eval model from the compressed artifact so the
+    # reported score matches the thing that would actually be submitted.
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(
+            zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+            if _COMPRESSOR == "zstd"
+            else zlib.decompress(quant_blob_disk)
+        ),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    deq_router_state = dequantize_mixed_int6(
+        quant_state["rw"], quant_state["rm"], router_sd_cpu
+    )
+
+    eval_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_end,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=0,
+            mtp_loss_weight=0.0,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,  # must match training model
+        )
+        .to(device)
+        .bfloat16()
+    )
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_router_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    eval_model.set_transformer_router(eval_router_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    eval_router_model.load_state_dict(deq_router_state, strict=True)
+    eval_router_model.eval()
+
+    # Standard non-overlapping eval (sanity check)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+        router_active=True,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    # Sliding-window eval is the record's headline submission metric.
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}"
+        )
+
+    # Second sliding window eval at stride=64 for submission comparison
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window_s64",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}"
+        )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_2.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_2.py
@@ -1,0 +1,2735 @@
+"""
+Adaptive Recurrent Transformer
+
+Three identically sized transformer blocks are reused recurrently with Fourier
+step embeddings. A sidecar Transformer Router chooses among the three blocks or
+stopping recursion from latent-state features and is trained directly from the
+final sequence loss with an entropy bonus.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from collections import deque
+from pathlib import Path
+
+# Delta vs `train_gpt.py`: prefer zstd for the final artifact when
+# the package is available, but keep a zlib fallback so the script still runs in
+# lighter local environments.
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# Delta vs baseline attention: call FlashAttention 3 directly instead of
+# `torch.scaled_dot_product_attention(...)`.
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.checkpoint import checkpoint
+
+
+class Hyperparameters:
+    # Highest-impact run budget, data, and schedule knobs.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model"
+    )
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+
+    # Router-specific policy training knobs.
+    router_hidden_dim = int(os.environ.get("ROUTER_HIDDEN_DIM", 128))
+    router_lr = float(os.environ.get("ROUTER_LR", 0.001))
+    router_wd = float(os.environ.get("ROUTER_WD", 0.01))
+    router_entropy_bonus_start = float(
+        os.environ.get("ROUTER_ENTROPY_BONUS_START", 0.2)
+    )
+    router_entropy_bonus_end = float(os.environ.get("ROUTER_ENTROPY_BONUS_END", 0.02))
+    router_step_penalty = float(os.environ.get("ROUTER_STEP_PENALTY", 0.02))
+
+    # Model shape. ART core architecture stays unchanged relative to ART.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 3))
+    num_recurrent_steps = int(os.environ.get("NUM_RECURRENT_STEPS", 12))
+    model_dim = int(os.environ.get("MODEL_DIM", 896))
+    num_heads = int(os.environ.get("NUM_HEADS", 28))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 14))
+    mlp_mult = float(os.environ.get("MLP_MULT", 5.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+
+    # Optimizer and regularization defaults adapted from the record run where
+    # they transfer cleanly to ART.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+
+    # Eval/export/runtime controls.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    activation_checkpointing = bool(
+        int(os.environ.get("ACTIVATION_CHECKPOINTING", "0"))
+    )
+    compiled_routed_experts = bool(int(os.environ.get("COMPILED_ROUTED_EXPERTS", "0")))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+
+    # Auxiliary training features retained from ART.
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # Optional carry-over from the source experiment: apply XSA only on the last
+    # N recurrent steps.
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 0))  # 0 disables XSA entirely
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+#
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+
+def zeropower_via_newtonschulz5(
+    G: Tensor, steps: int = 10, eps: float = 1e-7
+) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+        row_normalize: bool = False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            # Delta vs baseline Muon: this version adds decoupled weight decay so
+            # matrix params can use MuonWD without moving them onto Adam.
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    # Delta vs baseline eval: training and evaluation sequence lengths can
+    # differ, because this stack trains at long context and also uses
+    # sliding-window evaluation later in the script.
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y, router_active=router_active).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+# Delta vs baseline export: extra control tensors from SmearGate/Bigram/XSA stay
+# out of the aggressive quantization path.
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(
+    name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]
+) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(
+            torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None]
+        )
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = (
+            torch.clamp(torch.round(clipped / scale[:, None]), -127, 127)
+            .to(torch.int8)
+            .contiguous()
+        )
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = (
+        float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item())
+        if t32.numel()
+        else 0.0
+    )
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = (
+        torch.clamp(
+            torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127
+        )
+        .to(torch.int8)
+        .contiguous()
+    )
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "int8_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (
+                (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1))))
+                .to(dtype=dtype)
+                .contiguous()
+            )
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE: dict[str, int] = {}
+_MMAP_CACHE: dict[str, np.memmap] = {}
+
+
+def _read_num_tokens(file: Path) -> int:
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = num_tokens
+    return num_tokens
+
+
+def _get_shard_memmap(file: Path) -> np.memmap:
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    mm = np.memmap(
+        file,
+        mode="r",
+        dtype="<u2",
+        offset=_SHARD_HEADER_BYTES,
+        shape=(_read_num_tokens(file),),
+    )
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+class ShuffledSequenceLoader:
+    # Record-style shard-local randomized sequence sampling keeps each rank on a
+    # disjoint shard subset and avoids materializing global batches on every rank.
+    def __init__(
+        self, args: Hyperparameters, rank: int, world_size: int, device: torch.device
+    ):
+        self.rank = rank
+        self.world_size = world_size
+        self.seq_len = args.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(args.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {args.train_files}")
+        self.files = all_files[rank::world_size]
+        if not self.files:
+            raise ValueError(
+                f"No training shards assigned to rank {rank} out of {world_size}"
+            )
+        self.rng = np.random.Generator(np.random.PCG64(args.seed + rank))
+        self.num_tokens = [_read_num_tokens(file) for file in self.files]
+        self.start_inds: list[list[int]] = [[] for _ in self.files]
+        for shard_idx in range(len(self.files)):
+            self._reset_shard(shard_idx)
+
+    def _reset_shard(self, shard_idx: int) -> None:
+        max_phase = min(
+            self.seq_len - 1,
+            max(0, self.num_tokens[shard_idx] - self.seq_len - 1),
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[shard_idx] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[shard_idx] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(
+        self, global_tokens: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array(
+            [len(starts) for starts in self.start_inds], dtype=np.float64
+        )
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for batch_idx in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for shard_idx in range(len(self.files)):
+                    self._reset_shard(shard_idx)
+                remaining = np.array(
+                    [len(starts) for starts in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            shard_idx = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[shard_idx].pop()
+            remaining[shard_idx] -= 1
+            mm = _get_shard_memmap(self.files[shard_idx])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[batch_idx] = window[:-1]
+            y[batch_idx] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        # Delta vs baseline linear layers: optional straight-through fake quant
+        # lets later experiments turn on lightweight QAT without changing module
+        # call sites or adding parallel weight copies.
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (
+                    torch.clamp(torch.round(w32 / scale[:, None]), -32, 31)
+                    * scale[:, None]
+                ).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # NTK-aware RoPE: auto-scales base frequency when seq_len exceeds train_seq_len.
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (
+                    new_base
+                    ** (
+                        torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                        / self.dim
+                    )
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+# Delta vs `train_gpt.py`:
+# - head layout matches FlashAttention 3 directly, so there are no transpose
+#   calls around the kernel invocation
+# - late recurrent steps can opt into XSA after the main attention kernel runs
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        # Reshape y into KV head groups — free view, no memory alloc
+        y_g = y.reshape(B, T, Hkv, group, D)  # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)  # [B, T, Hkv, 1, D] — broadcast ready
+        # Project out self-value component per KV head group
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, use_xsa: bool | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # Baseline uses SDPA with `enable_gqa=True`; this record uses FA3
+        # directly, then optionally applies XSA as a cheap post-processing step.
+        y = flash_attn_3_func(q, k, v, causal=True)
+        apply_xsa = self.use_xsa if use_xsa is None else use_xsa
+        if apply_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# Delta vs baseline input path: before the block stack, embeddings get a
+# one-token temporal blend (`SmearGate`) plus a cheap hashed-bigram residual.
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = (
+            CastedLinear(bigram_dim, model_dim, bias=False)
+            if bigram_dim != model_dim
+            else None
+        )
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class FourierStepEmbedding(nn.Module):
+    """Deterministic sinusoidal embedding for recurrent UT steps."""
+
+    def __init__(self, num_steps: int, dim: int):
+        super().__init__()
+        half = dim // 2
+        steps = torch.arange(num_steps, dtype=torch.float32).unsqueeze(1)
+        freqs = 1.0 / (10000.0 ** (2.0 * torch.arange(half, dtype=torch.float32) / dim))
+        angles = steps * freqs.unsqueeze(0)
+        table = torch.zeros(num_steps, dim, dtype=torch.float32)
+        table[:, 0 : 2 * half : 2] = torch.sin(angles)
+        table[:, 1 : 2 * half : 2] = torch.cos(angles)
+        self.register_buffer("table", table, persistent=False)
+
+    def forward(self, step_idx: int) -> Tensor:
+        return self.table[step_idx]
+
+
+class MLP(nn.Module):
+    def __init__(self, dim: int, mlp_mult: int):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class TransformerRouter(nn.Module):
+    """Predict routing logits over the three blocks plus stop."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, num_actions: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_actions)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, router_inputs: Tensor) -> Tensor:
+        x = F.gelu(self.fc(router_inputs.float()))
+        return self.proj(x)
+
+
+class UniversalTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        # Keep the residual path simple for recurrence: pre-norm attention,
+        # residual add, then pre-norm MLP and residual add.
+
+    def forward(self, h: Tensor, step_emb: Tensor, use_xsa: bool = False) -> Tensor:
+        x = h + step_emb[None, None, :]
+        h = h + self.attn(self.attn_norm(x), use_xsa=use_xsa)
+        h = h + self.mlp(self.mlp_norm(h))
+        return h
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_mult: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_recurrent_steps: int = 8,
+        router_entropy_bonus: float = 0.01,
+        router_step_penalty: float = 0.01,
+        activation_checkpointing: bool = True,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if num_layers != 3:
+            raise ValueError(
+                f"Adaptive Recurrent Transformer expects NUM_LAYERS=3, got {num_layers}"
+            )
+        if num_recurrent_steps <= 0:
+            raise ValueError(
+                f"NUM_RECURRENT_STEPS must be positive, got {num_recurrent_steps}"
+            )
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_recurrent_steps = num_recurrent_steps
+        self.router_entropy_bonus = router_entropy_bonus
+        self.router_step_penalty = router_step_penalty
+        self.activation_checkpointing = activation_checkpointing
+        self.xsa_last_n = xsa_last_n
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.last_actual_recurrent_steps = 0.0
+        self.last_main_loss = 0.0
+        self.last_router_loss = 0.0
+        self.last_router_policy_loss = 0.0
+        self.last_router_entropy = 0.0
+        self.last_forward_action_counts = torch.zeros(
+            self.num_recurrent_steps, num_layers + 1, dtype=torch.float32
+        )
+        object.__setattr__(self, "_transformer_router", None)
+        self._last_router_log_probs: Tensor | None = None
+        self._last_router_entropies: Tensor | None = None
+        self._last_router_decision_counts: Tensor | None = None
+        self._last_router_depths: Tensor | None = None
+        self._compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+        self._unused_block_anchor_enabled = False
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = (
+            BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim)
+            if bigram_vocab_size > 0
+            else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.step_embedding = FourierStepEmbedding(num_recurrent_steps, model_dim)
+        # Keep an empty tensor attribute for compatibility with the existing
+        # trainer plumbing, but register it as a buffer, not a Parameter.
+        # Otherwise DDP sees an unused parameter and can fail on the next
+        # warmup/train forward with an unfinished reduction error.
+        self.register_buffer(
+            "skip_weights",
+            torch.empty(0, model_dim, dtype=torch.float32),
+            persistent=False,
+        )
+        self.blocks = nn.ModuleList(
+            [
+                UniversalTransformerBlock(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [
+                CastedLinear(model_dim, vocab_size, bias=False)
+                for _ in range(mtp_num_heads)
+            ]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        self._init_weights()
+
+    def xsa_step_indices(self, num_recurrent_steps: int | None = None) -> list[int]:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if self.xsa_last_n <= 0:
+            return []
+        start = max(0, steps - self.xsa_last_n)
+        return list(range(start, steps))
+
+    def _step_uses_xsa(
+        self, step_idx: int, num_recurrent_steps: int | None = None
+    ) -> bool:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        return self.xsa_last_n > 0 and step_idx >= steps - self.xsa_last_n
+
+    def set_compiled_recurrent_step_runners(
+        self, runners: dict[tuple[int, int], callable]
+    ) -> None:
+        self._compiled_recurrent_step_runners = runners
+
+    def set_unused_block_anchor_enabled(self, enabled: bool) -> None:
+        self._unused_block_anchor_enabled = enabled
+
+    def _unused_block_param_anchor(
+        self, used_block_indices: set[int], ref: Tensor
+    ) -> Tensor:
+        if len(used_block_indices) >= len(self.blocks):
+            return ref.new_zeros(())
+        # Touch parameters of blocks that were skipped so DDP can keep
+        # `find_unused_parameters=False` without changing the numerical forward.
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx, block in enumerate(self.blocks):
+            if block_idx in used_block_indices:
+                continue
+            for param in block.parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def set_transformer_router(self, router: nn.Module) -> None:
+        # The router is trained separately and should not be registered as part
+        # of the transformer module graph, otherwise DDP would expect router
+        # parameters to participate in every transformer backward pass.
+        object.__setattr__(self, "_transformer_router", router)
+
+    def _router_features(self, x: Tensor, step_idx: int) -> Tensor:
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        step_batch = step_emb.unsqueeze(0).expand(x.size(0), -1)
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled, step_batch), dim=-1)
+
+    def _router_logits(self, router_inputs: Tensor) -> Tensor:
+        router = self._transformer_router
+        if router is None:
+            raise RuntimeError("Transformer Router must be set before router use")
+        return router(router_inputs)
+
+    def _sequence_losses_from_hidden(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self._logits_from_hidden(x)
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        return token_losses.mean(dim=1)
+
+    def _recurrent_step(
+        self,
+        x: Tensor,
+        step_idx: int,
+        block_idx: int,
+        total_steps: int,
+    ) -> Tensor:
+        runner = (
+            self._compiled_recurrent_step_runners.get((step_idx, block_idx))
+            if total_steps == self.num_recurrent_steps
+            else None
+        )
+        if runner is not None:
+            if (
+                self.activation_checkpointing
+                and self.training
+                and torch.is_grad_enabled()
+            ):
+                return checkpoint(
+                    runner,
+                    x,
+                    use_reentrant=False,
+                    preserve_rng_state=False,
+                )
+            return runner(x)
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        block = self.blocks[block_idx]
+        use_xsa = self._step_uses_xsa(step_idx, total_steps)
+        if self.activation_checkpointing and self.training and torch.is_grad_enabled():
+
+            def run_block(h: Tensor) -> Tensor:
+                return block(h, step_emb, use_xsa=use_xsa)
+
+            return checkpoint(
+                run_block,
+                x,
+                use_reentrant=False,
+                preserve_rng_state=False,
+            )
+        return block(x, step_emb, use_xsa=use_xsa)
+
+    def _masked_router_probs(self, router_inputs: Tensor, allow_stop: bool) -> Tensor:
+        logits = self._router_logits(router_inputs).float()
+        if not allow_stop:
+            logits = logits.clone()
+            logits[:, len(self.blocks)] = torch.finfo(logits.dtype).min
+        return torch.softmax(logits, dim=-1)
+
+    def _recurrent_forward(
+        self,
+        input_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        target_ids: Tensor | None = None,
+        router_active: bool = False,
+    ) -> Tensor:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if steps <= 0 or steps > self.num_recurrent_steps:
+            raise ValueError(
+                f"num_recurrent_steps must be in [1, {self.num_recurrent_steps}], got {steps}"
+            )
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        # RoPE inside attention still handles token-position encoding; the
+        # recurrent addition here is per-step conditioning for whichever block
+        # the route selects next.
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        stop_enabled = num_recurrent_steps is None
+        batch_size = int(x.size(0))
+        active_indices = torch.arange(batch_size, device=x.device, dtype=torch.int64)
+        active_x = x
+        final_x = torch.empty_like(x)
+        depths = torch.zeros(batch_size, device=x.device, dtype=torch.float32)
+        router_log_prob_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_entropy_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_decision_counts = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        action_counts = torch.zeros(
+            steps, len(self.blocks) + 1, device=x.device, dtype=torch.float32
+        )
+        used_block_indices: set[int] = set()
+        for step_idx in range(steps):
+            if active_indices.numel() == 0:
+                break
+            allow_stop = stop_enabled and step_idx > 0
+            router_inputs = self._router_features(active_x, step_idx)
+            action_probs = self._masked_router_probs(router_inputs, allow_stop)
+            if self.training and torch.is_grad_enabled() and router_active:
+                action_ids = torch.multinomial(action_probs, num_samples=1).squeeze(1)
+                log_action_probs = torch.log(action_probs.clamp_min(1e-9))
+                router_log_prob_sums[active_indices] += log_action_probs.gather(
+                    1, action_ids.unsqueeze(1)
+                ).squeeze(1)
+                router_entropy_sums[active_indices] += -(
+                    action_probs * log_action_probs
+                ).sum(dim=1)
+                router_decision_counts[active_indices] += 1.0
+            else:
+                action_ids = action_probs.argmax(dim=1)
+            action_counts[step_idx] += torch.bincount(
+                action_ids, minlength=len(self.blocks) + 1
+            ).to(dtype=action_counts.dtype)
+            stop_action_idx = len(self.blocks)
+            if allow_stop:
+                stop_mask = action_ids == stop_action_idx
+                if stop_mask.any():
+                    stop_indices = active_indices[stop_mask]
+                    final_x[stop_indices] = active_x[stop_mask]
+                    active_keep_mask = ~stop_mask
+                    active_indices = active_indices[active_keep_mask]
+                    active_x = active_x[active_keep_mask]
+                    action_ids = action_ids[active_keep_mask]
+            if active_indices.numel() == 0:
+                break
+            next_active_x = torch.empty_like(active_x)
+            ran_any_block = False
+            for block_idx in range(len(self.blocks)):
+                block_mask = action_ids == block_idx
+                if not block_mask.any():
+                    continue
+                ran_any_block = True
+                used_block_indices.add(block_idx)
+                block_hidden = self._recurrent_step(
+                    active_x[block_mask], step_idx, block_idx, steps
+                )
+                next_active_x[block_mask] = block_hidden
+            if not ran_any_block:
+                break
+            depths[active_indices] = float(step_idx + 1)
+            active_x = next_active_x
+        if active_indices.numel() > 0:
+            final_x[active_indices] = active_x
+        self.last_actual_recurrent_steps = float(depths.mean().item())
+        self.last_forward_action_counts = action_counts.detach()
+        self._last_router_log_probs = router_log_prob_sums
+        self._last_router_entropies = router_entropy_sums
+        self._last_router_decision_counts = router_decision_counts
+        self._last_router_depths = depths
+        x = self.final_norm(final_x)
+        if (
+            self._unused_block_anchor_enabled
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._unused_block_param_anchor(used_block_indices, x).view(1, 1, 1)
+        return x
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        effective_depth = self.num_recurrent_steps
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    # Delta vs baseline init: large matrices use orthogonal init,
+                    # and output projections get an extra depth-aware shrink.
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * effective_depth))
+
+    def _logits_from_hidden(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _loss_from_hidden(self, x: Tensor, target_ids: Tensor) -> tuple[Tensor, Tensor]:
+        seq_losses = self._sequence_losses_from_hidden(x, target_ids)
+        main_loss = seq_losses.mean()
+
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(
+                    mtp_logits_proj / self.logit_softcap
+                )
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(
+                    mtp_logits.float(), mtp_targets, reduction="mean"
+                )
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (
+                    mtp_loss_sum / mtp_loss_count
+                )
+
+        return main_loss, seq_losses
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            target_ids=target_ids,
+            router_active=router_active,
+        )
+        main_loss, seq_losses = self._loss_from_hidden(x, target_ids)
+        self.last_main_loss = float(main_loss.detach().item())
+        total_loss = main_loss
+        router_loss = x.new_zeros(())
+        router_policy_loss = x.new_zeros(())
+        router_mean_entropy = x.new_zeros(())
+        if (
+            router_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_router_log_probs is not None
+            and self._last_router_entropies is not None
+            and self._last_router_decision_counts is not None
+            and self._last_router_depths is not None
+        ):
+            valid_mask = self._last_router_decision_counts > 0
+            if valid_mask.any():
+                router_costs = seq_losses.detach()[valid_mask] + (
+                    self.router_step_penalty * self._last_router_depths[valid_mask]
+                )
+                advantages = router_costs - router_costs.mean()
+                router_policy_loss = (
+                    advantages * self._last_router_log_probs[valid_mask]
+                ).mean()
+                # Normalize entropy by the number of routing decisions per
+                # sequence so longer trajectories do not get a larger bonus
+                # merely for avoiding the stop action.
+                router_mean_entropy = (
+                    self._last_router_entropies[valid_mask]
+                    / self._last_router_decision_counts[valid_mask].clamp_min(1.0)
+                ).mean()
+                router_loss = (
+                    router_policy_loss - self.router_entropy_bonus * router_mean_entropy
+                )
+                total_loss = total_loss + router_loss
+        self.last_router_policy_loss = float(router_policy_loss.detach().item())
+        self.last_router_entropy = float(router_mean_entropy.detach().item())
+        self.last_router_loss = float(router_loss.detach().item())
+        return total_loss
+
+    def forward_loss_at_depth(
+        self, input_ids: Tensor, target_ids: Tensor, depth: int
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=depth,
+            target_ids=target_ids,
+            router_active=True,
+        )
+        main_loss, _ = self._loss_from_hidden(x, target_ids)
+        return main_loss
+
+    def forward_logits(self, input_ids: Tensor, router_active: bool = True) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self._recurrent_forward(input_ids, router_active=router_active)
+        return self._logits_from_hidden(x)
+
+
+class TrainDepthDispatcher(nn.Module):
+    def __init__(self, base_model: GPT):
+        super().__init__()
+        self.base_model = base_model
+        self._compiled_train_depth_runners: dict[int, callable] = {}
+
+    def set_compiled_train_depth_runners(self, runners: dict[int, callable]) -> None:
+        self._compiled_train_depth_runners = runners
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        if num_recurrent_steps is not None and self.training:
+            runner = self._compiled_train_depth_runners.get(num_recurrent_steps)
+            if runner is not None:
+                return runner(input_ids, target_ids)
+        return self.base_model(
+            input_ids,
+            target_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            router_active=router_active,
+        )
+
+
+def build_compiled_train_depth_runner(base_model: GPT, depth: int):
+    # Give each compiled training entrypoint a distinct code object so Dynamo
+    # does not treat depth-specialized runners as recompiles of the same frame.
+    runner_name = f"train_depth_runner_{depth}"
+    runner_src = (
+        f"def {runner_name}(input_ids, target_ids):\n"
+        f"    return base_model(input_ids, target_ids, num_recurrent_steps={depth})\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+def build_compiled_recurrent_step_runner(
+    base_model: GPT, step_idx: int, block_idx: int
+):
+    # Random routing still loops in Python, so compile each (step, block)
+    # recurrent application separately and dispatch to the sampled route.
+    # Use shape-specialized runners here. Inductor's dynamic-shape path has been
+    # unstable for these tiny per-expert helpers, while the script already bumps
+    # Dynamo's recompile/cache budget enough to tolerate a modest number of
+    # routed batch-size specializations.
+    runner_name = f"recurrent_step_runner_{step_idx}_{block_idx}"
+    runner_src = (
+        f"def {runner_name}(hidden):\n"
+        f"    step_emb = base_model.step_embedding.table[{step_idx}].to(dtype=hidden.dtype)\n"
+        f"    return base_model.blocks[{block_idx}](\n"
+        f"        hidden,\n"
+        f"        step_emb,\n"
+        f"        use_xsa=base_model._step_uses_xsa({step_idx}, base_model.num_recurrent_steps),\n"
+        f"    )\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+# -----------------------------
+# SLIDING WINDOW EVALUATION
+# -----------------------------
+# Delta vs baseline evaluation: the default experiment script only scores
+# non-overlapping chunks. This record also computes the submission metric using
+# overlapping windows so each token is evaluated with near-max context.
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+    progress_label: str | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, stride)
+        if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    total_windows = len(window_starts)
+
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    progress_total = max(len(my_windows), 1)
+    progress_step = max(progress_total // 100, 1)
+    next_progress = progress_step
+    if progress_label is not None and rank == 0:
+        print(
+            f"final_eval_progress:0/{progress_total} label:{progress_label}", flush=True
+        )
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    compiled_logits = (
+        torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+        if not router_active
+        else None
+    )
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                if compiled_logits is not None:
+                    logits = compiled_logits(x_batch)
+                else:
+                    logits = base_model.forward_logits(
+                        x_batch, router_active=router_active
+                    )
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(
+                    torch.float64
+                )
+                byte_count += tb.sum()
+            current_done = min(bi + bsz, len(my_windows))
+            if (
+                progress_label is not None
+                and rank == 0
+                and (current_done >= next_progress or current_done >= len(my_windows))
+            ):
+                print(
+                    f"final_eval_progress:{current_done}/{progress_total} label:{progress_label}",
+                    flush=True,
+                )
+                next_progress = current_done + progress_step
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# ROUTER LOGGING
+# -----------------------------
+# The model logs the recent selected-action distribution per recurrent step and
+# the average router policy loss alongside average depth.
+
+
+def format_router_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    router_objective_sum: float,
+    router_objective_count: float,
+    router_entropy_sum: float,
+    router_entropy_count: float,
+) -> str:
+    avg_depth = depth_sum / depth_count if depth_count > 0 else 0.0
+    router_objective_text = (
+        f"{router_objective_sum / router_objective_count:.4f}"
+        if router_objective_count > 0
+        else "none"
+    )
+    router_entropy_text = (
+        f"{router_entropy_sum / router_entropy_count:.4f}"
+        if router_entropy_count > 0
+        else "none"
+    )
+    return (
+        f"step:{step}/{total_steps} router_probe "
+        f"window_steps:{window_steps} avg_depth:{avg_depth:.3f} "
+        f"router_objective:{router_objective_text} "
+        f"router_entropy:{router_entropy_text}"
+    )
+
+
+def format_router_action_matrix(
+    step: int,
+    total_steps: int,
+    total_counts: Tensor | None,
+    num_layers: int,
+) -> str:
+    if total_counts is None:
+        return f"step:{step}/{total_steps} router_matrix:none"
+    action_names = [f"b{i}" for i in range(num_layers)] + ["stop"]
+    lines = [f"step:{step}/{total_steps} router_matrix"]
+    for step_idx in range(total_counts.size(0)):
+        row = total_counts[step_idx]
+        row_total = float(row.sum().item())
+        if row_total <= 0:
+            continue
+        probs = row / row_total
+        row_text = " ".join(
+            f"{name}:{float(probs[action_idx].item()):.3f}"
+            for action_idx, name in enumerate(action_names)
+        )
+        lines.append(f"  s{step_idx + 1:02d} {row_text}")
+    return "\n".join(lines)
+
+
+# -----------------------------
+# INT6 MIXED QUANTIZATION (transplanted from working diagnostic scripts)
+# -----------------------------
+# Delta vs baseline export: attention/MLP matrices move to int6 while the
+# remaining weights use int8 or float passthrough. The baseline export path is
+# pure int8 + zlib.
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_int6_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / 31.0).clamp_min(1.0 / 31.0).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -32, 31).to(
+            torch.int8
+        )
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / 31.0 if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -32, 31).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = (
+        max(
+            (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+            default=0,
+        )
+        + 1
+    )
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        # tok_emb.weight falls through to int8 via "embed" category
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # Keep a larger Dynamo cache budget as a conservative default for the
+    # recurrent training/eval helpers used elsewhere in the script.
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                torch._dynamo.config.recompile_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "cache_size_limit"):
+            torch._dynamo.config.cache_size_limit = max(
+                torch._dynamo.config.cache_size_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "accumulated_cache_size_limit"):
+            torch._dynamo.config.accumulated_cache_size_limit = max(
+                torch._dynamo.config.accumulated_cache_size_limit,
+                16 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "fail_on_recompile_limit_hit"):
+            torch._dynamo.config.fail_on_recompile_limit_hit = False
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        torch._dynamo.config.optimize_ddp = False
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(
+            ["nvidia-smi"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(
+            f"Script only setup for SentencePiece .model file: {args.tokenizer_path}"
+        )
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    # Delta vs baseline data/eval setup: validation tensors are loaded long
+    # enough to support either plain non-overlapping eval or sliding-window eval
+    # at a different sequence length.
+    effective_eval_seq_len = (
+        args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    )
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = (
+        build_sentencepiece_luts(sp, args.vocab_size, device)
+    )
+    log0(
+        f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}"
+    )
+    log0(
+        f"train_loader:dataset:{dataset_dir.name} mode:shuffled_memmap "
+        f"train_shards:{actual_train_files}"
+    )
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    # This global switch activates the STE fake-quant path in `CastedLinear`.
+    CastedLinear._qat_enabled = args.qat_enabled
+
+    base_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_start,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=args.mtp_num_heads,
+            mtp_loss_weight=args.mtp_loss_weight,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,
+        )
+        .to(device)
+        .bfloat16()
+    )
+    router_base_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    dispatch_model = TrainDepthDispatcher(base_model)
+    compiled_train_depth_runners: dict[int, callable] = {}
+    compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+    if args.compiled_routed_experts:
+        for step_idx in range(args.num_recurrent_steps):
+            for block_idx in range(args.num_layers):
+                compiled_recurrent_step_runners[(step_idx, block_idx)] = (
+                    build_compiled_recurrent_step_runner(
+                        base_model, step_idx, block_idx
+                    )
+                )
+    dispatch_model.set_compiled_train_depth_runners(compiled_train_depth_runners)
+    base_model.set_compiled_recurrent_step_runners(compiled_recurrent_step_runners)
+    base_model.set_unused_block_anchor_enabled(distributed)
+    model: nn.Module = (
+        DDP(
+            dispatch_model,
+            device_ids=[local_rank],
+            broadcast_buffers=False,
+        )
+        if distributed
+        else dispatch_model
+    )
+    router_model: nn.Module = (
+        DDP(router_base_model, device_ids=[local_rank], broadcast_buffers=False)
+        if distributed
+        else router_base_model
+    )
+    base_model.set_transformer_router(router_model)
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    # Delta vs baseline parameter routing:
+    # - Bigram embeddings join the token optimizer
+    # - Smear/bigram scales join the scalar optimizer
+    # - MTP heads join the matrix optimizer when enabled
+    # - AdamW/Muon weight decay is explicit instead of relying on pure Adam/Muon
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2
+        and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.mtp_num_heads > 0:
+        matrix_params.extend(
+            [p for p in base_model.mtp_heads.parameters() if p.ndim == 2]
+        )
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2
+        or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [
+        {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+    ]
+    if base_model.bigram is not None:
+        tok_params.append(
+            {
+                "params": [base_model.bigram.embed.weight],
+                "lr": token_lr,
+                "base_lr": token_lr,
+            }
+        )
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.embed_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+        row_normalize=args.muon_row_normalize,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_router = torch.optim.AdamW(
+        [
+            {
+                "params": router_base_model.parameters(),
+                "lr": args.router_lr,
+                "base_lr": args.router_lr,
+            }
+        ],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.router_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [
+        optimizer_tok,
+        optimizer_muon,
+        optimizer_scalar,
+    ]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [
+                {
+                    "params": [base_model.lm_head.weight],
+                    "lr": args.head_lr,
+                    "base_lr": args.head_lr,
+                }
+            ],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    all_optimizers: list[torch.optim.Optimizer] = [*optimizers, optimizer_router]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    router_params = sum(p.numel() for p in router_base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"router_params:{router_params}")
+    log0(
+        f"unique_blocks:{len(base_model.blocks)} recurrent_steps:{base_model.num_recurrent_steps}"
+    )
+    log0(
+        f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}"
+    )
+    xsa_steps = base_model.xsa_step_indices()
+    log0(f"XSA:last_{args.xsa_last_n} active_steps:{xsa_steps}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(
+        f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}"
+    )
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"warmdown_frac:{args.warmdown_frac:.2f} min_lr:{args.min_lr:.4f} "
+        f"val_loss_every:{args.val_loss_every} "
+        f"num_recurrent_steps:{args.num_recurrent_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"router_actions:{args.num_layers + 1} "
+        f"eval_recurrent_steps:{args.num_recurrent_steps}"
+    )
+    log0(
+        f"router_input_dim:{3 * args.model_dim} "
+        f"router_hidden_dim:{args.router_hidden_dim} "
+        f"router_lr:{args.router_lr} router_wd:{args.router_wd} "
+        f"router_entropy_bonus_start:{args.router_entropy_bonus_start} "
+        f"router_entropy_bonus_end:{args.router_entropy_bonus_end} "
+        f"router_step_penalty:{args.router_step_penalty} "
+        f"compiled_routed_experts:{int(args.compiled_routed_experts)} "
+        f"activation_checkpointing:{int(args.activation_checkpointing)} "
+        f"ema_decay:{args.ema_decay} "
+        f"muon_momentum_warmup_steps:{args.muon_momentum_warmup_steps}"
+    )
+    log0(
+        f"muon_row_normalize:{int(args.muon_row_normalize)} "
+        f"muon_wd:{args.muon_wd} adam_wd:{args.adam_wd} embed_wd:{args.embed_wd}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+    router_model.train()
+    optimizer_router.zero_grad(set_to_none=True)
+
+    def zero_grad_all() -> None:
+        for opt in all_optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = (
+        1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is None:
+            return step / max(args.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-9)
+
+    def lr_mul(progress: float) -> float:
+        if args.warmdown_frac <= 0.0:
+            return 1.0
+        if progress >= 1.0 - args.warmdown_frac:
+            return max((1.0 - progress) / args.warmdown_frac, args.min_lr)
+        return 1.0
+
+    def router_entropy_bonus_value(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is not None and max_wallclock_ms > 0.0:
+            progress = min(max(elapsed_ms / max_wallclock_ms, 0.0), 1.0)
+        elif args.iterations > 1:
+            progress = min(max(step / (args.iterations - 1), 0.0), 1.0)
+        else:
+            progress = 1.0
+        return (
+            1.0 - progress
+        ) * args.router_entropy_bonus_start + progress * args.router_entropy_bonus_end
+
+    # Warmup exercises the actual router-controlled training path and optimizer
+    # kernels, then we restore the initial weights/optimizer state so measured
+    # training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_router_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in router_base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in all_optimizers
+        ]
+        model.train()
+        router_model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                    router_model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(
+                    args.train_batch_tokens, grad_accum_steps
+                )
+                with torch.autocast(
+                    device_type="cuda", dtype=torch.bfloat16, enabled=True
+                ):
+                    warmup_loss = model(x, y, router_active=True)
+                (warmup_loss * grad_scale).backward()
+            for opt in all_optimizers:
+                opt.step()
+            zero_grad_all()
+            if (
+                args.warmup_steps <= 20
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == args.warmup_steps
+            ):
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        router_base_model.load_state_dict(initial_router_state, strict=True)
+        for opt, state in zip(all_optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+            router_model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+        optimizer_router.zero_grad(set_to_none=True)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    ema_model_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in base_model.state_dict().items()
+    }
+    ema_router_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in router_base_model.state_dict().items()
+    }
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    probe_window_size = max(args.recurrence_probe_every, 1)
+    recent_depth_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_depth_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_action_counts: deque[Tensor] = deque(maxlen=probe_window_size)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+
+        should_validate = last_step or (
+            args.val_loss_every > 0 and step % args.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                router_active=True,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        progress = training_frac(step, elapsed_ms)
+        scale = lr_mul(progress)
+        base_model.router_entropy_bonus = router_entropy_bonus_value(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        router_loss = torch.zeros((), device=device)
+        router_entropy = torch.zeros((), device=device)
+        step_depth_sum = 0.0
+        step_depth_count = 0
+        step_action_counts = torch.zeros(
+            args.num_recurrent_steps,
+            args.num_layers + 1,
+            device=device,
+            dtype=torch.float32,
+        )
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                router_model.require_backward_grad_sync = (
+                    micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(args.train_batch_tokens, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, router_active=True)
+            step_depth_sum += float(base_model.last_actual_recurrent_steps)
+            step_depth_count += 1
+            step_action_counts += base_model.last_forward_action_counts.to(
+                device=device, dtype=step_action_counts.dtype
+            )
+            train_loss += float(base_model.last_main_loss)
+            router_loss += float(base_model.last_router_loss)
+            router_entropy += float(base_model.last_router_entropy)
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        router_loss /= grad_accum_steps
+        router_entropy /= grad_accum_steps
+
+        frac = (
+            min(step / args.muon_momentum_warmup_steps, 1.0)
+            if args.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        for group in optimizer_router.param_groups:
+            group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(
+                router_base_model.parameters(), args.grad_clip_norm
+            )
+        for opt in all_optimizers:
+            opt.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, tensor in base_model.state_dict().items():
+                ema_model_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+            for name, tensor in router_base_model.state_dict().items():
+                ema_router_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+
+        local_step_depth_sum = float(step_depth_sum)
+        local_step_depth_count = float(step_depth_count)
+        local_router_objective_sum = float(router_loss.item()) * grad_accum_steps
+        local_router_objective_count = float(grad_accum_steps)
+        local_router_entropy_sum = float(router_entropy.item()) * grad_accum_steps
+        local_router_entropy_count = float(grad_accum_steps)
+        recent_depth_sums.append(local_step_depth_sum)
+        recent_depth_counts.append(local_step_depth_count)
+        recent_router_objective_sums.append(local_router_objective_sum)
+        recent_router_objective_counts.append(local_router_objective_count)
+        recent_router_entropy_sums.append(local_router_entropy_sum)
+        recent_router_entropy_counts.append(local_router_entropy_count)
+        recent_router_action_counts.append(step_action_counts.detach().cpu())
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        should_probe_recurrence = (
+            args.recurrence_probe_every > 0 and step % args.recurrence_probe_every == 0
+        )
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10
+            or step % args.train_log_every == 0
+            or stop_after_step is not None
+        )
+        step_avg_depth = local_step_depth_sum / max(local_step_depth_count, 1.0)
+        step_avg_router_objective = (
+            local_router_objective_sum / local_router_objective_count
+            if local_router_objective_count > 0
+            else None
+        )
+        step_avg_router_entropy = (
+            local_router_entropy_sum / local_router_entropy_count
+            if local_router_entropy_count > 0
+            else None
+        )
+        if distributed and (should_probe_recurrence or should_log_train):
+            step_stats = torch.tensor(
+                [
+                    local_step_depth_sum,
+                    local_step_depth_count,
+                    local_router_objective_sum,
+                    local_router_objective_count,
+                    local_router_entropy_sum,
+                    local_router_entropy_count,
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_avg_depth = float(
+                (step_stats[0] / step_stats[1].clamp_min(1.0)).item()
+            )
+            step_avg_router_objective = (
+                float((step_stats[2] / step_stats[3]).item())
+                if step_stats[3].item() > 0
+                else None
+            )
+            step_avg_router_entropy = (
+                float((step_stats[4] / step_stats[5]).item())
+                if step_stats[5].item() > 0
+                else None
+            )
+        if should_probe_recurrence:
+            window_stats = torch.tensor(
+                [
+                    sum(recent_depth_sums),
+                    sum(recent_depth_counts),
+                    sum(recent_router_objective_sums),
+                    sum(recent_router_objective_counts),
+                    sum(recent_router_entropy_sums),
+                    sum(recent_router_entropy_counts),
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            window_action_counts: Tensor | None = (
+                torch.stack(list(recent_router_action_counts), dim=0)
+                .sum(dim=0)
+                .to(device=device, dtype=torch.float64)
+                if recent_router_action_counts
+                else None
+            )
+            if distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+                if window_action_counts is not None:
+                    dist.all_reduce(window_action_counts, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+            window_action_counts = None
+        if should_probe_recurrence and (not distributed or rank == 0):
+            log0(
+                format_router_probe_summary(
+                    step,
+                    args.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                    float(window_stats[4].item()),
+                    float(window_stats[5].item()),
+                )
+            )
+            log0(
+                format_router_action_matrix(
+                    step,
+                    args.iterations,
+                    None
+                    if window_action_counts is None
+                    else window_action_counts.cpu(),
+                    args.num_layers,
+                )
+            )
+
+        if should_log_train:
+            router_log = (
+                f" router_objective:{step_avg_router_objective:.4f}"
+                f" router_entropy:{step_avg_router_entropy:.4f}"
+                f" router_entropy_bonus:{base_model.router_entropy_bonus:.4f}"
+            )
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+                f" router_forward:1"
+                f"{router_log}"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    log0("ema:applying EMA weights")
+    base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=base_model.state_dict()[name].dtype)
+            for name, tensor in ema_model_state.items()
+        },
+        strict=True,
+    )
+    router_base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=router_base_model.state_dict()[name].dtype)
+            for name, tensor in ema_router_state.items()
+        },
+        strict=True,
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Delta vs baseline export: MTP helps training but is not part of the final
+    # artifact, so those heads are dropped before serialization.
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    router_export_sd = router_base_model.state_dict()
+    excluded_mtp = sum(
+        int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k
+    )
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+
+    if master_process:
+        torch.save({"model": export_sd, "router": router_export_sd}, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    router_sd_cpu = {k: v.detach().cpu() for k, v in router_export_sd.items()}
+    # Baseline writes int8+zlib. This record uses mixed int6/int8 and prefers
+    # zstd-22 when available to squeeze under the 16 MB artifact limit.
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+    router_quant_result, router_quant_meta = mixed_quantize_int6(router_sd_cpu, set())
+    quant_buf = io.BytesIO()
+    torch.save(
+        {
+            "w": quant_result,
+            "m": quant_meta,
+            "rw": router_quant_result,
+            "rm": router_quant_meta,
+        },
+        quant_buf,
+    )
+    quant_raw = quant_buf.getvalue()
+    quant_blob = (
+        zstandard.ZstdCompressor(level=22).compress(quant_raw)
+        if _COMPRESSOR == "zstd"
+        else zlib.compress(quant_raw, 9)
+    )
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(
+            f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes"
+        )
+
+    # Roundtrip: rebuild a fresh eval model from the compressed artifact so the
+    # reported score matches the thing that would actually be submitted.
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(
+            zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+            if _COMPRESSOR == "zstd"
+            else zlib.decompress(quant_blob_disk)
+        ),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    deq_router_state = dequantize_mixed_int6(
+        quant_state["rw"], quant_state["rm"], router_sd_cpu
+    )
+
+    eval_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_mult=args.mlp_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_end,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=0,
+            mtp_loss_weight=0.0,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,  # must match training model
+        )
+        .to(device)
+        .bfloat16()
+    )
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_router_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    eval_model.set_transformer_router(eval_router_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    eval_router_model.load_state_dict(deq_router_state, strict=True)
+    eval_router_model.eval()
+
+    # Standard non-overlapping eval (sanity check)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+        router_active=True,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    # Sliding-window eval is the record's headline submission metric.
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}"
+        )
+
+    # Second sliding window eval at stride=64 for submission comparison
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window_s64",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}"
+        )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_2_5.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_2_5.py
@@ -1,0 +1,2835 @@
+"""
+ART-2.5
+
+Four identically sized transformer blocks are reused recurrently with Fourier
+step embeddings. A sidecar Transformer Router chooses among the four blocks or
+stopping recursion from latent-state features, while each block uses its own
+token-level MoE MLP router internally.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from collections import deque
+from pathlib import Path
+
+# Delta vs `train_gpt.py`: prefer zstd for the final artifact when
+# the package is available, but keep a zlib fallback so the script still runs in
+# lighter local environments.
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# Delta vs baseline attention: call FlashAttention 3 directly instead of
+# `torch.scaled_dot_product_attention(...)`.
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.checkpoint import checkpoint
+
+
+class Hyperparameters:
+    # Highest-impact run budget, data, and schedule knobs.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model"
+    )
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+
+    # Router-specific policy training knobs.
+    router_hidden_dim = int(os.environ.get("ROUTER_HIDDEN_DIM", 128))
+    router_lr = float(os.environ.get("ROUTER_LR", 0.001))
+    router_wd = float(os.environ.get("ROUTER_WD", 0.01))
+    router_entropy_bonus_start = float(
+        os.environ.get("ROUTER_ENTROPY_BONUS_START", 0.2)
+    )
+    router_entropy_bonus_end = float(os.environ.get("ROUTER_ENTROPY_BONUS_END", 0.02))
+    router_step_penalty = float(os.environ.get("ROUTER_STEP_PENALTY", 0.02))
+
+    # Per-block MoE MLP knobs. ART-2.5 keeps the ART-2 outer router, but each
+    # transformer block now has its own token-level expert router internally.
+    mlp_router_hidden_dim = int(os.environ.get("MLP_ROUTER_HIDDEN_DIM", 128))
+    mlp_num_experts = int(os.environ.get("MLP_NUM_EXPERTS", 4))
+    mlp_expert_top_k = int(os.environ.get("MLP_EXPERT_TOP_K", 2))
+    mlp_expert_mult = float(os.environ.get("MLP_EXPERT_MULT", 1.25))
+
+    # Model shape. ART-2.5 keeps the ART-2 outer structure, but each block now
+    # swaps its dense MLP for a routed MoE MLP.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 4))
+    num_recurrent_steps = int(os.environ.get("NUM_RECURRENT_STEPS", 12))
+    model_dim = int(os.environ.get("MODEL_DIM", 1024))
+    num_heads = int(os.environ.get("NUM_HEADS", 32))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 16))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+
+    # Optimizer and regularization defaults adapted from the record run where
+    # they transfer cleanly to ART.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+
+    # Eval/export/runtime controls.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    activation_checkpointing = bool(
+        int(os.environ.get("ACTIVATION_CHECKPOINTING", "0"))
+    )
+    compiled_routed_experts = bool(int(os.environ.get("COMPILED_ROUTED_EXPERTS", "0")))
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+
+    # Auxiliary training features retained from ART.
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # Optional carry-over from the source experiment: apply XSA only on the last
+    # N recurrent steps.
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 0))  # 0 disables XSA entirely
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+#
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+
+def zeropower_via_newtonschulz5(
+    G: Tensor, steps: int = 10, eps: float = 1e-7
+) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+        row_normalize: bool = False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            # Delta vs baseline Muon: this version adds decoupled weight decay so
+            # matrix params can use MuonWD without moving them onto Adam.
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    # Delta vs baseline eval: training and evaluation sequence lengths can
+    # differ, because this stack trains at long context and also uses
+    # sliding-window evaluation later in the script.
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y, router_active=router_active).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+# Delta vs baseline export: extra control tensors from SmearGate/Bigram/XSA stay
+# out of the aggressive quantization path.
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(
+    name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]
+) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(
+            torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None]
+        )
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = (
+            torch.clamp(torch.round(clipped / scale[:, None]), -127, 127)
+            .to(torch.int8)
+            .contiguous()
+        )
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = (
+        float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item())
+        if t32.numel()
+        else 0.0
+    )
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = (
+        torch.clamp(
+            torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127
+        )
+        .to(torch.int8)
+        .contiguous()
+    )
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "int8_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (
+                (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1))))
+                .to(dtype=dtype)
+                .contiguous()
+            )
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE: dict[str, int] = {}
+_MMAP_CACHE: dict[str, np.memmap] = {}
+
+
+def _read_num_tokens(file: Path) -> int:
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = num_tokens
+    return num_tokens
+
+
+def _get_shard_memmap(file: Path) -> np.memmap:
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    mm = np.memmap(
+        file,
+        mode="r",
+        dtype="<u2",
+        offset=_SHARD_HEADER_BYTES,
+        shape=(_read_num_tokens(file),),
+    )
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+class ShuffledSequenceLoader:
+    # Record-style shard-local randomized sequence sampling keeps each rank on a
+    # disjoint shard subset and avoids materializing global batches on every rank.
+    def __init__(
+        self, args: Hyperparameters, rank: int, world_size: int, device: torch.device
+    ):
+        self.rank = rank
+        self.world_size = world_size
+        self.seq_len = args.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(args.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {args.train_files}")
+        self.files = all_files[rank::world_size]
+        if not self.files:
+            raise ValueError(
+                f"No training shards assigned to rank {rank} out of {world_size}"
+            )
+        self.rng = np.random.Generator(np.random.PCG64(args.seed + rank))
+        self.num_tokens = [_read_num_tokens(file) for file in self.files]
+        self.start_inds: list[list[int]] = [[] for _ in self.files]
+        for shard_idx in range(len(self.files)):
+            self._reset_shard(shard_idx)
+
+    def _reset_shard(self, shard_idx: int) -> None:
+        max_phase = min(
+            self.seq_len - 1,
+            max(0, self.num_tokens[shard_idx] - self.seq_len - 1),
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[shard_idx] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[shard_idx] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(
+        self, global_tokens: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array(
+            [len(starts) for starts in self.start_inds], dtype=np.float64
+        )
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for batch_idx in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for shard_idx in range(len(self.files)):
+                    self._reset_shard(shard_idx)
+                remaining = np.array(
+                    [len(starts) for starts in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            shard_idx = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[shard_idx].pop()
+            remaining[shard_idx] -= 1
+            mm = _get_shard_memmap(self.files[shard_idx])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[batch_idx] = window[:-1]
+            y[batch_idx] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        # Delta vs baseline linear layers: optional straight-through fake quant
+        # lets later experiments turn on lightweight QAT without changing module
+        # call sites or adding parallel weight copies.
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (
+                    torch.clamp(torch.round(w32 / scale[:, None]), -32, 31)
+                    * scale[:, None]
+                ).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # NTK-aware RoPE: auto-scales base frequency when seq_len exceeds train_seq_len.
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (
+                    new_base
+                    ** (
+                        torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                        / self.dim
+                    )
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+# Delta vs `train_gpt.py`:
+# - head layout matches FlashAttention 3 directly, so there are no transpose
+#   calls around the kernel invocation
+# - late recurrent steps can opt into XSA after the main attention kernel runs
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        """Efficient XSA: subtract self-value projection via GQA-aware reshape (no repeat_interleave).
+        y: [B, T, H, D], v: [B, T, Hkv, D]. H must be divisible by Hkv."""
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        # Reshape y into KV head groups — free view, no memory alloc
+        y_g = y.reshape(B, T, Hkv, group, D)  # [B, T, Hkv, group, D]
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)  # [B, T, Hkv, 1, D] — broadcast ready
+        # Project out self-value component per KV head group
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x: Tensor, use_xsa: bool | None = None) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        # Baseline uses SDPA with `enable_gqa=True`; this record uses FA3
+        # directly, then optionally applies XSA as a cheap post-processing step.
+        y = flash_attn_3_func(q, k, v, causal=True)
+        apply_xsa = self.use_xsa if use_xsa is None else use_xsa
+        if apply_xsa:
+            y = self._xsa_efficient(y, v)
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# Delta vs baseline input path: before the block stack, embeddings get a
+# one-token temporal blend (`SmearGate`) plus a cheap hashed-bigram residual.
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = (
+            CastedLinear(bigram_dim, model_dim, bias=False)
+            if bigram_dim != model_dim
+            else None
+        )
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class FourierStepEmbedding(nn.Module):
+    """Deterministic sinusoidal embedding for recurrent UT steps."""
+
+    def __init__(self, num_steps: int, dim: int):
+        super().__init__()
+        half = dim // 2
+        steps = torch.arange(num_steps, dtype=torch.float32).unsqueeze(1)
+        freqs = 1.0 / (10000.0 ** (2.0 * torch.arange(half, dtype=torch.float32) / dim))
+        angles = steps * freqs.unsqueeze(0)
+        table = torch.zeros(num_steps, dim, dtype=torch.float32)
+        table[:, 0 : 2 * half : 2] = torch.sin(angles)
+        table[:, 1 : 2 * half : 2] = torch.cos(angles)
+        self.register_buffer("table", table, persistent=False)
+
+    def forward(self, step_idx: int) -> Tensor:
+        return self.table[step_idx]
+
+
+class MoEExpert(nn.Module):
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class TokenExpertRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, num_experts: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_experts)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, token_states: Tensor) -> Tensor:
+        x = F.gelu(self.fc(token_states.float()))
+        return self.proj(x)
+
+
+class SharedMixtureOfExpertsMLP(nn.Module):
+    def __init__(self, dim: int, num_experts: int, expert_mult: float):
+        super().__init__()
+        hidden = max(1, int(dim * expert_mult))
+        self.num_experts = num_experts
+        self.experts = nn.ModuleList(
+            [MoEExpert(dim, hidden) for _ in range(num_experts)]
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        selected_expert_indices: Tensor,
+        selected_expert_weights: Tensor,
+    ) -> Tensor:
+        # Keep the expert bank dense. With four experts at expert_mult=1.25,
+        # running all experts over the whole active batch matches the original
+        # dense MLP flop budget (4 * 1.25 = 5.0) while avoiding the sparse
+        # token-dispatch overhead that was crushing throughput.
+        expert_weights = x.new_zeros((*x.shape[:2], self.num_experts))
+        expert_weights.scatter_(-1, selected_expert_indices, selected_expert_weights)
+        output = torch.zeros_like(x)
+        for expert_idx, expert in enumerate(self.experts):
+            output = output + expert(x) * expert_weights[..., expert_idx].unsqueeze(-1)
+        return output
+
+
+class TransformerRouter(nn.Module):
+    """Predict routing logits over the block set plus stop."""
+
+    def __init__(self, input_dim: int, hidden_dim: int, num_actions: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_actions)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, router_inputs: Tensor) -> Tensor:
+        x = F.gelu(self.fc(router_inputs.float()))
+        return self.proj(x)
+
+
+class UniversalTransformerBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_router_hidden_dim: int,
+        mlp_num_experts: int,
+        mlp_expert_top_k: int,
+        mlp_expert_mult: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if mlp_expert_top_k <= 0 or mlp_expert_top_k > mlp_num_experts:
+            raise ValueError(
+                f"MLP_EXPERT_TOP_K must be in [1, {mlp_num_experts}], got {mlp_expert_top_k}"
+            )
+        self.mlp_expert_top_k = mlp_expert_top_k
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init
+        )
+        self.mlp_router = TokenExpertRouter(dim, mlp_router_hidden_dim, mlp_num_experts)
+        # Keep the residual path simple for recurrence: pre-norm attention,
+        # residual add, then pre-norm MLP and residual add.
+
+    def forward(
+        self,
+        h: Tensor,
+        step_emb: Tensor,
+        shared_mlp: SharedMixtureOfExpertsMLP,
+        use_xsa: bool = False,
+    ) -> Tensor:
+        x = h + step_emb[None, None, :]
+        h = h + self.attn(self.attn_norm(x), use_xsa=use_xsa)
+        token_states = self.mlp_norm(h)
+        expert_logits = self.mlp_router(token_states).float()
+        if self.training and torch.is_grad_enabled():
+            uniform = torch.rand_like(expert_logits).clamp_(1e-6, 1.0 - 1e-6)
+            gumbel = -torch.log(-torch.log(uniform))
+            selection_scores = expert_logits + gumbel
+        else:
+            selection_scores = expert_logits
+        selected_expert_indices = selection_scores.topk(
+            self.mlp_expert_top_k, dim=-1
+        ).indices
+        selected_expert_logits = expert_logits.gather(
+            dim=-1, index=selected_expert_indices
+        )
+        selected_expert_weights = torch.softmax(selected_expert_logits, dim=-1).to(
+            dtype=token_states.dtype
+        )
+        h = h + shared_mlp(
+            token_states, selected_expert_indices, selected_expert_weights
+        )
+        return h
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_router_hidden_dim: int,
+        mlp_num_experts: int,
+        mlp_expert_top_k: int,
+        mlp_expert_mult: float,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_recurrent_steps: int = 8,
+        router_entropy_bonus: float = 0.01,
+        router_step_penalty: float = 0.01,
+        activation_checkpointing: bool = True,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if num_layers != 4:
+            raise ValueError(f"ART-2.5 expects NUM_LAYERS=4, got {num_layers}")
+        if num_recurrent_steps <= 0:
+            raise ValueError(
+                f"NUM_RECURRENT_STEPS must be positive, got {num_recurrent_steps}"
+            )
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_recurrent_steps = num_recurrent_steps
+        self.router_entropy_bonus = router_entropy_bonus
+        self.router_step_penalty = router_step_penalty
+        self.activation_checkpointing = activation_checkpointing
+        self.xsa_last_n = xsa_last_n
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.last_actual_recurrent_steps = 0.0
+        self.last_main_loss = 0.0
+        self.last_router_loss = 0.0
+        self.last_router_policy_loss = 0.0
+        self.last_router_entropy = 0.0
+        self.last_forward_action_counts = torch.zeros(
+            self.num_recurrent_steps, num_layers + 1, dtype=torch.float32
+        )
+        object.__setattr__(self, "_transformer_router", None)
+        self._last_router_log_probs: Tensor | None = None
+        self._last_router_entropies: Tensor | None = None
+        self._last_router_decision_counts: Tensor | None = None
+        self._last_router_depths: Tensor | None = None
+        self._compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+        self._unused_block_anchor_enabled = False
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = (
+            BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim)
+            if bigram_vocab_size > 0
+            else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.step_embedding = FourierStepEmbedding(num_recurrent_steps, model_dim)
+        # Keep an empty tensor attribute for compatibility with the existing
+        # trainer plumbing, but register it as a buffer, not a Parameter.
+        # Otherwise DDP sees an unused parameter and can fail on the next
+        # warmup/train forward with an unfinished reduction error.
+        self.register_buffer(
+            "skip_weights",
+            torch.empty(0, model_dim, dtype=torch.float32),
+            persistent=False,
+        )
+        self.shared_mlp = SharedMixtureOfExpertsMLP(
+            model_dim, mlp_num_experts, mlp_expert_mult
+        )
+        self.blocks = nn.ModuleList(
+            [
+                UniversalTransformerBlock(
+                    model_dim,
+                    num_heads,
+                    num_kv_heads,
+                    mlp_router_hidden_dim,
+                    mlp_num_experts,
+                    mlp_expert_top_k,
+                    mlp_expert_mult,
+                    rope_base,
+                    qk_gain_init,
+                )
+                for _ in range(num_layers)
+            ]
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [
+                CastedLinear(model_dim, vocab_size, bias=False)
+                for _ in range(mtp_num_heads)
+            ]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        self._init_weights()
+
+    def xsa_step_indices(self, num_recurrent_steps: int | None = None) -> list[int]:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if self.xsa_last_n <= 0:
+            return []
+        start = max(0, steps - self.xsa_last_n)
+        return list(range(start, steps))
+
+    def _step_uses_xsa(
+        self, step_idx: int, num_recurrent_steps: int | None = None
+    ) -> bool:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        return self.xsa_last_n > 0 and step_idx >= steps - self.xsa_last_n
+
+    def set_compiled_recurrent_step_runners(
+        self, runners: dict[tuple[int, int], callable]
+    ) -> None:
+        self._compiled_recurrent_step_runners = runners
+
+    def set_unused_block_anchor_enabled(self, enabled: bool) -> None:
+        self._unused_block_anchor_enabled = enabled
+
+    def _unused_block_param_anchor(
+        self, used_block_indices: set[int], ref: Tensor
+    ) -> Tensor:
+        if len(used_block_indices) >= len(self.blocks):
+            return ref.new_zeros(())
+        # Touch parameters of blocks that were skipped so DDP can keep
+        # `find_unused_parameters=False` without changing the numerical forward.
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx, block in enumerate(self.blocks):
+            if block_idx in used_block_indices:
+                continue
+            for param in block.parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def set_transformer_router(self, router: nn.Module) -> None:
+        # The router is trained separately and should not be registered as part
+        # of the transformer module graph, otherwise DDP would expect router
+        # parameters to participate in every transformer backward pass.
+        object.__setattr__(self, "_transformer_router", router)
+
+    def _router_features(self, x: Tensor, step_idx: int) -> Tensor:
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        step_batch = step_emb.unsqueeze(0).expand(x.size(0), -1)
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled, step_batch), dim=-1)
+
+    def _router_logits(self, router_inputs: Tensor) -> Tensor:
+        router = self._transformer_router
+        if router is None:
+            raise RuntimeError("Transformer Router must be set before router use")
+        return router(router_inputs)
+
+    def _sequence_losses_from_hidden(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self._logits_from_hidden(x)
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        return token_losses.mean(dim=1)
+
+    def _recurrent_step(
+        self,
+        x: Tensor,
+        step_idx: int,
+        block_idx: int,
+        total_steps: int,
+    ) -> Tensor:
+        runner = (
+            self._compiled_recurrent_step_runners.get((step_idx, block_idx))
+            if total_steps == self.num_recurrent_steps
+            else None
+        )
+        if runner is not None:
+            if (
+                self.activation_checkpointing
+                and self.training
+                and torch.is_grad_enabled()
+            ):
+                return checkpoint(
+                    runner,
+                    x,
+                    use_reentrant=False,
+                    preserve_rng_state=False,
+                )
+            return runner(x)
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        block = self.blocks[block_idx]
+        use_xsa = self._step_uses_xsa(step_idx, total_steps)
+        if self.activation_checkpointing and self.training and torch.is_grad_enabled():
+
+            def run_block(h: Tensor) -> Tensor:
+                return block(h, step_emb, self.shared_mlp, use_xsa=use_xsa)
+
+            return checkpoint(
+                run_block,
+                x,
+                use_reentrant=False,
+                preserve_rng_state=False,
+            )
+        return block(x, step_emb, self.shared_mlp, use_xsa=use_xsa)
+
+    def _masked_router_probs(self, router_inputs: Tensor, allow_stop: bool) -> Tensor:
+        logits = self._router_logits(router_inputs).float()
+        if not allow_stop:
+            logits = logits.clone()
+            logits[:, len(self.blocks)] = torch.finfo(logits.dtype).min
+        return torch.softmax(logits, dim=-1)
+
+    def _recurrent_forward(
+        self,
+        input_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        target_ids: Tensor | None = None,
+        router_active: bool = False,
+    ) -> Tensor:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if steps <= 0 or steps > self.num_recurrent_steps:
+            raise ValueError(
+                f"num_recurrent_steps must be in [1, {self.num_recurrent_steps}], got {steps}"
+            )
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        # RoPE inside attention still handles token-position encoding; the
+        # recurrent addition here is per-step conditioning for whichever block
+        # the route selects next.
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        stop_enabled = num_recurrent_steps is None
+        batch_size = int(x.size(0))
+        active_indices = torch.arange(batch_size, device=x.device, dtype=torch.int64)
+        active_x = x
+        final_x = torch.empty_like(x)
+        depths = torch.zeros(batch_size, device=x.device, dtype=torch.float32)
+        router_log_prob_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_entropy_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        router_decision_counts = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        action_counts = torch.zeros(
+            steps, len(self.blocks) + 1, device=x.device, dtype=torch.float32
+        )
+        used_block_indices: set[int] = set()
+        for step_idx in range(steps):
+            if active_indices.numel() == 0:
+                break
+            allow_stop = stop_enabled and step_idx > 0
+            router_inputs = self._router_features(active_x, step_idx)
+            action_probs = self._masked_router_probs(router_inputs, allow_stop)
+            if self.training and torch.is_grad_enabled() and router_active:
+                action_ids = torch.multinomial(action_probs, num_samples=1).squeeze(1)
+                log_action_probs = torch.log(action_probs.clamp_min(1e-9))
+                router_log_prob_sums[active_indices] += log_action_probs.gather(
+                    1, action_ids.unsqueeze(1)
+                ).squeeze(1)
+                router_entropy_sums[active_indices] += -(
+                    action_probs * log_action_probs
+                ).sum(dim=1)
+                router_decision_counts[active_indices] += 1.0
+            else:
+                action_ids = action_probs.argmax(dim=1)
+            action_counts[step_idx] += torch.bincount(
+                action_ids, minlength=len(self.blocks) + 1
+            ).to(dtype=action_counts.dtype)
+            stop_action_idx = len(self.blocks)
+            if allow_stop:
+                stop_mask = action_ids == stop_action_idx
+                if stop_mask.any():
+                    stop_indices = active_indices[stop_mask]
+                    final_x[stop_indices] = active_x[stop_mask]
+                    active_keep_mask = ~stop_mask
+                    active_indices = active_indices[active_keep_mask]
+                    active_x = active_x[active_keep_mask]
+                    action_ids = action_ids[active_keep_mask]
+            if active_indices.numel() == 0:
+                break
+            next_active_x = torch.empty_like(active_x)
+            ran_any_block = False
+            for block_idx in range(len(self.blocks)):
+                block_mask = action_ids == block_idx
+                if not block_mask.any():
+                    continue
+                ran_any_block = True
+                used_block_indices.add(block_idx)
+                block_hidden = self._recurrent_step(
+                    active_x[block_mask], step_idx, block_idx, steps
+                )
+                next_active_x[block_mask] = block_hidden
+            if not ran_any_block:
+                break
+            depths[active_indices] = float(step_idx + 1)
+            active_x = next_active_x
+        if active_indices.numel() > 0:
+            final_x[active_indices] = active_x
+        self.last_actual_recurrent_steps = float(depths.mean().item())
+        self.last_forward_action_counts = action_counts.detach()
+        self._last_router_log_probs = router_log_prob_sums
+        self._last_router_entropies = router_entropy_sums
+        self._last_router_decision_counts = router_decision_counts
+        self._last_router_depths = depths
+        x = self.final_norm(final_x)
+        if (
+            self._unused_block_anchor_enabled
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._unused_block_param_anchor(used_block_indices, x).view(1, 1, 1)
+        return x
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        effective_depth = self.num_recurrent_steps
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    # Delta vs baseline init: large matrices use orthogonal init,
+                    # and output projections get an extra depth-aware shrink.
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+                    if ".proj." in name or name.endswith(".proj"):
+                        with torch.no_grad():
+                            module.weight.mul_(1.0 / math.sqrt(2 * effective_depth))
+
+    def _logits_from_hidden(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _loss_from_hidden(self, x: Tensor, target_ids: Tensor) -> tuple[Tensor, Tensor]:
+        seq_losses = self._sequence_losses_from_hidden(x, target_ids)
+        main_loss = seq_losses.mean()
+
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(
+                    mtp_logits_proj / self.logit_softcap
+                )
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(
+                    mtp_logits.float(), mtp_targets, reduction="mean"
+                )
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (
+                    mtp_loss_sum / mtp_loss_count
+                )
+
+        return main_loss, seq_losses
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            target_ids=target_ids,
+            router_active=router_active,
+        )
+        main_loss, seq_losses = self._loss_from_hidden(x, target_ids)
+        self.last_main_loss = float(main_loss.detach().item())
+        total_loss = main_loss
+        router_loss = x.new_zeros(())
+        router_policy_loss = x.new_zeros(())
+        router_mean_entropy = x.new_zeros(())
+        if (
+            router_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_router_log_probs is not None
+            and self._last_router_entropies is not None
+            and self._last_router_decision_counts is not None
+            and self._last_router_depths is not None
+        ):
+            valid_mask = self._last_router_decision_counts > 0
+            if valid_mask.any():
+                router_costs = seq_losses.detach()[valid_mask] + (
+                    self.router_step_penalty * self._last_router_depths[valid_mask]
+                )
+                advantages = router_costs - router_costs.mean()
+                router_policy_loss = (
+                    advantages * self._last_router_log_probs[valid_mask]
+                ).mean()
+                # Normalize entropy by the number of routing decisions per
+                # sequence so longer trajectories do not get a larger bonus
+                # merely for avoiding the stop action.
+                router_mean_entropy = (
+                    self._last_router_entropies[valid_mask]
+                    / self._last_router_decision_counts[valid_mask].clamp_min(1.0)
+                ).mean()
+                router_loss = (
+                    router_policy_loss - self.router_entropy_bonus * router_mean_entropy
+                )
+                total_loss = total_loss + router_loss
+        self.last_router_policy_loss = float(router_policy_loss.detach().item())
+        self.last_router_entropy = float(router_mean_entropy.detach().item())
+        self.last_router_loss = float(router_loss.detach().item())
+        return total_loss
+
+    def forward_loss_at_depth(
+        self, input_ids: Tensor, target_ids: Tensor, depth: int
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=depth,
+            target_ids=target_ids,
+            router_active=True,
+        )
+        main_loss, _ = self._loss_from_hidden(x, target_ids)
+        return main_loss
+
+    def forward_logits(self, input_ids: Tensor, router_active: bool = True) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self._recurrent_forward(input_ids, router_active=router_active)
+        return self._logits_from_hidden(x)
+
+
+class TrainDepthDispatcher(nn.Module):
+    def __init__(self, base_model: GPT):
+        super().__init__()
+        self.base_model = base_model
+        self._compiled_train_depth_runners: dict[int, callable] = {}
+
+    def set_compiled_train_depth_runners(self, runners: dict[int, callable]) -> None:
+        self._compiled_train_depth_runners = runners
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        if num_recurrent_steps is not None and self.training:
+            runner = self._compiled_train_depth_runners.get(num_recurrent_steps)
+            if runner is not None:
+                return runner(input_ids, target_ids)
+        return self.base_model(
+            input_ids,
+            target_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            router_active=router_active,
+        )
+
+
+def build_compiled_train_depth_runner(base_model: GPT, depth: int):
+    # Give each compiled training entrypoint a distinct code object so Dynamo
+    # does not treat depth-specialized runners as recompiles of the same frame.
+    runner_name = f"train_depth_runner_{depth}"
+    runner_src = (
+        f"def {runner_name}(input_ids, target_ids):\n"
+        f"    return base_model(input_ids, target_ids, num_recurrent_steps={depth})\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+def build_compiled_recurrent_step_runner(
+    base_model: GPT, step_idx: int, block_idx: int
+):
+    # Random routing still loops in Python, so compile each (step, block)
+    # recurrent application separately and dispatch to the sampled route.
+    # Use shape-specialized runners here. Inductor's dynamic-shape path has been
+    # unstable for these tiny per-expert helpers, while the script already bumps
+    # Dynamo's recompile/cache budget enough to tolerate a modest number of
+    # routed batch-size specializations.
+    runner_name = f"recurrent_step_runner_{step_idx}_{block_idx}"
+    runner_src = (
+        f"def {runner_name}(hidden):\n"
+        f"    step_emb = base_model.step_embedding.table[{step_idx}].to(dtype=hidden.dtype)\n"
+        f"    return base_model.blocks[{block_idx}](\n"
+        f"        hidden,\n"
+        f"        step_emb,\n"
+        f"        base_model.shared_mlp,\n"
+        f"        use_xsa=base_model._step_uses_xsa({step_idx}, base_model.num_recurrent_steps),\n"
+        f"    )\n"
+    )
+    namespace = {"base_model": base_model}
+    exec(runner_src, namespace)
+    return torch.compile(namespace[runner_name], dynamic=False, fullgraph=True)
+
+
+# -----------------------------
+# SLIDING WINDOW EVALUATION
+# -----------------------------
+# Delta vs baseline evaluation: the default experiment script only scores
+# non-overlapping chunks. This record also computes the submission metric using
+# overlapping windows so each token is evaluated with near-max context.
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+    progress_label: str | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, stride)
+        if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    total_windows = len(window_starts)
+
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    progress_total = max(len(my_windows), 1)
+    progress_step = max(progress_total // 100, 1)
+    next_progress = progress_step
+    if progress_label is not None and rank == 0:
+        print(
+            f"final_eval_progress:0/{progress_total} label:{progress_label}", flush=True
+        )
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    compiled_logits = (
+        torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+        if not router_active
+        else None
+    )
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                if compiled_logits is not None:
+                    logits = compiled_logits(x_batch)
+                else:
+                    logits = base_model.forward_logits(
+                        x_batch, router_active=router_active
+                    )
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(
+                    torch.float64
+                )
+                byte_count += tb.sum()
+            current_done = min(bi + bsz, len(my_windows))
+            if (
+                progress_label is not None
+                and rank == 0
+                and (current_done >= next_progress or current_done >= len(my_windows))
+            ):
+                print(
+                    f"final_eval_progress:{current_done}/{progress_total} label:{progress_label}",
+                    flush=True,
+                )
+                next_progress = current_done + progress_step
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# ROUTER LOGGING
+# -----------------------------
+# The model logs the recent selected-action distribution per recurrent step and
+# the average router policy loss alongside average depth.
+
+
+def format_router_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    router_objective_sum: float,
+    router_objective_count: float,
+    router_entropy_sum: float,
+    router_entropy_count: float,
+) -> str:
+    avg_depth = depth_sum / depth_count if depth_count > 0 else 0.0
+    router_objective_text = (
+        f"{router_objective_sum / router_objective_count:.4f}"
+        if router_objective_count > 0
+        else "none"
+    )
+    router_entropy_text = (
+        f"{router_entropy_sum / router_entropy_count:.4f}"
+        if router_entropy_count > 0
+        else "none"
+    )
+    return (
+        f"step:{step}/{total_steps} router_probe "
+        f"window_steps:{window_steps} avg_depth:{avg_depth:.3f} "
+        f"router_objective:{router_objective_text} "
+        f"router_entropy:{router_entropy_text}"
+    )
+
+
+def format_router_action_matrix(
+    step: int,
+    total_steps: int,
+    total_counts: Tensor | None,
+    num_layers: int,
+) -> str:
+    if total_counts is None:
+        return f"step:{step}/{total_steps} router_matrix:none"
+    action_names = [f"b{i}" for i in range(num_layers)] + ["stop"]
+    lines = [f"step:{step}/{total_steps} router_matrix"]
+    for step_idx in range(total_counts.size(0)):
+        row = total_counts[step_idx]
+        row_total = float(row.sum().item())
+        if row_total <= 0:
+            continue
+        probs = row / row_total
+        row_text = " ".join(
+            f"{name}:{float(probs[action_idx].item()):.3f}"
+            for action_idx, name in enumerate(action_names)
+        )
+        lines.append(f"  s{step_idx + 1:02d} {row_text}")
+    return "\n".join(lines)
+
+
+# -----------------------------
+# INT6 MIXED QUANTIZATION (transplanted from working diagnostic scripts)
+# -----------------------------
+# Delta vs baseline export: attention/MLP matrices move to int6 while the
+# remaining weights use int8 or float passthrough. The baseline export path is
+# pure int8 + zlib.
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name or "shared_mlp" in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_int6_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / 31.0).clamp_min(1.0 / 31.0).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -32, 31).to(
+            torch.int8
+        )
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / 31.0 if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -32, 31).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = (
+        max(
+            (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+            default=0,
+        )
+        + 1
+    )
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        # tok_emb.weight falls through to int8 via "embed" category
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # Keep a larger Dynamo cache budget as a conservative default for the
+    # recurrent training/eval helpers used elsewhere in the script.
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                torch._dynamo.config.recompile_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "cache_size_limit"):
+            torch._dynamo.config.cache_size_limit = max(
+                torch._dynamo.config.cache_size_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "accumulated_cache_size_limit"):
+            torch._dynamo.config.accumulated_cache_size_limit = max(
+                torch._dynamo.config.accumulated_cache_size_limit,
+                16 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "fail_on_recompile_limit_hit"):
+            torch._dynamo.config.fail_on_recompile_limit_hit = False
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        torch._dynamo.config.optimize_ddp = False
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(
+            ["nvidia-smi"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(
+            f"Script only setup for SentencePiece .model file: {args.tokenizer_path}"
+        )
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    # Delta vs baseline data/eval setup: validation tensors are loaded long
+    # enough to support either plain non-overlapping eval or sliding-window eval
+    # at a different sequence length.
+    effective_eval_seq_len = (
+        args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    )
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = (
+        build_sentencepiece_luts(sp, args.vocab_size, device)
+    )
+    log0(
+        f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}"
+    )
+    log0(
+        f"train_loader:dataset:{dataset_dir.name} mode:shuffled_memmap "
+        f"train_shards:{actual_train_files}"
+    )
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    # This global switch activates the STE fake-quant path in `CastedLinear`.
+    CastedLinear._qat_enabled = args.qat_enabled
+
+    base_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_router_hidden_dim=args.mlp_router_hidden_dim,
+            mlp_num_experts=args.mlp_num_experts,
+            mlp_expert_top_k=args.mlp_expert_top_k,
+            mlp_expert_mult=args.mlp_expert_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_start,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=args.mtp_num_heads,
+            mtp_loss_weight=args.mtp_loss_weight,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,
+        )
+        .to(device)
+        .bfloat16()
+    )
+    router_base_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    dispatch_model = TrainDepthDispatcher(base_model)
+    compiled_train_depth_runners: dict[int, callable] = {}
+    compiled_recurrent_step_runners: dict[tuple[int, int], callable] = {}
+    if args.compiled_routed_experts:
+        for step_idx in range(args.num_recurrent_steps):
+            for block_idx in range(args.num_layers):
+                compiled_recurrent_step_runners[(step_idx, block_idx)] = (
+                    build_compiled_recurrent_step_runner(
+                        base_model, step_idx, block_idx
+                    )
+                )
+    dispatch_model.set_compiled_train_depth_runners(compiled_train_depth_runners)
+    base_model.set_compiled_recurrent_step_runners(compiled_recurrent_step_runners)
+    base_model.set_unused_block_anchor_enabled(distributed)
+    model: nn.Module = (
+        DDP(
+            dispatch_model,
+            device_ids=[local_rank],
+            broadcast_buffers=False,
+        )
+        if distributed
+        else dispatch_model
+    )
+    router_model: nn.Module = (
+        DDP(router_base_model, device_ids=[local_rank], broadcast_buffers=False)
+        if distributed
+        else router_base_model
+    )
+    base_model.set_transformer_router(router_model)
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    # Delta vs baseline parameter routing:
+    # - Bigram embeddings join the token optimizer
+    # - Smear/bigram scales join the scalar optimizer
+    # - MTP heads join the matrix optimizer when enabled
+    # - AdamW/Muon weight decay is explicit instead of relying on pure Adam/Muon
+    block_named_params = list(base_model.blocks.named_parameters()) + [
+        (f"shared_mlp.{name}", param)
+        for name, param in base_model.shared_mlp.named_parameters()
+    ]
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2
+        and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.mtp_num_heads > 0:
+        matrix_params.extend(
+            [p for p in base_model.mtp_heads.parameters() if p.ndim == 2]
+        )
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2
+        or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [
+        {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+    ]
+    if base_model.bigram is not None:
+        tok_params.append(
+            {
+                "params": [base_model.bigram.embed.weight],
+                "lr": token_lr,
+                "base_lr": token_lr,
+            }
+        )
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.embed_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+        row_normalize=args.muon_row_normalize,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_router = torch.optim.AdamW(
+        [
+            {
+                "params": router_base_model.parameters(),
+                "lr": args.router_lr,
+                "base_lr": args.router_lr,
+            }
+        ],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.router_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [
+        optimizer_tok,
+        optimizer_muon,
+        optimizer_scalar,
+    ]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [
+                {
+                    "params": [base_model.lm_head.weight],
+                    "lr": args.head_lr,
+                    "base_lr": args.head_lr,
+                }
+            ],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    all_optimizers: list[torch.optim.Optimizer] = [*optimizers, optimizer_router]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    router_params = sum(p.numel() for p in router_base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"router_params:{router_params}")
+    log0(
+        f"unique_blocks:{len(base_model.blocks)} recurrent_steps:{base_model.num_recurrent_steps}"
+    )
+    log0(
+        f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}"
+    )
+    xsa_steps = base_model.xsa_step_indices()
+    log0(f"XSA:last_{args.xsa_last_n} active_steps:{xsa_steps}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(
+        f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}"
+    )
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"warmdown_frac:{args.warmdown_frac:.2f} min_lr:{args.min_lr:.4f} "
+        f"val_loss_every:{args.val_loss_every} "
+        f"num_recurrent_steps:{args.num_recurrent_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"router_actions:{args.num_layers + 1} "
+        f"eval_recurrent_steps:{args.num_recurrent_steps}"
+    )
+    log0(
+        f"router_input_dim:{3 * args.model_dim} "
+        f"router_hidden_dim:{args.router_hidden_dim} "
+        f"mlp_router_hidden_dim:{args.mlp_router_hidden_dim} "
+        f"mlp_num_experts:{args.mlp_num_experts} "
+        f"mlp_expert_top_k:{args.mlp_expert_top_k} "
+        f"mlp_expert_mult:{args.mlp_expert_mult} "
+        f"router_lr:{args.router_lr} router_wd:{args.router_wd} "
+        f"router_entropy_bonus_start:{args.router_entropy_bonus_start} "
+        f"router_entropy_bonus_end:{args.router_entropy_bonus_end} "
+        f"router_step_penalty:{args.router_step_penalty} "
+        f"compiled_routed_experts:{int(args.compiled_routed_experts)} "
+        f"activation_checkpointing:{int(args.activation_checkpointing)} "
+        f"ema_decay:{args.ema_decay} "
+        f"muon_momentum_warmup_steps:{args.muon_momentum_warmup_steps}"
+    )
+    log0(
+        f"muon_row_normalize:{int(args.muon_row_normalize)} "
+        f"muon_wd:{args.muon_wd} adam_wd:{args.adam_wd} embed_wd:{args.embed_wd}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+    router_model.train()
+    optimizer_router.zero_grad(set_to_none=True)
+
+    def zero_grad_all() -> None:
+        for opt in all_optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = (
+        1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is None:
+            return step / max(args.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-9)
+
+    def lr_mul(progress: float) -> float:
+        if args.warmdown_frac <= 0.0:
+            return 1.0
+        if progress >= 1.0 - args.warmdown_frac:
+            return max((1.0 - progress) / args.warmdown_frac, args.min_lr)
+        return 1.0
+
+    def router_entropy_bonus_value(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is not None and max_wallclock_ms > 0.0:
+            progress = min(max(elapsed_ms / max_wallclock_ms, 0.0), 1.0)
+        elif args.iterations > 1:
+            progress = min(max(step / (args.iterations - 1), 0.0), 1.0)
+        else:
+            progress = 1.0
+        return (
+            1.0 - progress
+        ) * args.router_entropy_bonus_start + progress * args.router_entropy_bonus_end
+
+    # Warmup exercises the actual router-controlled training path and optimizer
+    # kernels, then we restore the initial weights/optimizer state so measured
+    # training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_router_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in router_base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in all_optimizers
+        ]
+        model.train()
+        router_model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                    router_model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(
+                    args.train_batch_tokens, grad_accum_steps
+                )
+                with torch.autocast(
+                    device_type="cuda", dtype=torch.bfloat16, enabled=True
+                ):
+                    warmup_loss = model(x, y, router_active=True)
+                (warmup_loss * grad_scale).backward()
+            for opt in all_optimizers:
+                opt.step()
+            zero_grad_all()
+            if (
+                args.warmup_steps <= 20
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == args.warmup_steps
+            ):
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        router_base_model.load_state_dict(initial_router_state, strict=True)
+        for opt, state in zip(all_optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+            router_model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+        optimizer_router.zero_grad(set_to_none=True)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    ema_model_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in base_model.state_dict().items()
+    }
+    ema_router_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in router_base_model.state_dict().items()
+    }
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    probe_window_size = max(args.recurrence_probe_every, 1)
+    recent_depth_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_depth_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_objective_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_entropy_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_router_action_counts: deque[Tensor] = deque(maxlen=probe_window_size)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+
+        should_validate = last_step or (
+            args.val_loss_every > 0 and step % args.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                router_active=True,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        progress = training_frac(step, elapsed_ms)
+        scale = lr_mul(progress)
+        base_model.router_entropy_bonus = router_entropy_bonus_value(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        router_loss = torch.zeros((), device=device)
+        router_entropy = torch.zeros((), device=device)
+        step_depth_sum = 0.0
+        step_depth_count = 0
+        step_action_counts = torch.zeros(
+            args.num_recurrent_steps,
+            args.num_layers + 1,
+            device=device,
+            dtype=torch.float32,
+        )
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                router_model.require_backward_grad_sync = (
+                    micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(args.train_batch_tokens, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, router_active=True)
+            step_depth_sum += float(base_model.last_actual_recurrent_steps)
+            step_depth_count += 1
+            step_action_counts += base_model.last_forward_action_counts.to(
+                device=device, dtype=step_action_counts.dtype
+            )
+            train_loss += float(base_model.last_main_loss)
+            router_loss += float(base_model.last_router_loss)
+            router_entropy += float(base_model.last_router_entropy)
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        router_loss /= grad_accum_steps
+        router_entropy /= grad_accum_steps
+
+        frac = (
+            min(step / args.muon_momentum_warmup_steps, 1.0)
+            if args.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        for group in optimizer_router.param_groups:
+            group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(
+                router_base_model.parameters(), args.grad_clip_norm
+            )
+        for opt in all_optimizers:
+            opt.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, tensor in base_model.state_dict().items():
+                ema_model_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+            for name, tensor in router_base_model.state_dict().items():
+                ema_router_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+
+        local_step_depth_sum = float(step_depth_sum)
+        local_step_depth_count = float(step_depth_count)
+        local_router_objective_sum = float(router_loss.item()) * grad_accum_steps
+        local_router_objective_count = float(grad_accum_steps)
+        local_router_entropy_sum = float(router_entropy.item()) * grad_accum_steps
+        local_router_entropy_count = float(grad_accum_steps)
+        recent_depth_sums.append(local_step_depth_sum)
+        recent_depth_counts.append(local_step_depth_count)
+        recent_router_objective_sums.append(local_router_objective_sum)
+        recent_router_objective_counts.append(local_router_objective_count)
+        recent_router_entropy_sums.append(local_router_entropy_sum)
+        recent_router_entropy_counts.append(local_router_entropy_count)
+        recent_router_action_counts.append(step_action_counts.detach().cpu())
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        should_probe_recurrence = (
+            args.recurrence_probe_every > 0 and step % args.recurrence_probe_every == 0
+        )
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10
+            or step % args.train_log_every == 0
+            or stop_after_step is not None
+        )
+        step_avg_depth = local_step_depth_sum / max(local_step_depth_count, 1.0)
+        step_avg_router_objective = (
+            local_router_objective_sum / local_router_objective_count
+            if local_router_objective_count > 0
+            else None
+        )
+        step_avg_router_entropy = (
+            local_router_entropy_sum / local_router_entropy_count
+            if local_router_entropy_count > 0
+            else None
+        )
+        if distributed and (should_probe_recurrence or should_log_train):
+            step_stats = torch.tensor(
+                [
+                    local_step_depth_sum,
+                    local_step_depth_count,
+                    local_router_objective_sum,
+                    local_router_objective_count,
+                    local_router_entropy_sum,
+                    local_router_entropy_count,
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_avg_depth = float(
+                (step_stats[0] / step_stats[1].clamp_min(1.0)).item()
+            )
+            step_avg_router_objective = (
+                float((step_stats[2] / step_stats[3]).item())
+                if step_stats[3].item() > 0
+                else None
+            )
+            step_avg_router_entropy = (
+                float((step_stats[4] / step_stats[5]).item())
+                if step_stats[5].item() > 0
+                else None
+            )
+        if should_probe_recurrence:
+            window_stats = torch.tensor(
+                [
+                    sum(recent_depth_sums),
+                    sum(recent_depth_counts),
+                    sum(recent_router_objective_sums),
+                    sum(recent_router_objective_counts),
+                    sum(recent_router_entropy_sums),
+                    sum(recent_router_entropy_counts),
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            window_action_counts: Tensor | None = (
+                torch.stack(list(recent_router_action_counts), dim=0)
+                .sum(dim=0)
+                .to(device=device, dtype=torch.float64)
+                if recent_router_action_counts
+                else None
+            )
+            if distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+                if window_action_counts is not None:
+                    dist.all_reduce(window_action_counts, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+            window_action_counts = None
+        if should_probe_recurrence and (not distributed or rank == 0):
+            log0(
+                format_router_probe_summary(
+                    step,
+                    args.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                    float(window_stats[4].item()),
+                    float(window_stats[5].item()),
+                )
+            )
+            log0(
+                format_router_action_matrix(
+                    step,
+                    args.iterations,
+                    None
+                    if window_action_counts is None
+                    else window_action_counts.cpu(),
+                    args.num_layers,
+                )
+            )
+
+        if should_log_train:
+            router_log = (
+                f" router_objective:{step_avg_router_objective:.4f}"
+                f" router_entropy:{step_avg_router_entropy:.4f}"
+                f" router_entropy_bonus:{base_model.router_entropy_bonus:.4f}"
+            )
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+                f" router_forward:1"
+                f"{router_log}"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    log0("ema:applying EMA weights")
+    base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=base_model.state_dict()[name].dtype)
+            for name, tensor in ema_model_state.items()
+        },
+        strict=True,
+    )
+    router_base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=router_base_model.state_dict()[name].dtype)
+            for name, tensor in ema_router_state.items()
+        },
+        strict=True,
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Delta vs baseline export: MTP helps training but is not part of the final
+    # artifact, so those heads are dropped before serialization.
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    router_export_sd = router_base_model.state_dict()
+    excluded_mtp = sum(
+        int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k
+    )
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+
+    if master_process:
+        torch.save({"model": export_sd, "router": router_export_sd}, "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    router_sd_cpu = {k: v.detach().cpu() for k, v in router_export_sd.items()}
+    # Baseline writes int8+zlib. This record uses mixed int6/int8 and prefers
+    # zstd-22 when available to squeeze under the 16 MB artifact limit.
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+    router_quant_result, router_quant_meta = mixed_quantize_int6(router_sd_cpu, set())
+    quant_buf = io.BytesIO()
+    torch.save(
+        {
+            "w": quant_result,
+            "m": quant_meta,
+            "rw": router_quant_result,
+            "rm": router_quant_meta,
+        },
+        quant_buf,
+    )
+    quant_raw = quant_buf.getvalue()
+    quant_blob = (
+        zstandard.ZstdCompressor(level=22).compress(quant_raw)
+        if _COMPRESSOR == "zstd"
+        else zlib.compress(quant_raw, 9)
+    )
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(
+            f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes"
+        )
+
+    # Roundtrip: rebuild a fresh eval model from the compressed artifact so the
+    # reported score matches the thing that would actually be submitted.
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(
+            zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+            if _COMPRESSOR == "zstd"
+            else zlib.decompress(quant_blob_disk)
+        ),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    deq_router_state = dequantize_mixed_int6(
+        quant_state["rw"], quant_state["rm"], router_sd_cpu
+    )
+
+    eval_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_router_hidden_dim=args.mlp_router_hidden_dim,
+            mlp_num_experts=args.mlp_num_experts,
+            mlp_expert_top_k=args.mlp_expert_top_k,
+            mlp_expert_mult=args.mlp_expert_mult,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            router_entropy_bonus=args.router_entropy_bonus_end,
+            router_step_penalty=args.router_step_penalty,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=0,
+            mtp_loss_weight=0.0,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,  # must match training model
+        )
+        .to(device)
+        .bfloat16()
+    )
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_router_model = TransformerRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.router_hidden_dim,
+        num_actions=args.num_layers + 1,
+    ).to(device)
+    eval_model.set_transformer_router(eval_router_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    eval_router_model.load_state_dict(deq_router_state, strict=True)
+    eval_router_model.eval()
+
+    # Standard non-overlapping eval (sanity check)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+        router_active=True,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    # Sliding-window eval is the record's headline submission metric.
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}"
+        )
+
+    # Second sliding window eval at stride=64 for submission comparison
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window_s64",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}"
+        )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_3.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_3.py
@@ -1,0 +1,3091 @@
+"""
+ART-3
+
+A single recurrent transformer block is reused for a fixed number of steps.
+Within that block, attention heads are sparsely selected by a sequence-level
+attention router, while a token-level MLP router selects top-k experts from a
+mixture-of-experts feedforward module.
+"""
+
+from __future__ import annotations
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from collections import deque
+from pathlib import Path
+
+# Delta vs `train_gpt.py`: prefer zstd for the final artifact when
+# the package is available, but keep a zlib fallback so the script still runs in
+# lighter local environments.
+try:
+    import zstandard
+
+    _COMPRESSOR = "zstd"
+except ImportError:
+    _COMPRESSOR = "zlib"
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+
+# Delta vs baseline attention: call FlashAttention 3 directly instead of
+# `torch.scaled_dot_product_attention(...)`.
+from flash_attn_interface import flash_attn_func as flash_attn_3_func
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+from torch.utils.checkpoint import checkpoint
+
+
+class Hyperparameters:
+    # Highest-impact run budget, data, and schedule knobs.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    tokenizer_path = os.environ.get(
+        "TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model"
+    )
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+
+    # Router-specific knobs. ART-3 uses two routers in parallel: one for
+    # sequence-level attention head selection and one for token-level expert
+    # selection.
+    attention_router_hidden_dim = int(
+        os.environ.get("ATTENTION_ROUTER_HIDDEN_DIM", 128)
+    )
+    attention_router_lr = float(os.environ.get("ATTENTION_ROUTER_LR", 0.001))
+    attention_router_wd = float(os.environ.get("ATTENTION_ROUTER_WD", 0.01))
+    attention_router_entropy_bonus_start = float(
+        os.environ.get("ATTENTION_ROUTER_ENTROPY_BONUS_START", 0.02)
+    )
+    attention_router_entropy_bonus_end = float(
+        os.environ.get("ATTENTION_ROUTER_ENTROPY_BONUS_END", 0.002)
+    )
+    attention_router_js_bonus = float(os.environ.get("ATTENTION_ROUTER_JS_BONUS", 0.5))
+    attention_head_top_k = int(os.environ.get("ATTENTION_HEAD_TOP_K", 16))
+    mlp_router_hidden_dim = int(os.environ.get("MLP_ROUTER_HIDDEN_DIM", 128))
+    mlp_router_lr = float(os.environ.get("MLP_ROUTER_LR", 0.001))
+    mlp_router_wd = float(os.environ.get("MLP_ROUTER_WD", 0.01))
+    mlp_router_entropy_bonus_start = float(
+        os.environ.get("MLP_ROUTER_ENTROPY_BONUS_START", 0.02)
+    )
+    mlp_router_entropy_bonus_end = float(
+        os.environ.get("MLP_ROUTER_ENTROPY_BONUS_END", 0.002)
+    )
+    mlp_router_js_bonus = float(os.environ.get("MLP_ROUTER_JS_BONUS", 0.02))
+    mlp_num_experts = int(os.environ.get("MLP_NUM_EXPERTS", 12))
+    mlp_expert_top_k = int(os.environ.get("MLP_EXPERT_TOP_K", 2))
+    mlp_expert_mult = float(os.environ.get("MLP_EXPERT_MULT", 2))
+
+    # Model shape. ART-3 has one physical recurrent block.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 1))
+    num_recurrent_steps = int(os.environ.get("NUM_RECURRENT_STEPS", 8))
+    model_dim = int(os.environ.get("MODEL_DIM", 1024))
+    num_heads = int(os.environ.get("NUM_HEADS", 32))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 32))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+
+    # Optimizer and regularization defaults adapted from the record run where
+    # they transfer cleanly to ART.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+
+    # Eval/export/runtime controls.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    activation_checkpointing = bool(
+        int(os.environ.get("ACTIVATION_CHECKPOINTING", "0"))
+    )
+    qat_enabled = bool(int(os.environ.get("QAT_ENABLED", "0")))
+
+    # Auxiliary training features retained from ART.
+    mtp_num_heads = int(os.environ.get("MTP_NUM_HEADS", 0))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", 0.2))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    bigram_vocab_size = int(os.environ.get("BIGRAM_VOCAB_SIZE", 4096))
+    bigram_dim = int(os.environ.get("BIGRAM_DIM", 128))
+
+    # Optional carry-over from the source experiment: apply XSA only on the last
+    # N recurrent steps.
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 0))  # 0 disables XSA entirely
+
+
+# -----------------------------
+# MUON OPTIMIZER
+# -----------------------------
+#
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+
+def zeropower_via_newtonschulz5(
+    G: Tensor, steps: int = 10, eps: float = 1e-7
+) -> Tensor:
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        weight_decay: float = 0.0,
+        row_normalize: bool = False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = g.float().norm(dim=-1, keepdim=True).clamp_min(1e-7)
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            # Delta vs baseline Muon: this version adds decoupled weight decay so
+            # matrix params can use MuonWD without moving them onto Adam.
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    eval_seq_len: int | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    # Delta vs baseline eval: training and evaluation sequence lengths can
+    # differ, because this stack trains at long context and also uses
+    # sliding-window evaluation later in the script.
+    seq_len = eval_seq_len or args.train_seq_len
+    local_batch_tokens = args.val_batch_size // (world_size * grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"GRAD_ACCUM_STEPS={grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_tokens.numel() - 1) // seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y, router_active=router_active).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+# Delta vs baseline export: extra control tensors from SmearGate/Bigram/XSA stay
+# out of the aggressive quantization path.
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,smear",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+
+def keep_float_tensor(
+    name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]
+) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(
+            torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None]
+        )
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = (
+            torch.clamp(torch.round(clipped / scale[:, None]), -127, 127)
+            .to(torch.int8)
+            .contiguous()
+        )
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = (
+        float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item())
+        if t32.numel()
+        else 0.0
+    )
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = (
+        torch.clamp(
+            torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127
+        )
+        .to(torch.int8)
+        .contiguous()
+    )
+    return q, scale
+
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        (
+            "param_count",
+            "num_tensors",
+            "num_float_tensors",
+            "num_nonfloat_tensors",
+            "baseline_tensor_bytes",
+            "int8_payload_bytes",
+        ),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (
+                (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1))))
+                .to(dtype=dtype)
+                .contiguous()
+            )
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING
+# -----------------------------
+
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE: dict[str, int] = {}
+_MMAP_CACHE: dict[str, np.memmap] = {}
+
+
+def _read_num_tokens(file: Path) -> int:
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = num_tokens
+    return num_tokens
+
+
+def _get_shard_memmap(file: Path) -> np.memmap:
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    mm = np.memmap(
+        file,
+        mode="r",
+        dtype="<u2",
+        offset=_SHARD_HEADER_BYTES,
+        shape=(_read_num_tokens(file),),
+    )
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+class ShuffledSequenceLoader:
+    # Record-style shard-local randomized sequence sampling keeps each rank on a
+    # disjoint shard subset and avoids materializing global batches on every rank.
+    def __init__(
+        self, args: Hyperparameters, rank: int, world_size: int, device: torch.device
+    ):
+        self.rank = rank
+        self.world_size = world_size
+        self.seq_len = args.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(args.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {args.train_files}")
+        self.files = all_files[rank::world_size]
+        if not self.files:
+            raise ValueError(
+                f"No training shards assigned to rank {rank} out of {world_size}"
+            )
+        self.rng = np.random.Generator(np.random.PCG64(args.seed + rank))
+        self.num_tokens = [_read_num_tokens(file) for file in self.files]
+        self.start_inds: list[list[int]] = [[] for _ in self.files]
+        for shard_idx in range(len(self.files)):
+            self._reset_shard(shard_idx)
+
+    def _reset_shard(self, shard_idx: int) -> None:
+        max_phase = min(
+            self.seq_len - 1,
+            max(0, self.num_tokens[shard_idx] - self.seq_len - 1),
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[shard_idx] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[shard_idx] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(
+        self, global_tokens: int, grad_accum_steps: int
+    ) -> tuple[Tensor, Tensor]:
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array(
+            [len(starts) for starts in self.start_inds], dtype=np.float64
+        )
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for batch_idx in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for shard_idx in range(len(self.files)):
+                    self._reset_shard(shard_idx)
+                remaining = np.array(
+                    [len(starts) for starts in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            shard_idx = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[shard_idx].pop()
+            remaining[shard_idx] -= 1
+            mm = _get_shard_memmap(self.files[shard_idx])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[batch_idx] = window[:-1]
+            y[batch_idx] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+# -----------------------------
+# TRANSFORMER MODULES
+# -----------------------------
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps: float | None = None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x: Tensor) -> Tensor:
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    _qat_enabled: bool = False
+
+    def forward(self, x: Tensor) -> Tensor:
+        w = self.weight.to(x.dtype)
+        # Delta vs baseline linear layers: optional straight-through fake quant
+        # lets later experiments turn on lightweight QAT without changing module
+        # call sites or adding parallel weight copies.
+        if CastedLinear._qat_enabled and self.training and w.ndim == 2:
+            with torch.no_grad():
+                w32 = self.weight.float()
+                row_max = w32.abs().amax(dim=1)
+                scale = (row_max / 31.0).clamp_min(1.0 / 31.0)
+                w_q = (
+                    torch.clamp(torch.round(w32 / scale[:, None]), -32, 31)
+                    * scale[:, None]
+                ).to(x.dtype)
+            w = w + (w_q - w).detach()
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+def restore_low_dim_params_to_fp32(module: nn.Module) -> None:
+    # Keep small/control parameters in fp32 even when the model body runs in bf16.
+    with torch.no_grad():
+        for name, param in module.named_parameters():
+            if (
+                param.ndim < 2
+                or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+            ) and param.dtype != torch.float32:
+                param.data = param.data.float()
+
+
+class Rotary(nn.Module):
+    # NTK-aware RoPE: auto-scales base frequency when seq_len exceeds train_seq_len.
+    def __init__(self, dim: int, base: float = 10000.0, train_seq_len: int = 1024):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached: Tensor | None = None
+        self._sin_cached: Tensor | None = None
+
+    def forward(
+        self, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> tuple[Tensor, Tensor]:
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * (scale ** (self.dim / (self.dim - 2)))
+                inv_freq = 1.0 / (
+                    new_base
+                    ** (
+                        torch.arange(0, self.dim, 2, dtype=torch.float32, device=device)
+                        / self.dim
+                    )
+                )
+            else:
+                inv_freq = self.inv_freq.to(device)
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)
+
+
+# Delta vs `train_gpt.py`:
+# - head layout matches FlashAttention 3 directly, so there are no transpose
+#   calls around the kernel invocation
+# - late recurrent steps can opt into XSA after the main attention kernel runs
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads != num_kv_heads:
+            raise ValueError(
+                "ART-3 currently requires NUM_KV_HEADS == NUM_HEADS so the "
+                "attention router can select individual heads directly"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, dim, bias=False)
+        self.c_v = CastedLinear(dim, dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=1024)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y: Tensor, v: Tensor) -> Tensor:
+        vn = F.normalize(v, dim=-1)
+        return y - (y * vn).sum(dim=-1, keepdim=True) * vn
+
+    def forward(
+        self,
+        x: Tensor,
+        selected_head_indices: Tensor,
+        selected_head_weights: Tensor,
+        use_xsa: bool | None = None,
+    ) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin)
+        k = apply_rotary_emb(k, cos, sin)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        apply_xsa = self.use_xsa if use_xsa is None else use_xsa
+
+        selected_head_indices = selected_head_indices.to(
+            device=x.device, dtype=torch.long
+        )
+        selected_head_weights = selected_head_weights.to(device=x.device, dtype=q.dtype)
+        gather_index = selected_head_indices[:, None, :, None].expand(
+            bsz, seqlen, selected_head_indices.size(1), self.head_dim
+        )
+        q_sel = q.gather(dim=2, index=gather_index)
+        k_sel = k.gather(dim=2, index=gather_index)
+        v_sel = v.gather(dim=2, index=gather_index)
+        y_sel = flash_attn_3_func(q_sel, k_sel, v_sel, causal=True)
+        if apply_xsa:
+            y_sel = self._xsa_efficient(y_sel, v_sel)
+        y_sel = y_sel * selected_head_weights[:, None, :, None]
+
+        # `topk` guarantees unique head ids per sequence, so a plain scatter is
+        # sufficient here. Avoiding `scatter_add_` sidesteps a more fragile CUDA
+        # reduction kernel on multi-GPU runs.
+        y_full = torch.zeros_like(q).permute(0, 2, 1, 3).contiguous()
+        scatter_index = selected_head_indices[:, :, None, None].expand(
+            bsz, selected_head_indices.size(1), seqlen, self.head_dim
+        )
+        y_full.scatter_(dim=1, index=scatter_index, src=y_sel.permute(0, 2, 1, 3))
+        y_full = y_full.permute(0, 2, 1, 3).contiguous()
+
+        y = y_full.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+# Delta vs baseline input path: before the block stack, embeddings get a
+# one-token temporal blend (`SmearGate`) plus a cheap hashed-bigram residual.
+class SmearGate(nn.Module):
+    def __init__(self, dim: int):
+        super().__init__()
+        self.gate = nn.Parameter(torch.zeros(dim, dtype=torch.float32))
+
+    def forward(self, x: Tensor) -> Tensor:
+        g = torch.sigmoid(self.gate.to(dtype=x.dtype))[None, None, :]
+        x_prev = torch.cat([torch.zeros_like(x[:, :1]), x[:, :-1]], dim=1)
+        return (1 - g) * x + g * x_prev
+
+
+class BigramHashEmbedding(nn.Module):
+    def __init__(self, bigram_vocab_size: int, bigram_dim: int, model_dim: int):
+        super().__init__()
+        self.bigram_vocab_size = bigram_vocab_size
+        self.embed = nn.Embedding(bigram_vocab_size, bigram_dim)
+        nn.init.zeros_(self.embed.weight)
+        self.proj = (
+            CastedLinear(bigram_dim, model_dim, bias=False)
+            if bigram_dim != model_dim
+            else None
+        )
+        if self.proj is not None:
+            nn.init.zeros_(self.proj.weight)
+        self.scale = nn.Parameter(torch.tensor(0.05, dtype=torch.float32))
+
+    def bigram_hash(self, tokens: Tensor) -> Tensor:
+        t = tokens.to(torch.int32)
+        mod = self.bigram_vocab_size - 1
+        out = torch.empty_like(t)
+        out[..., 0] = mod
+        out[..., 1:] = torch.bitwise_xor(36313 * t[..., 1:], 27191 * t[..., :-1]) % mod
+        return out.long()
+
+    def forward(self, token_ids: Tensor) -> Tensor:
+        h = self.embed(self.bigram_hash(token_ids))
+        if self.proj is not None:
+            h = self.proj(h)
+        return h * self.scale.to(dtype=h.dtype)
+
+
+class FourierStepEmbedding(nn.Module):
+    """Deterministic sinusoidal embedding for recurrent UT steps."""
+
+    def __init__(self, num_steps: int, dim: int):
+        super().__init__()
+        half = dim // 2
+        steps = torch.arange(num_steps, dtype=torch.float32).unsqueeze(1)
+        freqs = 1.0 / (10000.0 ** (2.0 * torch.arange(half, dtype=torch.float32) / dim))
+        angles = steps * freqs.unsqueeze(0)
+        table = torch.zeros(num_steps, dim, dtype=torch.float32)
+        table[:, 0 : 2 * half : 2] = torch.sin(angles)
+        table[:, 1 : 2 * half : 2] = torch.cos(angles)
+        self.register_buffer("table", table, persistent=False)
+
+    def forward(self, step_idx: int) -> Tensor:
+        return self.table[step_idx]
+
+
+class MoEExpert(nn.Module):
+    def __init__(self, dim: int, hidden: int):
+        super().__init__()
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x: Tensor) -> Tensor:
+        x = torch.relu(self.fc(x))
+        return self.proj(x.square())
+
+
+class AttentionHeadRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, num_heads: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_heads)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, router_inputs: Tensor) -> Tensor:
+        x = F.gelu(self.fc(router_inputs.float()))
+        return self.proj(x)
+
+
+class TokenExpertRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int, num_experts: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, num_experts)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, token_states: Tensor) -> Tensor:
+        x = F.gelu(self.fc(token_states.float()))
+        return self.proj(x)
+
+
+class MixtureOfExpertsMLP(nn.Module):
+    def __init__(self, dim: int, num_experts: int, expert_mult: float):
+        super().__init__()
+        hidden = max(1, int(dim * expert_mult))
+        self.num_experts = num_experts
+        self.experts = nn.ModuleList(
+            [MoEExpert(dim, hidden) for _ in range(num_experts)]
+        )
+
+    def forward(
+        self,
+        x: Tensor,
+        selected_expert_indices: Tensor,
+        selected_expert_weights: Tensor,
+    ) -> Tensor:
+        bsz, seqlen, dim = x.shape
+        flat_x = x.reshape(-1, dim)
+        top_k = selected_expert_indices.size(-1)
+        flat_indices = selected_expert_indices.reshape(-1)
+        flat_weights = selected_expert_weights.reshape(-1).to(dtype=x.dtype)
+        output = torch.zeros_like(flat_x)
+
+        # Dispatch once: sort all token/expert assignments by expert id, gather the
+        # corresponding token states once, then let each expert process a contiguous
+        # slice. This avoids rescanning the full assignment tensor for every expert.
+        token_indices = (
+            torch.arange(flat_x.size(0), device=x.device, dtype=torch.long)
+            .unsqueeze(1)
+            .expand(-1, top_k)
+            .reshape(-1)
+        )
+        sort_perm = flat_indices.argsort(stable=True)
+        sorted_experts = flat_indices.index_select(0, sort_perm)
+        sorted_token_indices = token_indices.index_select(0, sort_perm)
+        sorted_weights = flat_weights.index_select(0, sort_perm)
+        expert_counts = torch.bincount(sorted_experts, minlength=self.num_experts)
+
+        offset = 0
+        for expert_idx, expert in enumerate(self.experts):
+            count = int(expert_counts[expert_idx].item())
+            if count == 0:
+                continue
+            next_offset = offset + count
+            expert_token_indices = sorted_token_indices[offset:next_offset]
+            expert_out = expert(flat_x.index_select(0, expert_token_indices))
+            output[expert_token_indices] = output[expert_token_indices] + (
+                expert_out * sorted_weights[offset:next_offset].unsqueeze(-1)
+            )
+            offset = next_offset
+        return output.reshape(bsz, seqlen, dim)
+
+
+class AdaptiveRecurrentBlock(nn.Module):
+    def __init__(
+        self,
+        dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        num_experts: int,
+        expert_mult: float,
+        rope_base: float,
+        qk_gain_init: float,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init
+        )
+        self.mlp = MixtureOfExpertsMLP(dim, num_experts, expert_mult)
+
+
+class GPT(nn.Module):
+    def __init__(
+        self,
+        vocab_size: int,
+        num_layers: int,
+        model_dim: int,
+        num_heads: int,
+        num_kv_heads: int,
+        mlp_num_experts: int,
+        mlp_expert_mult: float,
+        attention_head_top_k: int,
+        mlp_expert_top_k: int,
+        tie_embeddings: bool,
+        tied_embed_init_std: float,
+        logit_softcap: float,
+        rope_base: float,
+        qk_gain_init: float,
+        num_recurrent_steps: int = 8,
+        attention_router_entropy_bonus: float = 0.01,
+        attention_router_js_bonus: float = 0.0,
+        mlp_router_entropy_bonus: float = 0.01,
+        mlp_router_js_bonus: float = 0.0,
+        activation_checkpointing: bool = True,
+        mtp_num_heads: int = 0,
+        mtp_loss_weight: float = 0.1,
+        bigram_vocab_size: int = 0,
+        bigram_dim: int = 128,
+        xsa_last_n: int = 0,
+    ):
+        super().__init__()
+        if logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")
+        if num_layers != 1:
+            raise ValueError(f"ART-3 expects NUM_LAYERS=1, got {num_layers}")
+        if num_recurrent_steps <= 0:
+            raise ValueError(
+                f"NUM_RECURRENT_STEPS must be positive, got {num_recurrent_steps}"
+            )
+        if attention_head_top_k <= 0 or attention_head_top_k > num_heads:
+            raise ValueError(
+                f"ATTENTION_HEAD_TOP_K must be in [1, {num_heads}], got {attention_head_top_k}"
+            )
+        if mlp_expert_top_k <= 0 or mlp_expert_top_k > mlp_num_experts:
+            raise ValueError(
+                f"MLP_EXPERT_TOP_K must be in [1, {mlp_num_experts}], got {mlp_expert_top_k}"
+            )
+        self.tie_embeddings = tie_embeddings
+        self.tied_embed_init_std = tied_embed_init_std
+        self.logit_softcap = logit_softcap
+        self.num_recurrent_steps = num_recurrent_steps
+        self.num_heads = num_heads
+        self.mlp_num_experts = mlp_num_experts
+        self.attention_head_top_k = attention_head_top_k
+        self.mlp_expert_top_k = mlp_expert_top_k
+        self.attention_router_entropy_bonus = attention_router_entropy_bonus
+        self.attention_router_js_bonus = attention_router_js_bonus
+        self.mlp_router_entropy_bonus = mlp_router_entropy_bonus
+        self.mlp_router_js_bonus = mlp_router_js_bonus
+        self.activation_checkpointing = activation_checkpointing
+        self.xsa_last_n = xsa_last_n
+        self.mtp_num_heads = mtp_num_heads
+        self.mtp_loss_weight = mtp_loss_weight
+        self.last_actual_recurrent_steps = 0.0
+        self.last_main_loss = 0.0
+        self.last_attention_router_aux_loss = 0.0
+        self.last_attention_router_entropy = 0.0
+        self.last_attention_router_js = 0.0
+        self.last_mlp_router_aux_loss = 0.0
+        self.last_mlp_router_entropy = 0.0
+        self.last_mlp_router_js = 0.0
+        self.last_forward_head_counts = torch.zeros(
+            self.num_recurrent_steps, self.num_heads, dtype=torch.float32
+        )
+        self.last_forward_expert_counts = torch.zeros(
+            self.num_recurrent_steps, self.mlp_num_experts, dtype=torch.float32
+        )
+        object.__setattr__(self, "_attention_router", None)
+        object.__setattr__(self, "_mlp_router", None)
+        self._last_attention_router_entropies: Tensor | None = None
+        self._last_mlp_router_entropies: Tensor | None = None
+        self._last_attention_router_js: Tensor | None = None
+        self._last_mlp_router_js: Tensor | None = None
+        self.tok_emb = nn.Embedding(vocab_size, model_dim)
+        self.bigram = (
+            BigramHashEmbedding(bigram_vocab_size, bigram_dim, model_dim)
+            if bigram_vocab_size > 0
+            else None
+        )
+        self.smear = SmearGate(model_dim)
+        self.step_embedding = FourierStepEmbedding(num_recurrent_steps, model_dim)
+        self.block = AdaptiveRecurrentBlock(
+            model_dim,
+            num_heads,
+            num_kv_heads,
+            mlp_num_experts,
+            mlp_expert_mult,
+            rope_base,
+            qk_gain_init,
+        )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        self.mtp_heads = nn.ModuleList(
+            [
+                CastedLinear(model_dim, vocab_size, bias=False)
+                for _ in range(mtp_num_heads)
+            ]
+        )
+        for head in self.mtp_heads:
+            head._zero_init = True
+        self._init_weights()
+
+    def xsa_step_indices(self, num_recurrent_steps: int | None = None) -> list[int]:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if self.xsa_last_n <= 0:
+            return []
+        start = max(0, steps - self.xsa_last_n)
+        return list(range(start, steps))
+
+    def _step_uses_xsa(
+        self, step_idx: int, num_recurrent_steps: int | None = None
+    ) -> bool:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        return self.xsa_last_n > 0 and step_idx >= steps - self.xsa_last_n
+
+    def set_routers(self, attention_router: nn.Module, mlp_router: nn.Module) -> None:
+        object.__setattr__(self, "_attention_router", attention_router)
+        object.__setattr__(self, "_mlp_router", mlp_router)
+
+    def _router_features(self, x: Tensor, step_idx: int) -> Tensor:
+        step_emb = self.step_embedding.table[step_idx].to(dtype=x.dtype)
+        step_batch = step_emb.unsqueeze(0).expand(x.size(0), -1)
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled, step_batch), dim=-1)
+
+    def _attention_router_logits(self, router_inputs: Tensor) -> Tensor:
+        router = self._attention_router
+        if router is None:
+            raise RuntimeError("Attention router must be set before router use")
+        return router(router_inputs)
+
+    def _mlp_router_logits(self, token_states: Tensor) -> Tensor:
+        router = self._mlp_router
+        if router is None:
+            raise RuntimeError("MLP router must be set before router use")
+        return router(token_states)
+
+    def _sample_topk_indices(
+        self, logits: Tensor, top_k: int, router_active: bool
+    ) -> Tensor:
+        if router_active and self.training and torch.is_grad_enabled():
+            uniform = torch.rand_like(logits).clamp_(1e-6, 1.0 - 1e-6)
+            gumbel = -torch.log(-torch.log(uniform))
+            selection_scores = logits + gumbel
+        else:
+            selection_scores = logits
+        return selection_scores.topk(top_k, dim=-1).indices
+
+    def _sequence_losses_from_hidden(self, x: Tensor, target_ids: Tensor) -> Tensor:
+        logits = self._logits_from_hidden(x)
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        return token_losses.mean(dim=1)
+
+    def _cross_step_js_divergence(self, step_probs: list[Tensor]) -> Tensor:
+        if len(step_probs) < 2:
+            if not step_probs:
+                return torch.zeros((), device=self.tok_emb.weight.device)
+            return step_probs[0].new_zeros(())
+        probs = torch.stack(step_probs, dim=1).clamp_min(1e-9)
+        num_steps = probs.size(1)
+        total = probs.new_zeros(())
+        pairs = 0
+        for left in range(num_steps):
+            p = probs[:, left, :]
+            log_p = torch.log(p)
+            for right in range(left + 1, num_steps):
+                q = probs[:, right, :]
+                log_q = torch.log(q)
+                mean = 0.5 * (p + q)
+                log_mean = torch.log(mean)
+                js = 0.5 * (
+                    (p * (log_p - log_mean)).sum(dim=-1)
+                    + (q * (log_q - log_mean)).sum(dim=-1)
+                )
+                total = total + js.mean()
+                pairs += 1
+        return total / max(pairs, 1)
+
+    def _select_attention_heads(
+        self, x: Tensor, step_idx: int, router_active: bool
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        if router_active:
+            attn_logits = self._attention_router_logits(
+                self._router_features(x, step_idx)
+            ).float()
+            attn_probs = torch.softmax(attn_logits, dim=-1)
+            topk_indices = self._sample_topk_indices(
+                attn_logits, self.attention_head_top_k, router_active
+            )
+            topk_vals = attn_logits.gather(dim=-1, index=topk_indices)
+            topk_weights = torch.softmax(topk_vals, dim=-1)
+        else:
+            attn_probs = torch.full(
+                (x.size(0), self.num_heads),
+                1.0 / self.num_heads,
+                device=x.device,
+                dtype=torch.float32,
+            )
+            topk_indices = (
+                torch.arange(self.num_heads, device=x.device, dtype=torch.long)
+                .unsqueeze(0)
+                .expand(x.size(0), -1)
+            )
+            topk_weights = attn_probs
+        return attn_probs, topk_indices, topk_weights.to(dtype=x.dtype)
+
+    def _select_mlp_experts(
+        self, token_states: Tensor, router_active: bool
+    ) -> tuple[Tensor, Tensor, Tensor]:
+        if router_active:
+            expert_logits = self._mlp_router_logits(token_states).float()
+            expert_probs = torch.softmax(expert_logits, dim=-1)
+            topk_indices = self._sample_topk_indices(
+                expert_logits, self.mlp_expert_top_k, router_active
+            )
+            topk_vals = expert_logits.gather(dim=-1, index=topk_indices)
+            topk_weights = torch.softmax(topk_vals, dim=-1)
+        else:
+            expert_probs = torch.full(
+                (*token_states.shape[:2], self.mlp_num_experts),
+                1.0 / self.mlp_num_experts,
+                device=token_states.device,
+                dtype=torch.float32,
+            )
+            topk_indices = (
+                torch.arange(
+                    self.mlp_num_experts, device=token_states.device, dtype=torch.long
+                )
+                .view(1, 1, -1)
+                .expand(token_states.size(0), token_states.size(1), -1)
+            )
+            topk_weights = expert_probs
+        return expert_probs, topk_indices, topk_weights.to(dtype=token_states.dtype)
+
+    def _apply_attention_substep(
+        self,
+        h: Tensor,
+        step_idx: int,
+        total_steps: int,
+        selected_head_indices: Tensor,
+        selected_head_weights: Tensor,
+    ) -> Tensor:
+        step_emb = self.step_embedding.table[step_idx].to(dtype=h.dtype)
+        x = h + step_emb[None, None, :]
+        use_xsa = self._step_uses_xsa(step_idx, total_steps)
+        return h + self.block.attn(
+            self.block.attn_norm(x),
+            selected_head_indices,
+            selected_head_weights,
+            use_xsa=use_xsa,
+        )
+
+    def _apply_mlp_substep(
+        self,
+        h: Tensor,
+        selected_expert_indices: Tensor,
+        selected_expert_weights: Tensor,
+    ) -> Tensor:
+        mlp_input = self.block.mlp_norm(h)
+        return h + self.block.mlp(
+            mlp_input, selected_expert_indices, selected_expert_weights
+        )
+
+    def _recurrent_forward(
+        self,
+        input_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = False,
+    ) -> Tensor:
+        steps = (
+            self.num_recurrent_steps
+            if num_recurrent_steps is None
+            else num_recurrent_steps
+        )
+        if steps <= 0 or steps > self.num_recurrent_steps:
+            raise ValueError(
+                f"num_recurrent_steps must be in [1, {self.num_recurrent_steps}], got {steps}"
+            )
+        x = self.tok_emb(input_ids)
+        if self.bigram is not None:
+            x = x + self.bigram(input_ids)
+        # RoPE inside attention still handles token-position encoding; the
+        # recurrent addition here is per-step conditioning for whichever block
+        # the route selects next.
+        x = F.rms_norm(x, (x.size(-1),))
+        x = self.smear(x)
+        batch_size = int(x.size(0))
+        attention_entropy_sums = torch.zeros(
+            batch_size, device=x.device, dtype=torch.float32
+        )
+        mlp_entropy_sums = torch.zeros(batch_size, device=x.device, dtype=torch.float32)
+        attention_step_probs: list[Tensor] = []
+        mlp_step_probs: list[Tensor] = []
+        head_counts = torch.zeros(
+            steps, self.num_heads, device=x.device, dtype=torch.float32
+        )
+        expert_counts = torch.zeros(
+            steps, self.mlp_num_experts, device=x.device, dtype=torch.float32
+        )
+        for step_idx in range(steps):
+            attention_probs, selected_head_indices, selected_head_weights = (
+                self._select_attention_heads(x, step_idx, router_active)
+            )
+            attention_entropy_sums += -(
+                attention_probs * torch.log(attention_probs.clamp_min(1e-9))
+            ).sum(dim=-1)
+            attention_step_probs.append(attention_probs)
+            head_counts[step_idx].scatter_add_(
+                0,
+                selected_head_indices.reshape(-1),
+                selected_head_weights.reshape(-1).to(dtype=head_counts.dtype),
+            )
+            if (
+                self.activation_checkpointing
+                and self.training
+                and torch.is_grad_enabled()
+            ):
+                h_attn = checkpoint(
+                    lambda hidden, head_idx, head_w: self._apply_attention_substep(
+                        hidden, step_idx, steps, head_idx, head_w
+                    ),
+                    x,
+                    selected_head_indices,
+                    selected_head_weights,
+                    use_reentrant=False,
+                    preserve_rng_state=False,
+                )
+            else:
+                h_attn = self._apply_attention_substep(
+                    x, step_idx, steps, selected_head_indices, selected_head_weights
+                )
+
+            mlp_router_inputs = self.block.mlp_norm(h_attn)
+            mlp_probs, selected_expert_indices, selected_expert_weights = (
+                self._select_mlp_experts(mlp_router_inputs, router_active)
+            )
+            mlp_entropy_sums += (
+                -(mlp_probs * torch.log(mlp_probs.clamp_min(1e-9)))
+                .sum(dim=-1)
+                .mean(dim=1)
+            )
+            mlp_step_probs.append(mlp_probs.mean(dim=1))
+            expert_counts[step_idx].scatter_add_(
+                0,
+                selected_expert_indices.reshape(-1),
+                selected_expert_weights.reshape(-1).to(dtype=expert_counts.dtype),
+            )
+            if (
+                self.activation_checkpointing
+                and self.training
+                and torch.is_grad_enabled()
+            ):
+                x = checkpoint(
+                    lambda hidden, expert_idx, expert_w: self._apply_mlp_substep(
+                        hidden, expert_idx, expert_w
+                    ),
+                    h_attn,
+                    selected_expert_indices,
+                    selected_expert_weights,
+                    use_reentrant=False,
+                    preserve_rng_state=False,
+                )
+            else:
+                x = self._apply_mlp_substep(
+                    h_attn, selected_expert_indices, selected_expert_weights
+                )
+
+        self.last_actual_recurrent_steps = float(steps)
+        self.last_forward_head_counts = head_counts.detach()
+        self.last_forward_expert_counts = expert_counts.detach()
+        self._last_attention_router_entropies = attention_entropy_sums / max(steps, 1)
+        self._last_mlp_router_entropies = mlp_entropy_sums / max(steps, 1)
+        self._last_attention_router_js = self._cross_step_js_divergence(
+            attention_step_probs
+        )
+        self._last_mlp_router_js = self._cross_step_js_divergence(mlp_step_probs)
+        x = self.final_norm(x)
+        return x
+
+    def _init_weights(self) -> None:
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _logits_from_hidden(self, x: Tensor) -> Tensor:
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            if self.lm_head is None:
+                raise RuntimeError("lm_head is required when tie_embeddings=False")
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _loss_from_hidden(self, x: Tensor, target_ids: Tensor) -> tuple[Tensor, Tensor]:
+        seq_losses = self._sequence_losses_from_hidden(x, target_ids)
+        main_loss = seq_losses.mean()
+
+        if self.training and self.mtp_num_heads > 0 and self.mtp_loss_weight > 0.0:
+            _, seqlen, dim = x.shape
+            mtp_loss_sum = x.new_zeros(())
+            mtp_loss_count = 0
+            for k, mtp_head in enumerate(self.mtp_heads):
+                valid_t = seqlen - (k + 1)
+                if valid_t <= 0:
+                    continue
+                mtp_hidden = x[:, :valid_t, :].reshape(-1, dim)
+                mtp_targets = target_ids[:, k + 1 :].reshape(-1)
+                mtp_logits_proj = mtp_head(mtp_hidden)
+                mtp_logits = self.logit_softcap * torch.tanh(
+                    mtp_logits_proj / self.logit_softcap
+                )
+                mtp_loss_sum = mtp_loss_sum + F.cross_entropy(
+                    mtp_logits.float(), mtp_targets, reduction="mean"
+                )
+                mtp_loss_count += 1
+            if mtp_loss_count > 0:
+                main_loss = main_loss + self.mtp_loss_weight * (
+                    mtp_loss_sum / mtp_loss_count
+                )
+
+        return main_loss, seq_losses
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        num_recurrent_steps: int | None = None,
+        router_active: bool = True,
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=num_recurrent_steps,
+            router_active=router_active,
+        )
+        main_loss, seq_losses = self._loss_from_hidden(x, target_ids)
+        self.last_main_loss = float(main_loss.detach().item())
+        total_loss = main_loss
+        attention_router_aux_loss = x.new_zeros(())
+        mlp_router_aux_loss = x.new_zeros(())
+        attention_router_mean_entropy = x.new_zeros(())
+        attention_router_js = x.new_zeros(())
+        mlp_router_mean_entropy = x.new_zeros(())
+        mlp_router_js = x.new_zeros(())
+        if (
+            router_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_attention_router_entropies is not None
+            and self._last_mlp_router_entropies is not None
+            and self._last_attention_router_js is not None
+            and self._last_mlp_router_js is not None
+        ):
+            attention_router_mean_entropy = self._last_attention_router_entropies.mean()
+            mlp_router_mean_entropy = self._last_mlp_router_entropies.mean()
+            attention_router_js = self._last_attention_router_js
+            mlp_router_js = self._last_mlp_router_js
+            attention_router_aux_loss = (
+                -self.attention_router_entropy_bonus * attention_router_mean_entropy
+                - self.attention_router_js_bonus * attention_router_js
+            )
+            mlp_router_aux_loss = (
+                -self.mlp_router_entropy_bonus * mlp_router_mean_entropy
+                - self.mlp_router_js_bonus * mlp_router_js
+            )
+            total_loss = total_loss + attention_router_aux_loss + mlp_router_aux_loss
+        self.last_attention_router_aux_loss = float(
+            attention_router_aux_loss.detach().item()
+        )
+        self.last_attention_router_entropy = float(
+            attention_router_mean_entropy.detach().item()
+        )
+        self.last_attention_router_js = float(attention_router_js.detach().item())
+        self.last_mlp_router_aux_loss = float(mlp_router_aux_loss.detach().item())
+        self.last_mlp_router_entropy = float(mlp_router_mean_entropy.detach().item())
+        self.last_mlp_router_js = float(mlp_router_js.detach().item())
+        return total_loss
+
+    def forward_loss_at_depth(
+        self, input_ids: Tensor, target_ids: Tensor, depth: int
+    ) -> Tensor:
+        x = self._recurrent_forward(
+            input_ids,
+            num_recurrent_steps=depth,
+            router_active=True,
+        )
+        main_loss, _ = self._loss_from_hidden(x, target_ids)
+        return main_loss
+
+    def forward_logits(self, input_ids: Tensor, router_active: bool = True) -> Tensor:
+        """Return logits (bsz, seq_len, vocab) without computing loss."""
+        x = self._recurrent_forward(input_ids, router_active=router_active)
+        return self._logits_from_hidden(x)
+
+
+# -----------------------------
+# SLIDING WINDOW EVALUATION
+# -----------------------------
+# Delta vs baseline evaluation: the default experiment script only scores
+# non-overlapping chunks. This record also computes the submission metric using
+# overlapping windows so each token is evaluated with near-max context.
+
+
+def eval_val_sliding(
+    args: Hyperparameters,
+    base_model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+    stride: int,
+    batch_seqs: int = 32,
+    eval_seq_len: int | None = None,
+    progress_label: str | None = None,
+    router_active: bool = True,
+) -> tuple[float, float]:
+    """Sliding window evaluation: each token scored with maximum context."""
+    seq_len = eval_seq_len or args.train_seq_len
+    total_tokens = val_tokens.numel() - 1
+
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, stride)
+        if min(ws + seq_len, total_tokens) - ws >= 1
+    ]
+    total_windows = len(window_starts)
+
+    my_s = (total_windows * rank) // world_size
+    my_e = (total_windows * (rank + 1)) // world_size
+    my_windows = window_starts[my_s:my_e]
+    progress_total = max(len(my_windows), 1)
+    progress_step = max(progress_total // 100, 1)
+    next_progress = progress_step
+    if progress_label is not None and rank == 0:
+        print(
+            f"final_eval_progress:0/{progress_total} label:{progress_label}", flush=True
+        )
+
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    base_model.eval()
+    compiled_logits = (
+        torch.compile(base_model.forward_logits, dynamic=False, fullgraph=True)
+        if not router_active
+        else None
+    )
+
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens: list[int] = []
+
+            for i, ws in enumerate(batch_ws):
+                end = min(ws + seq_len, total_tokens)
+                wlen = end - ws
+                wlens.append(wlen)
+                chunk = val_tokens[ws : end + 1].to(dtype=torch.int64, device=device)
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                if compiled_logits is not None:
+                    logits = compiled_logits(x_batch)
+                else:
+                    logits = base_model.forward_logits(
+                        x_batch, router_active=router_active
+                    )
+
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else max(wlen - stride, 0)
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = base_bytes_lut[tgt].to(torch.float64)
+                tb += (has_leading_space_lut[tgt] & ~is_boundary_token_lut[prev]).to(
+                    torch.float64
+                )
+                byte_count += tb.sum()
+            current_done = min(bi + bsz, len(my_windows))
+            if (
+                progress_label is not None
+                and rank == 0
+                and (current_done >= next_progress or current_done >= len(my_windows))
+            ):
+                print(
+                    f"final_eval_progress:{current_done}/{progress_total} label:{progress_label}",
+                    flush=True,
+                )
+                next_progress = current_done + progress_step
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = (loss_sum / token_count).item()
+    bits_per_token = val_loss / math.log(2.0)
+    tokens_per_byte = token_count.item() / byte_count.item()
+    base_model.train()
+    return val_loss, bits_per_token * tokens_per_byte
+
+
+# -----------------------------
+# ROUTER LOGGING
+# -----------------------------
+# The model logs recent average depth plus router entropy/auxiliary terms, and
+# shows per-step distributions for attention head and expert selections.
+
+
+def format_router_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    attention_aux_sum: float,
+    attention_aux_count: float,
+    attention_entropy_sum: float,
+    attention_entropy_count: float,
+    attention_js_sum: float,
+    attention_js_count: float,
+    mlp_aux_sum: float,
+    mlp_aux_count: float,
+    mlp_entropy_sum: float,
+    mlp_entropy_count: float,
+    mlp_js_sum: float,
+    mlp_js_count: float,
+) -> str:
+    avg_depth = depth_sum / depth_count if depth_count > 0 else 0.0
+    attention_aux_text = (
+        f"{attention_aux_sum / attention_aux_count:.4f}"
+        if attention_aux_count > 0
+        else "none"
+    )
+    attention_entropy_text = (
+        f"{attention_entropy_sum / attention_entropy_count:.4f}"
+        if attention_entropy_count > 0
+        else "none"
+    )
+    attention_js_text = (
+        f"{attention_js_sum / attention_js_count:.4f}"
+        if attention_js_count > 0
+        else "none"
+    )
+    mlp_aux_text = f"{mlp_aux_sum / mlp_aux_count:.4f}" if mlp_aux_count > 0 else "none"
+    mlp_entropy_text = (
+        f"{mlp_entropy_sum / mlp_entropy_count:.4f}"
+        if mlp_entropy_count > 0
+        else "none"
+    )
+    mlp_js_text = f"{mlp_js_sum / mlp_js_count:.4f}" if mlp_js_count > 0 else "none"
+    return (
+        f"step:{step}/{total_steps} router_probe "
+        f"window_steps:{window_steps} avg_depth:{avg_depth:.3f} "
+        f"attn_aux:{attention_aux_text} attn_entropy:{attention_entropy_text} attn_js:{attention_js_text} "
+        f"mlp_aux:{mlp_aux_text} mlp_entropy:{mlp_entropy_text} mlp_js:{mlp_js_text}"
+    )
+
+
+def format_selection_matrix(
+    step: int,
+    total_steps: int,
+    title: str,
+    total_counts: Tensor | None,
+    prefix: str,
+) -> str:
+    if total_counts is None:
+        return f"step:{step}/{total_steps} {title}:none"
+    lines = [f"step:{step}/{total_steps} {title}"]
+    for step_idx in range(total_counts.size(0)):
+        row = total_counts[step_idx]
+        row_total = float(row.sum().item())
+        if row_total <= 0:
+            continue
+        probs = row / row_total
+        row_text = " ".join(
+            f"{prefix}{action_idx:02d}:{float(probs[action_idx].item()):.3f}"
+            for action_idx in range(probs.numel())
+        )
+        lines.append(f"  s{step_idx + 1:02d} {row_text}")
+    return "\n".join(lines)
+
+
+# -----------------------------
+# INT6 MIXED QUANTIZATION (transplanted from working diagnostic scripts)
+# -----------------------------
+# Delta vs baseline export: attention/MLP matrices move to int6 while the
+# remaining weights use int8 or float passthrough. The baseline export path is
+# pure int8 + zlib.
+
+
+def _classify_param(name: str) -> str:
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+def quantize_int6_per_row(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        row_max = t32.abs().amax(dim=1)
+        scale = (row_max / 31.0).clamp_min(1.0 / 31.0).to(torch.float16)
+        q = torch.clamp(torch.round(t32 / scale.float()[:, None]), -32, 31).to(
+            torch.int8
+        )
+        return q, scale
+    amax = t32.abs().max().item()
+    scale = torch.tensor(amax / 31.0 if amax > 0 else 1.0, dtype=torch.float16)
+    q = torch.clamp(torch.round(t32 / scale.float()), -32, 31).to(torch.int8)
+    return q, scale
+
+
+def mixed_quantize_int6(state_dict: dict[str, Tensor], int6_cats: set[str]):
+    num_layers_total = (
+        max(
+            (int(k.split(".")[1]) for k in state_dict if k.startswith("blocks.")),
+            default=0,
+        )
+        + 1
+    )
+    late_k_layers = set(range(num_layers_total - 2, num_layers_total))
+
+    result: dict[str, Tensor] = {}
+    meta: dict[str, object] = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        cat = _classify_param(name)
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough"
+            continue
+        if any(p in name for p in CONTROL_TENSOR_NAME_PATTERNS):
+            result[name] = t.float()
+            meta[name] = "passthrough_ctrl"
+            continue
+        # tok_emb.weight falls through to int8 via "embed" category
+        if cat in int6_cats and t.ndim >= 1:
+            q, s = quantize_int6_per_row(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int6"}
+        else:
+            q, s = quantize_float_tensor(t)
+            result[name + ".q"] = q
+            result[name + ".scale"] = s
+            meta[name] = {"type": "int8"}
+    return result, meta
+
+
+def dequantize_mixed_int6(
+    result: dict[str, Tensor], meta: dict[str, object], template_sd: dict[str, Tensor]
+) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if info in ("passthrough", "passthrough_ctrl", "passthrough_fp16"):
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *([1] * (q.ndim - 1)))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code = Path(__file__).read_text(encoding="utf-8")
+    args = Hyperparameters()
+    # Keep a larger Dynamo cache budget as a conservative default for the
+    # recurrent training/eval helpers used elsewhere in the script.
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        if hasattr(torch._dynamo.config, "recompile_limit"):
+            torch._dynamo.config.recompile_limit = max(
+                torch._dynamo.config.recompile_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "cache_size_limit"):
+            torch._dynamo.config.cache_size_limit = max(
+                torch._dynamo.config.cache_size_limit,
+                8 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "accumulated_cache_size_limit"):
+            torch._dynamo.config.accumulated_cache_size_limit = max(
+                torch._dynamo.config.accumulated_cache_size_limit,
+                16 * args.num_recurrent_steps * args.num_layers,
+            )
+        if hasattr(torch._dynamo.config, "fail_on_recompile_limit_hit"):
+            torch._dynamo.config.fail_on_recompile_limit_hit = False
+    zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    master_process = rank == 0
+
+    # Fast math knobs
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    if hasattr(torch, "_dynamo") and hasattr(torch._dynamo, "config"):
+        torch._dynamo.config.optimize_ddp = False
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    log0(
+        subprocess.run(
+            ["nvidia-smi"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            check=False,
+        ).stdout,
+        console=False,
+    )
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(
+            f"Script only setup for SentencePiece .model file: {args.tokenizer_path}"
+        )
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    # Delta vs baseline data/eval setup: validation tensors are loaded long
+    # enough to support either plain non-overlapping eval or sliding-window eval
+    # at a different sequence length.
+    effective_eval_seq_len = (
+        args.eval_seq_len if args.eval_seq_len > 0 else args.train_seq_len
+    )
+    val_seq_len = max(args.train_seq_len, effective_eval_seq_len)
+    val_tokens = load_validation_tokens(args.val_files, val_seq_len)
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = (
+        build_sentencepiece_luts(sp, args.vocab_size, device)
+    )
+    log0(
+        f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}"
+    )
+    log0(
+        f"train_loader:dataset:{dataset_dir.name} mode:shuffled_memmap "
+        f"train_shards:{actual_train_files}"
+    )
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    # This global switch activates the STE fake-quant path in `CastedLinear`.
+    CastedLinear._qat_enabled = args.qat_enabled
+
+    base_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_num_experts=args.mlp_num_experts,
+            mlp_expert_mult=args.mlp_expert_mult,
+            attention_head_top_k=args.attention_head_top_k,
+            mlp_expert_top_k=args.mlp_expert_top_k,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            attention_router_entropy_bonus=args.attention_router_entropy_bonus_start,
+            attention_router_js_bonus=args.attention_router_js_bonus,
+            mlp_router_entropy_bonus=args.mlp_router_entropy_bonus_start,
+            mlp_router_js_bonus=args.mlp_router_js_bonus,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=args.mtp_num_heads,
+            mtp_loss_weight=args.mtp_loss_weight,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,
+        )
+        .to(device)
+        .bfloat16()
+    )
+    attention_router_base_model = AttentionHeadRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.attention_router_hidden_dim,
+        num_heads=args.num_heads,
+    ).to(device)
+    mlp_router_base_model = TokenExpertRouter(
+        input_dim=args.model_dim,
+        hidden_dim=args.mlp_router_hidden_dim,
+        num_experts=args.mlp_num_experts,
+    ).to(device)
+    for module in base_model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model)
+    model: nn.Module = (
+        DDP(
+            base_model,
+            device_ids=[local_rank],
+            broadcast_buffers=False,
+        )
+        if distributed
+        else base_model
+    )
+    attention_router_model: nn.Module = (
+        DDP(
+            attention_router_base_model,
+            device_ids=[local_rank],
+            broadcast_buffers=False,
+        )
+        if distributed
+        else attention_router_base_model
+    )
+    mlp_router_model: nn.Module = (
+        DDP(mlp_router_base_model, device_ids=[local_rank], broadcast_buffers=False)
+        if distributed
+        else mlp_router_base_model
+    )
+    base_model.set_routers(attention_router_model, mlp_router_model)
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    # Delta vs baseline parameter routing:
+    # - Bigram embeddings join the token optimizer
+    # - Smear/bigram scales join the scalar optimizer
+    # - MTP heads join the matrix optimizer when enabled
+    # - AdamW/Muon weight decay is explicit instead of relying on pure Adam/Muon
+    block_named_params = list(base_model.block.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2
+        and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.mtp_num_heads > 0:
+        matrix_params.extend(
+            [p for p in base_model.mtp_heads.parameters() if p.ndim == 2]
+        )
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2
+        or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params.append(base_model.smear.gate)
+    if base_model.bigram is not None:
+        scalar_params.append(base_model.bigram.scale)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    tok_params = [
+        {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+    ]
+    if base_model.bigram is not None:
+        tok_params.append(
+            {
+                "params": [base_model.bigram.embed.weight],
+                "lr": token_lr,
+                "base_lr": token_lr,
+            }
+        )
+        if base_model.bigram.proj is not None:
+            matrix_params.append(base_model.bigram.proj.weight)
+    optimizer_tok = torch.optim.AdamW(
+        tok_params,
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.embed_wd,
+        fused=True,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        weight_decay=args.muon_wd,
+        row_normalize=args.muon_row_normalize,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.AdamW(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.adam_wd,
+        fused=True,
+    )
+    optimizer_attention_router = torch.optim.AdamW(
+        [
+            {
+                "params": attention_router_base_model.parameters(),
+                "lr": args.attention_router_lr,
+                "base_lr": args.attention_router_lr,
+            }
+        ],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.attention_router_wd,
+        fused=True,
+    )
+    optimizer_mlp_router = torch.optim.AdamW(
+        [
+            {
+                "params": mlp_router_base_model.parameters(),
+                "lr": args.mlp_router_lr,
+                "base_lr": args.mlp_router_lr,
+            }
+        ],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        weight_decay=args.mlp_router_wd,
+        fused=True,
+    )
+    optimizers: list[torch.optim.Optimizer] = [
+        optimizer_tok,
+        optimizer_muon,
+        optimizer_scalar,
+    ]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [
+                {
+                    "params": [base_model.lm_head.weight],
+                    "lr": args.head_lr,
+                    "base_lr": args.head_lr,
+                }
+            ],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=True,
+        )
+        optimizers.insert(1, optimizer_head)
+    all_optimizers: list[torch.optim.Optimizer] = [
+        *optimizers,
+        optimizer_attention_router,
+        optimizer_mlp_router,
+    ]
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    mtp_params = sum(p.numel() for p in base_model.mtp_heads.parameters())
+    attention_router_params = sum(
+        p.numel() for p in attention_router_base_model.parameters()
+    )
+    mlp_router_params = sum(p.numel() for p in mlp_router_base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(
+        f"attention_router_params:{attention_router_params} "
+        f"mlp_router_params:{mlp_router_params}"
+    )
+    log0(f"unique_blocks:1 recurrent_steps:{base_model.num_recurrent_steps}")
+    log0(
+        f"mtp_num_heads:{args.mtp_num_heads} mtp_loss_weight:{args.mtp_loss_weight} mtp_params:{mtp_params}"
+    )
+    xsa_steps = base_model.xsa_step_indices()
+    log0(f"XSA:last_{args.xsa_last_n} active_steps:{xsa_steps}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0("sdp_backends:cudnn=False flash=True mem_efficient=False math=False")
+    log0(
+        f"attention_mode:routed_dense_qkv num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads}"
+    )
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"warmdown_frac:{args.warmdown_frac:.2f} min_lr:{args.min_lr:.4f} "
+        f"val_loss_every:{args.val_loss_every} "
+        f"num_recurrent_steps:{args.num_recurrent_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    log0(
+        f"attention_head_top_k:{args.attention_head_top_k} "
+        f"mlp_num_experts:{args.mlp_num_experts} mlp_expert_top_k:{args.mlp_expert_top_k} "
+        f"eval_recurrent_steps:{args.num_recurrent_steps}"
+    )
+    log0(
+        f"attention_router_input_dim:{3 * args.model_dim} "
+        f"attention_router_hidden_dim:{args.attention_router_hidden_dim} "
+        f"attention_router_lr:{args.attention_router_lr} attention_router_wd:{args.attention_router_wd} "
+        f"attention_router_entropy_bonus_start:{args.attention_router_entropy_bonus_start} "
+        f"attention_router_entropy_bonus_end:{args.attention_router_entropy_bonus_end} "
+        f"attention_router_js_bonus:{args.attention_router_js_bonus} "
+        f"mlp_router_hidden_dim:{args.mlp_router_hidden_dim} "
+        f"mlp_router_lr:{args.mlp_router_lr} mlp_router_wd:{args.mlp_router_wd} "
+        f"mlp_router_entropy_bonus_start:{args.mlp_router_entropy_bonus_start} "
+        f"mlp_router_entropy_bonus_end:{args.mlp_router_entropy_bonus_end} "
+        f"mlp_router_js_bonus:{args.mlp_router_js_bonus} "
+        f"activation_checkpointing:{int(args.activation_checkpointing)} "
+        f"ema_decay:{args.ema_decay} "
+        f"muon_momentum_warmup_steps:{args.muon_momentum_warmup_steps}"
+    )
+    log0(
+        f"muon_row_normalize:{int(args.muon_row_normalize)} "
+        f"muon_wd:{args.muon_wd} adam_wd:{args.adam_wd} embed_wd:{args.embed_wd}"
+    )
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+    attention_router_model.train()
+    mlp_router_model.train()
+    optimizer_attention_router.zero_grad(set_to_none=True)
+    optimizer_mlp_router.zero_grad(set_to_none=True)
+
+    def zero_grad_all() -> None:
+        for opt in all_optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = (
+        1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step: int, elapsed_ms: float) -> float:
+        if max_wallclock_ms is None:
+            return step / max(args.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-9)
+
+    def lr_mul(progress: float) -> float:
+        if args.warmdown_frac <= 0.0:
+            return 1.0
+        if progress >= 1.0 - args.warmdown_frac:
+            return max((1.0 - progress) / args.warmdown_frac, args.min_lr)
+        return 1.0
+
+    def entropy_bonus_value(
+        step: int, elapsed_ms: float, start: float, end: float
+    ) -> float:
+        if max_wallclock_ms is not None and max_wallclock_ms > 0.0:
+            progress = min(max(elapsed_ms / max_wallclock_ms, 0.0), 1.0)
+        elif args.iterations > 1:
+            progress = min(max(step / (args.iterations - 1), 0.0), 1.0)
+        else:
+            progress = 1.0
+        return (1.0 - progress) * start + progress * end
+
+    # Warmup exercises the actual router-controlled training path and optimizer
+    # kernels, then we restore the initial weights/optimizer state so measured
+    # training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in base_model.state_dict().items()
+        }
+        initial_router_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in attention_router_base_model.state_dict().items()
+        }
+        initial_mlp_router_state = {
+            name: tensor.detach().cpu().clone()
+            for name, tensor in mlp_router_base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in all_optimizers
+        ]
+        model.train()
+        attention_router_model.train()
+        mlp_router_model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                    attention_router_model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                    mlp_router_model.require_backward_grad_sync = (
+                        micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(
+                    args.train_batch_tokens, grad_accum_steps
+                )
+                with torch.autocast(
+                    device_type="cuda", dtype=torch.bfloat16, enabled=True
+                ):
+                    warmup_loss = model(x, y, router_active=True)
+                (warmup_loss * grad_scale).backward()
+            for opt in all_optimizers:
+                opt.step()
+            zero_grad_all()
+            if (
+                args.warmup_steps <= 20
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == args.warmup_steps
+            ):
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        attention_router_base_model.load_state_dict(initial_router_state, strict=True)
+        mlp_router_base_model.load_state_dict(initial_mlp_router_state, strict=True)
+        for opt, state in zip(all_optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+            attention_router_model.require_backward_grad_sync = True
+            mlp_router_model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(args, rank, world_size, device)
+        optimizer_attention_router.zero_grad(set_to_none=True)
+        optimizer_mlp_router.zero_grad(set_to_none=True)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    ema_model_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in base_model.state_dict().items()
+    }
+    ema_attention_router_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in attention_router_base_model.state_dict().items()
+    }
+    ema_mlp_router_state = {
+        name: tensor.detach().float().clone()
+        for name, tensor in mlp_router_base_model.state_dict().items()
+    }
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    probe_window_size = max(args.recurrence_probe_every, 1)
+    recent_depth_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_depth_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_aux_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_aux_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_entropy_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_entropy_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_js_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_attention_js_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_aux_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_aux_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_entropy_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_entropy_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_js_sums: deque[float] = deque(maxlen=probe_window_size)
+    recent_mlp_js_counts: deque[float] = deque(maxlen=probe_window_size)
+    recent_head_counts: deque[Tensor] = deque(maxlen=probe_window_size)
+    recent_expert_counts: deque[Tensor] = deque(maxlen=probe_window_size)
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+
+        should_validate = last_step or (
+            args.val_loss_every > 0 and step % args.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+                router_active=True,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        progress = training_frac(step, elapsed_ms)
+        scale = lr_mul(progress)
+        base_model.attention_router_entropy_bonus = entropy_bonus_value(
+            step,
+            elapsed_ms,
+            args.attention_router_entropy_bonus_start,
+            args.attention_router_entropy_bonus_end,
+        )
+        base_model.mlp_router_entropy_bonus = entropy_bonus_value(
+            step,
+            elapsed_ms,
+            args.mlp_router_entropy_bonus_start,
+            args.mlp_router_entropy_bonus_end,
+        )
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        attention_router_aux = torch.zeros((), device=device)
+        attention_router_entropy = torch.zeros((), device=device)
+        attention_router_js = torch.zeros((), device=device)
+        mlp_router_aux = torch.zeros((), device=device)
+        mlp_router_entropy = torch.zeros((), device=device)
+        mlp_router_js = torch.zeros((), device=device)
+        step_depth_sum = 0.0
+        step_depth_count = 0
+        step_head_counts = torch.zeros(
+            args.num_recurrent_steps,
+            args.num_heads,
+            device=device,
+            dtype=torch.float32,
+        )
+        step_expert_counts = torch.zeros(
+            args.num_recurrent_steps,
+            args.mlp_num_experts,
+            device=device,
+            dtype=torch.float32,
+        )
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = micro_step == grad_accum_steps - 1
+                attention_router_model.require_backward_grad_sync = (
+                    micro_step == grad_accum_steps - 1
+                )
+                mlp_router_model.require_backward_grad_sync = (
+                    micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(args.train_batch_tokens, grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, router_active=True)
+            step_depth_sum += float(base_model.last_actual_recurrent_steps)
+            step_depth_count += 1
+            step_head_counts += base_model.last_forward_head_counts.to(
+                device=device, dtype=step_head_counts.dtype
+            )
+            step_expert_counts += base_model.last_forward_expert_counts.to(
+                device=device, dtype=step_expert_counts.dtype
+            )
+            train_loss += float(base_model.last_main_loss)
+            attention_router_aux += float(base_model.last_attention_router_aux_loss)
+            attention_router_entropy += float(base_model.last_attention_router_entropy)
+            attention_router_js += float(base_model.last_attention_router_js)
+            mlp_router_aux += float(base_model.last_mlp_router_aux_loss)
+            mlp_router_entropy += float(base_model.last_mlp_router_entropy)
+            mlp_router_js += float(base_model.last_mlp_router_js)
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        attention_router_aux /= grad_accum_steps
+        attention_router_entropy /= grad_accum_steps
+        attention_router_js /= grad_accum_steps
+        mlp_router_aux /= grad_accum_steps
+        mlp_router_entropy /= grad_accum_steps
+        mlp_router_js /= grad_accum_steps
+
+        frac = (
+            min(step / args.muon_momentum_warmup_steps, 1.0)
+            if args.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+        for group in optimizer_attention_router.param_groups:
+            group["lr"] = group["base_lr"] * scale
+        for group in optimizer_mlp_router.param_groups:
+            group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+            torch.nn.utils.clip_grad_norm_(
+                attention_router_base_model.parameters(), args.grad_clip_norm
+            )
+            torch.nn.utils.clip_grad_norm_(
+                mlp_router_base_model.parameters(), args.grad_clip_norm
+            )
+        for opt in all_optimizers:
+            opt.step()
+        zero_grad_all()
+        with torch.no_grad():
+            for name, tensor in base_model.state_dict().items():
+                ema_model_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+            for name, tensor in attention_router_base_model.state_dict().items():
+                ema_attention_router_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+            for name, tensor in mlp_router_base_model.state_dict().items():
+                ema_mlp_router_state[name].mul_(args.ema_decay).add_(
+                    tensor.detach().float(), alpha=1.0 - args.ema_decay
+                )
+
+        local_step_depth_sum = float(step_depth_sum)
+        local_step_depth_count = float(step_depth_count)
+        local_attention_aux_sum = float(attention_router_aux.item()) * grad_accum_steps
+        local_attention_aux_count = float(grad_accum_steps)
+        local_attention_entropy_sum = (
+            float(attention_router_entropy.item()) * grad_accum_steps
+        )
+        local_attention_entropy_count = float(grad_accum_steps)
+        local_attention_js_sum = float(attention_router_js.item()) * grad_accum_steps
+        local_attention_js_count = float(grad_accum_steps)
+        local_mlp_aux_sum = float(mlp_router_aux.item()) * grad_accum_steps
+        local_mlp_aux_count = float(grad_accum_steps)
+        local_mlp_entropy_sum = float(mlp_router_entropy.item()) * grad_accum_steps
+        local_mlp_entropy_count = float(grad_accum_steps)
+        local_mlp_js_sum = float(mlp_router_js.item()) * grad_accum_steps
+        local_mlp_js_count = float(grad_accum_steps)
+        recent_depth_sums.append(local_step_depth_sum)
+        recent_depth_counts.append(local_step_depth_count)
+        recent_attention_aux_sums.append(local_attention_aux_sum)
+        recent_attention_aux_counts.append(local_attention_aux_count)
+        recent_attention_entropy_sums.append(local_attention_entropy_sum)
+        recent_attention_entropy_counts.append(local_attention_entropy_count)
+        recent_attention_js_sums.append(local_attention_js_sum)
+        recent_attention_js_counts.append(local_attention_js_count)
+        recent_mlp_aux_sums.append(local_mlp_aux_sum)
+        recent_mlp_aux_counts.append(local_mlp_aux_count)
+        recent_mlp_entropy_sums.append(local_mlp_entropy_sum)
+        recent_mlp_entropy_counts.append(local_mlp_entropy_count)
+        recent_mlp_js_sums.append(local_mlp_js_sum)
+        recent_mlp_js_counts.append(local_mlp_js_count)
+        recent_head_counts.append(step_head_counts.detach().cpu())
+        recent_expert_counts.append(step_expert_counts.detach().cpu())
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+
+        should_probe_recurrence = (
+            args.recurrence_probe_every > 0 and step % args.recurrence_probe_every == 0
+        )
+        should_log_train = args.train_log_every > 0 and (
+            step <= 10
+            or step % args.train_log_every == 0
+            or stop_after_step is not None
+        )
+        step_avg_depth = local_step_depth_sum / max(local_step_depth_count, 1.0)
+        step_avg_attention_aux = (
+            local_attention_aux_sum / local_attention_aux_count
+            if local_attention_aux_count > 0
+            else None
+        )
+        step_avg_attention_entropy = (
+            local_attention_entropy_sum / local_attention_entropy_count
+            if local_attention_entropy_count > 0
+            else None
+        )
+        step_avg_attention_js = (
+            local_attention_js_sum / local_attention_js_count
+            if local_attention_js_count > 0
+            else None
+        )
+        step_avg_mlp_aux = (
+            local_mlp_aux_sum / local_mlp_aux_count if local_mlp_aux_count > 0 else None
+        )
+        step_avg_mlp_entropy = (
+            local_mlp_entropy_sum / local_mlp_entropy_count
+            if local_mlp_entropy_count > 0
+            else None
+        )
+        step_avg_mlp_js = (
+            local_mlp_js_sum / local_mlp_js_count if local_mlp_js_count > 0 else None
+        )
+        if distributed and (should_probe_recurrence or should_log_train):
+            step_stats = torch.tensor(
+                [
+                    local_step_depth_sum,
+                    local_step_depth_count,
+                    local_attention_aux_sum,
+                    local_attention_aux_count,
+                    local_attention_entropy_sum,
+                    local_attention_entropy_count,
+                    local_attention_js_sum,
+                    local_attention_js_count,
+                    local_mlp_aux_sum,
+                    local_mlp_aux_count,
+                    local_mlp_entropy_sum,
+                    local_mlp_entropy_count,
+                    local_mlp_js_sum,
+                    local_mlp_js_count,
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_avg_depth = float(
+                (step_stats[0] / step_stats[1].clamp_min(1.0)).item()
+            )
+            step_avg_attention_aux = (
+                float((step_stats[2] / step_stats[3]).item())
+                if step_stats[3].item() > 0
+                else None
+            )
+            step_avg_attention_entropy = (
+                float((step_stats[4] / step_stats[5]).item())
+                if step_stats[5].item() > 0
+                else None
+            )
+            step_avg_attention_js = (
+                float((step_stats[6] / step_stats[7]).item())
+                if step_stats[7].item() > 0
+                else None
+            )
+            step_avg_mlp_aux = (
+                float((step_stats[8] / step_stats[9]).item())
+                if step_stats[9].item() > 0
+                else None
+            )
+            step_avg_mlp_entropy = (
+                float((step_stats[10] / step_stats[11]).item())
+                if step_stats[11].item() > 0
+                else None
+            )
+            step_avg_mlp_js = (
+                float((step_stats[12] / step_stats[13]).item())
+                if step_stats[13].item() > 0
+                else None
+            )
+        if should_probe_recurrence:
+            window_stats = torch.tensor(
+                [
+                    sum(recent_depth_sums),
+                    sum(recent_depth_counts),
+                    sum(recent_attention_aux_sums),
+                    sum(recent_attention_aux_counts),
+                    sum(recent_attention_entropy_sums),
+                    sum(recent_attention_entropy_counts),
+                    sum(recent_attention_js_sums),
+                    sum(recent_attention_js_counts),
+                    sum(recent_mlp_aux_sums),
+                    sum(recent_mlp_aux_counts),
+                    sum(recent_mlp_entropy_sums),
+                    sum(recent_mlp_entropy_counts),
+                    sum(recent_mlp_js_sums),
+                    sum(recent_mlp_js_counts),
+                ],
+                device=device,
+                dtype=torch.float64,
+            )
+            window_head_counts: Tensor | None = (
+                torch.stack(list(recent_head_counts), dim=0)
+                .sum(dim=0)
+                .to(device=device, dtype=torch.float64)
+                if recent_head_counts
+                else None
+            )
+            window_expert_counts: Tensor | None = (
+                torch.stack(list(recent_expert_counts), dim=0)
+                .sum(dim=0)
+                .to(device=device, dtype=torch.float64)
+                if recent_expert_counts
+                else None
+            )
+            if distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+                if window_head_counts is not None:
+                    dist.all_reduce(window_head_counts, op=dist.ReduceOp.SUM)
+                if window_expert_counts is not None:
+                    dist.all_reduce(window_expert_counts, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+            window_head_counts = None
+            window_expert_counts = None
+        if should_probe_recurrence and (not distributed or rank == 0):
+            log0(
+                format_router_probe_summary(
+                    step,
+                    args.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                    float(window_stats[4].item()),
+                    float(window_stats[5].item()),
+                    float(window_stats[6].item()),
+                    float(window_stats[7].item()),
+                    float(window_stats[8].item()),
+                    float(window_stats[9].item()),
+                    float(window_stats[10].item()),
+                    float(window_stats[11].item()),
+                    float(window_stats[12].item()),
+                    float(window_stats[13].item()),
+                )
+            )
+            log0(
+                format_selection_matrix(
+                    step,
+                    args.iterations,
+                    "attention_head_matrix",
+                    None if window_head_counts is None else window_head_counts.cpu(),
+                    "h",
+                )
+            )
+            log0(
+                format_selection_matrix(
+                    step,
+                    args.iterations,
+                    "mlp_expert_matrix",
+                    None
+                    if window_expert_counts is None
+                    else window_expert_counts.cpu(),
+                    "e",
+                )
+            )
+
+        if should_log_train:
+            router_log = (
+                f" attn_aux:{step_avg_attention_aux:.4f}"
+                f" attn_entropy:{step_avg_attention_entropy:.4f}"
+                f" attn_js:{step_avg_attention_js:.4f}"
+                f" attn_entropy_bonus:{base_model.attention_router_entropy_bonus:.4f}"
+                f" mlp_aux:{step_avg_mlp_aux:.4f}"
+                f" mlp_entropy:{step_avg_mlp_entropy:.4f}"
+                f" mlp_js:{step_avg_mlp_js:.4f}"
+                f" mlp_entropy_bonus:{base_model.mlp_router_entropy_bonus:.4f}"
+            )
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+                f" routers_forward:2"
+                f"{router_log}"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    log0(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+
+    log0("ema:applying EMA weights")
+    base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=base_model.state_dict()[name].dtype)
+            for name, tensor in ema_model_state.items()
+        },
+        strict=True,
+    )
+    attention_router_base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=attention_router_base_model.state_dict()[name].dtype)
+            for name, tensor in ema_attention_router_state.items()
+        },
+        strict=True,
+    )
+    mlp_router_base_model.load_state_dict(
+        {
+            name: tensor.to(dtype=mlp_router_base_model.state_dict()[name].dtype)
+            for name, tensor in ema_mlp_router_state.items()
+        },
+        strict=True,
+    )
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+
+    # Delta vs baseline export: MTP helps training but is not part of the final
+    # artifact, so those heads are dropped before serialization.
+    full_state_dict = base_model.state_dict()
+    export_sd = {k: v for k, v in full_state_dict.items() if "mtp_heads" not in k}
+    attention_router_export_sd = attention_router_base_model.state_dict()
+    mlp_router_export_sd = mlp_router_base_model.state_dict()
+    excluded_mtp = sum(
+        int(t.numel()) for k, t in full_state_dict.items() if "mtp_heads" in k
+    )
+    if excluded_mtp > 0:
+        log0(f"export_excluding_mtp_params:{excluded_mtp}")
+
+    if master_process:
+        torch.save(
+            {
+                "model": export_sd,
+                "attention_router": attention_router_export_sd,
+                "mlp_router": mlp_router_export_sd,
+            },
+            "final_model.pt",
+        )
+        model_bytes = os.path.getsize("final_model.pt")
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+
+    sd_cpu = {k: v.detach().cpu() for k, v in export_sd.items()}
+    attention_router_sd_cpu = {
+        k: v.detach().cpu() for k, v in attention_router_export_sd.items()
+    }
+    mlp_router_sd_cpu = {k: v.detach().cpu() for k, v in mlp_router_export_sd.items()}
+    # Baseline writes int8+zlib. This record uses mixed int6/int8 and prefers
+    # zstd-22 when available to squeeze under the 16 MB artifact limit.
+    quant_result, quant_meta = mixed_quantize_int6(sd_cpu, {"mlp", "attn"})
+    attention_router_quant_result, attention_router_quant_meta = mixed_quantize_int6(
+        attention_router_sd_cpu, set()
+    )
+    mlp_router_quant_result, mlp_router_quant_meta = mixed_quantize_int6(
+        mlp_router_sd_cpu, set()
+    )
+    quant_buf = io.BytesIO()
+    torch.save(
+        {
+            "w": quant_result,
+            "m": quant_meta,
+            "aw": attention_router_quant_result,
+            "am": attention_router_quant_meta,
+            "mw": mlp_router_quant_result,
+            "mm": mlp_router_quant_meta,
+        },
+        quant_buf,
+    )
+    quant_raw = quant_buf.getvalue()
+    quant_blob = (
+        zstandard.ZstdCompressor(level=22).compress(quant_raw)
+        if _COMPRESSOR == "zstd"
+        else zlib.compress(quant_raw, 9)
+    )
+    if master_process:
+        with open("final_model.int6.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = len(quant_blob)
+        code_bytes = len(code.encode("utf-8"))
+        log0(f"Serialized model int6+{_COMPRESSOR}: {quant_file_bytes} bytes")
+        log0(
+            f"Total submission size int6+{_COMPRESSOR}: {quant_file_bytes + code_bytes} bytes"
+        )
+
+    # Roundtrip: rebuild a fresh eval model from the compressed artifact so the
+    # reported score matches the thing that would actually be submitted.
+    if distributed:
+        dist.barrier()
+    with open("final_model.int6.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(
+            zstandard.ZstdDecompressor().decompress(quant_blob_disk)
+            if _COMPRESSOR == "zstd"
+            else zlib.decompress(quant_blob_disk)
+        ),
+        map_location="cpu",
+    )
+    deq_state = dequantize_mixed_int6(quant_state["w"], quant_state["m"], sd_cpu)
+    deq_attention_router_state = dequantize_mixed_int6(
+        quant_state["aw"], quant_state["am"], attention_router_sd_cpu
+    )
+    deq_mlp_router_state = dequantize_mixed_int6(
+        quant_state["mw"], quant_state["mm"], mlp_router_sd_cpu
+    )
+
+    eval_model = (
+        GPT(
+            vocab_size=args.vocab_size,
+            num_layers=args.num_layers,
+            model_dim=args.model_dim,
+            num_heads=args.num_heads,
+            num_kv_heads=args.num_kv_heads,
+            mlp_num_experts=args.mlp_num_experts,
+            mlp_expert_mult=args.mlp_expert_mult,
+            attention_head_top_k=args.attention_head_top_k,
+            mlp_expert_top_k=args.mlp_expert_top_k,
+            tie_embeddings=args.tie_embeddings,
+            tied_embed_init_std=args.tied_embed_init_std,
+            logit_softcap=args.logit_softcap,
+            rope_base=args.rope_base,
+            qk_gain_init=args.qk_gain_init,
+            num_recurrent_steps=args.num_recurrent_steps,
+            attention_router_entropy_bonus=args.attention_router_entropy_bonus_end,
+            attention_router_js_bonus=args.attention_router_js_bonus,
+            mlp_router_entropy_bonus=args.mlp_router_entropy_bonus_end,
+            mlp_router_js_bonus=args.mlp_router_js_bonus,
+            activation_checkpointing=args.activation_checkpointing,
+            mtp_num_heads=0,
+            mtp_loss_weight=0.0,
+            bigram_vocab_size=args.bigram_vocab_size,
+            bigram_dim=args.bigram_dim,
+            xsa_last_n=args.xsa_last_n,  # must match training model
+        )
+        .to(device)
+        .bfloat16()
+    )
+    for m in eval_model.modules():
+        if isinstance(m, CastedLinear):
+            m.float()
+    restore_low_dim_params_to_fp32(eval_model)
+    eval_attention_router_model = AttentionHeadRouter(
+        input_dim=3 * args.model_dim,
+        hidden_dim=args.attention_router_hidden_dim,
+        num_heads=args.num_heads,
+    ).to(device)
+    eval_mlp_router_model = TokenExpertRouter(
+        input_dim=args.model_dim,
+        hidden_dim=args.mlp_router_hidden_dim,
+        num_experts=args.mlp_num_experts,
+    ).to(device)
+    eval_model.set_routers(eval_attention_router_model, eval_mlp_router_model)
+    eval_model.load_state_dict(deq_state, strict=True)
+    eval_attention_router_model.load_state_dict(deq_attention_router_state, strict=True)
+    eval_mlp_router_model.load_state_dict(deq_mlp_router_state, strict=True)
+    eval_attention_router_model.eval()
+    eval_mlp_router_model.eval()
+
+    # Standard non-overlapping eval (sanity check)
+    torch.cuda.synchronize()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        eval_model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+        eval_seq_len=effective_eval_seq_len,
+        router_active=True,
+    )
+    torch.cuda.synchronize()
+    log0(
+        f"final_int6_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(
+        f"final_int6_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}"
+    )
+
+    # Sliding-window eval is the record's headline submission metric.
+    sw_seq_len = effective_eval_seq_len
+    if args.eval_stride > 0 and args.eval_stride < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide = time.perf_counter()
+        sw_val_loss, sw_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=args.eval_stride,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window val_loss:{sw_val_loss:.4f} val_bpb:{sw_val_bpb:.4f} "
+            f"stride:{args.eval_stride} eval_time:{1000.0 * (time.perf_counter() - t_slide):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_exact val_loss:{sw_val_loss:.8f} val_bpb:{sw_val_bpb:.8f}"
+        )
+
+    # Second sliding window eval at stride=64 for submission comparison
+    if args.eval_stride != 64 and 64 < sw_seq_len:
+        torch.cuda.synchronize()
+        t_slide64 = time.perf_counter()
+        sw64_val_loss, sw64_val_bpb = eval_val_sliding(
+            args,
+            eval_model,
+            rank,
+            world_size,
+            device,
+            val_tokens,
+            base_bytes_lut,
+            has_leading_space_lut,
+            is_boundary_token_lut,
+            stride=64,
+            eval_seq_len=sw_seq_len,
+            progress_label="sliding_window_s64",
+            router_active=True,
+        )
+        torch.cuda.synchronize()
+        log0(
+            f"final_int6_sliding_window_s64 val_loss:{sw64_val_loss:.4f} val_bpb:{sw64_val_bpb:.4f} "
+            f"stride:64 eval_time:{1000.0 * (time.perf_counter() - t_slide64):.0f}ms"
+        )
+        log0(
+            f"final_int6_sliding_window_s64_exact val_loss:{sw64_val_loss:.8f} val_bpb:{sw64_val_bpb:.8f}"
+        )
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_saved_rope_ttt.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/art_saved_rope_ttt.py
@@ -1,0 +1,3628 @@
+"""Parameter Golf submission: triple ART halt with RoPE reload fix, GPTQ, and post-quant TTT."""
+
+from __future__ import annotations
+
+import collections
+import copy
+import datetime
+import glob
+import io
+import math
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+_SMOKE_TEST: bool = bool(int(os.environ.get("SMOKE_TEST", "0")))
+try:
+    if _SMOKE_TEST:
+        raise ImportError("SMOKE_TEST: forcing SDPA fallback")
+    from flash_attn_interface import flash_attn_func as _fa3_impl
+
+    _USE_FA3 = True
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        return _fa3_impl(q, k, v, causal=causal)
+
+except ImportError:
+    _USE_FA3 = False
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        B, T, Hq, D = q.shape
+        Hkv = k.shape[2]
+        q_ = q.permute(0, 2, 1, 3).contiguous()
+        k_ = k.permute(0, 2, 1, 3).contiguous()
+        v_ = v.permute(0, 2, 1, 3).contiguous()
+        if Hkv != Hq:
+            repeat = Hq // Hkv
+            k_ = k_.repeat_interleave(repeat, dim=1)
+            v_ = v_.repeat_interleave(repeat, dim=1)
+        out = F.scaled_dot_product_attention(q_, k_, v_, is_causal=causal)
+        return out.permute(0, 2, 1, 3).contiguous()
+
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start.parent, *start.parents):
+        if (candidate / "experiments").exists() and (candidate / "data").exists():
+            return candidate
+    return start.parent
+
+
+_REPO_ROOT = _find_repo_root(_SCRIPT_PATH)
+
+
+def _unique_paths(paths) -> list[Path]:
+    seen = set()
+    unique = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _is_safe_recursive_search_root(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if resolved == resolved.parent:
+        return False
+    return str(resolved) not in {"/proc", "/sys", "/dev"}
+
+
+def _with_vocab_substitution(raw_path: str, vocab_size: int | None) -> list[str]:
+    paths = [raw_path]
+    if vocab_size is not None:
+        replaced = re.sub(r"fineweb10B_sp\d+", f"fineweb10B_sp{vocab_size}", raw_path)
+        replaced = re.sub(
+            r"fineweb_\d+_bpe\.model", f"fineweb_{vocab_size}_bpe.model", replaced
+        )
+        paths.insert(0, replaced)
+    return list(dict.fromkeys(paths))
+
+
+def _expand_path_candidates(raw_path: str, vocab_size: int | None = None) -> list[Path]:
+    candidates = []
+    for candidate_path in _with_vocab_substitution(raw_path, vocab_size):
+        path = Path(candidate_path).expanduser()
+        if path.is_absolute():
+            candidates.append(path)
+        else:
+            candidates.append((Path.cwd() / path).resolve())
+            candidates.append((_REPO_ROOT / path).resolve())
+    return _unique_paths(candidates)
+
+
+def _data_root_candidates_from_path(path: Path) -> list[Path]:
+    text = str(path)
+    base = path.parent if any(ch in text for ch in "*?[") else path
+    candidates = []
+    if base.name.startswith("fineweb10B_sp") and base.parent.name == "datasets":
+        candidates.append(base.parent.parent)
+    if base.name == "datasets":
+        candidates.append(base.parent)
+    if base.name == "tokenizers":
+        candidates.append(base.parent)
+    if base.parent.name == "tokenizers":
+        candidates.append(base.parent.parent)
+    candidates.append(base)
+    return _unique_paths(candidates)
+
+
+def _path_mentions_other_vocab(path: Path, vocab_size: int) -> bool:
+    text = str(path)
+    for pattern in (r"fineweb10B_sp(\d+)", r"fineweb_(\d+)_bpe\.model"):
+        for match in re.finditer(pattern, text):
+            if int(match.group(1)) != vocab_size:
+                return True
+    return False
+
+
+def _tokenizer_matches_vocab(path: Path, vocab_size: int) -> bool:
+    if not path.exists():
+        return False
+    try:
+        sp = spm.SentencePieceProcessor(model_file=str(path))
+    except Exception:
+        return False
+    return int(sp.vocab_size()) == vocab_size
+
+
+def _candidate_search_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend([path, *path.parents])
+    candidates.extend([_SCRIPT_PATH.parent, *_SCRIPT_PATH.parents])
+    cwd = Path.cwd().resolve()
+    candidates.extend([cwd, *cwd.parents])
+    candidates.extend(
+        [
+            _REPO_ROOT,
+            Path("/workspace"),
+            Path("/workspace/parameter-golf"),
+            Path("/workspace/caseops_data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(
+        [path for path in candidates if _is_safe_recursive_search_root(path)]
+    )
+
+
+def _candidate_data_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend(_data_root_candidates_from_path(path))
+    candidates.extend(
+        [
+            _REPO_ROOT / "data",
+            Path.cwd() / "data",
+            Path("/workspace/parameter-golf/data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(candidates)
+
+
+def _resolve_existing_path(candidates: list[Path]) -> Path | None:
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_data_dir(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> str:
+    candidates = _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _resolve_existing_path(candidates)
+    return str(resolved if resolved is not None else candidates[0])
+
+
+def _resolve_glob_candidates(
+    patterns: list[Path], vocab_size: int | None = None
+) -> Path | None:
+    for pattern in patterns:
+        matches = [Path(path) for path in glob.glob(str(pattern))]
+        if vocab_size is not None:
+            matches = [
+                path
+                for path in matches
+                if not _path_mentions_other_vocab(path, vocab_size)
+            ]
+        if matches:
+            return pattern
+    return None
+
+
+def _search_dataset_pattern(
+    split: str, vocab_size: int, roots: list[Path]
+) -> Path | None:
+    target_dir = f"fineweb10B_sp{vocab_size}"
+    filename = f"fineweb_{split}_*.bin"
+    direct_patterns = []
+    for root in roots:
+        direct_patterns.extend(
+            [
+                root / "data" / "datasets" / target_dir / filename,
+                root / "datasets" / target_dir / filename,
+                root / "dashboard_data" / "smoke_data" / target_dir / filename,
+                root / filename,
+            ]
+        )
+    resolved = _resolve_glob_candidates(
+        _unique_paths(direct_patterns), vocab_size=vocab_size
+    )
+    if resolved is not None:
+        return resolved
+
+    for root in roots:
+        try:
+            recursive = sorted(root.glob(f"**/{target_dir}/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        usable = [path for path in recursive if "_bytes_" not in path.name]
+        if usable:
+            return usable[0].parent / filename
+    return None
+
+
+def _resolve_data_pattern(
+    split: str,
+    vocab_size: int,
+    explicit_pattern: str | None,
+    explicit_data_dir: str | None,
+) -> str:
+    if explicit_pattern:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(explicit_pattern, vocab_size=vocab_size)
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        resolved = _resolve_glob_candidates(explicit_candidates, vocab_size=vocab_size)
+        if resolved is not None:
+            return str(resolved)
+        if explicit_candidates:
+            return str(explicit_candidates[0])
+
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _search_dataset_pattern(split, vocab_size, search_roots)
+    if resolved is not None:
+        return str(resolved)
+
+    candidates = [
+        root / "datasets" / f"fineweb10B_sp{vocab_size}" / f"fineweb_{split}_*.bin"
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if glob.glob(str(candidate)):
+            return str(candidate)
+    return str(candidates[0])
+
+
+def _resolve_tokenizer_path(
+    vocab_size: int, explicit_tokenizer_path: str | None, explicit_data_dir: str | None
+) -> str:
+    if explicit_tokenizer_path:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(
+                explicit_tokenizer_path, vocab_size=vocab_size
+            )
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        for candidate in explicit_candidates:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+    filename = f"fineweb_{vocab_size}_bpe.model"
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    candidates = []
+    for root in search_roots:
+        candidates.extend(
+            [
+                root / "data" / "tokenizers" / filename,
+                root / "tokenizers" / filename,
+            ]
+        )
+    for candidate in _unique_paths(candidates):
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+
+    for root in search_roots:
+        try:
+            recursive = sorted(root.glob(f"**/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        for candidate in recursive:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+
+    candidates = [
+        root / "tokenizers" / filename
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+    return str(_unique_paths(candidates)[0])
+
+
+class Hyperparameters:
+    _ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    _short = uuid.uuid4().hex[:8]
+    run_id = os.environ.get("RUN_ID", f"{_ts}_{_short}")
+    seed = int(os.environ.get("SEED", 1337))
+
+    requested_vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    vocab_size = 8192
+    data_root_hint = os.environ.get("DATA_DIR") or os.environ.get("DATA_PATH")
+    data_dir = _resolve_data_dir(data_root_hint, vocab_size=vocab_size)
+    datasets_dir = os.path.dirname(
+        _resolve_data_pattern(
+            "train",
+            vocab_size,
+            os.environ.get("TRAIN_FILES"),
+            data_root_hint,
+        )
+    )
+    train_files = _resolve_data_pattern(
+        "train",
+        vocab_size,
+        os.environ.get("TRAIN_FILES"),
+        data_root_hint,
+    )
+    val_files = _resolve_data_pattern(
+        "val",
+        vocab_size,
+        os.environ.get("VAL_FILES"),
+        data_root_hint,
+    )
+    tokenizer_path = _resolve_tokenizer_path(
+        vocab_size,
+        os.environ.get("TOKENIZER_PATH"),
+        data_root_hint,
+    )
+
+    iterations = int(os.environ.get("ITERATIONS", 50000))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524_288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.25))
+
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    art_halt_enabled = bool(int(os.environ.get("ART_HALT_ENABLED", "1")))
+    art_halt_enable_at = float(os.environ.get("ART_HALT_ENABLE_AT", 0.55))
+    art_router_hidden_dim = int(os.environ.get("ART_ROUTER_HIDDEN_DIM", 64))
+    art_router_lr = float(os.environ.get("ART_ROUTER_LR", 5e-4))
+    art_router_wd = float(os.environ.get("ART_ROUTER_WD", 0.01))
+    art_router_entropy_start = float(os.environ.get("ART_ROUTER_ENTROPY_START", 0.05))
+    art_router_entropy_end = float(os.environ.get("ART_ROUTER_ENTROPY_END", 0.0))
+    art_cycle_penalty = float(os.environ.get("ART_CYCLE_PENALTY", 0.001))
+    art_route_group_size = int(os.environ.get("ART_ROUTE_GROUP_SIZE", 1))
+    art_shard_coherent_batches = bool(
+        int(os.environ.get("ART_SHARD_COHERENT_BATCHES", "0"))
+    )
+    art_gptq_calibrate_routed = bool(
+        int(os.environ.get("ART_GPTQ_CALIBRATE_ROUTED", "0"))
+    )
+    art_quant_router_fp32 = bool(int(os.environ.get("ART_QUANT_ROUTER_FP32", "0")))
+    art_eval_route_stats = bool(int(os.environ.get("ART_EVAL_ROUTE_STATS", "1")))
+    art_eval_sample_routes = bool(int(os.environ.get("ART_EVAL_SAMPLE_ROUTES", "1")))
+    art_eval_route_threshold = float(os.environ.get("ART_EVAL_ROUTE_THRESHOLD", 0.5))
+    art_quant_diag_enabled = bool(int(os.environ.get("ART_QUANT_DIAG_ENABLED", "0")))
+    art_quant_diag_modes = os.environ.get(
+        "ART_QUANT_DIAG_MODES", "sample,argmax,force0,force1,force2,force3"
+    )
+    raw_roundtrip_check_enabled = bool(
+        int(os.environ.get("RAW_ROUNDTRIP_CHECK_ENABLED", "0"))
+    )
+    parallel_residual_start = int(os.environ.get("PARALLEL_RESIDUAL_START", 7))
+
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_fraction = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_FRACTION", 0.22)
+    )
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.005))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    muon_wd_mlp = float(os.environ.get("MUON_WD_MLP", 0.115))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_reset_on_looping = bool(int(os.environ.get("EMA_RESET_ON_LOOPING", "1")))
+    ema_reset_on_art = bool(int(os.environ.get("EMA_RESET_ON_ART", "1")))
+
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.005))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 4))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 65536))
+    ttt_log_every_chunks = int(os.environ.get("TTT_LOG_EVERY_CHUNKS", 1))
+
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 20.0))
+    lowbit_layers = os.environ.get("LOWBIT_LAYERS", "")
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = max(1, 8 // world_size)
+
+    logfile = f"logs/{run_id}.txt"
+    os.makedirs("ckpt", exist_ok=True)
+    model_path = "ckpt/final_model.pt"
+    quantized_model_path = "ckpt/final_model.int6.ptz"
+
+
+if _SMOKE_TEST:
+    Hyperparameters.iterations = int(os.environ.get("ITERATIONS", "30"))
+    Hyperparameters.train_batch_tokens = int(
+        os.environ.get("TRAIN_BATCH_TOKENS", "32768")
+    )
+    Hyperparameters.train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", "512"))
+    Hyperparameters.eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", "512"))
+    Hyperparameters.max_wallclock_seconds = float(
+        os.environ.get("MAX_WALLCLOCK_SECONDS", "120.0")
+    )
+    Hyperparameters.val_batch_tokens = int(
+        os.environ.get("VAL_BATCH_TOKENS", "2097152")
+    )
+    Hyperparameters.warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", "0.2"))
+    Hyperparameters.val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", "0"))
+    Hyperparameters.train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", "5"))
+    Hyperparameters.warmup_steps = int(os.environ.get("WARMUP_STEPS", "0"))
+    Hyperparameters.ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    Hyperparameters.gptq_calibration_batches = int(
+        os.environ.get("GPTQ_CALIBRATION_BATCHES", "2")
+    )
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(f) for f in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for seq_len={seq_len}")
+    return tokens[: usable + 1]
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert sp.piece_to_id("▁") != sp.unk_id(), (
+        "Tokenizer must have '▁' as a token for BPB byte counting"
+    )
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        if not Path(h.tokenizer_path).exists():
+            raise FileNotFoundError(
+                f"Tokenizer model not found: {h.tokenizer_path}. "
+                "Set TOKENIZER_PATH or DATA_DIR/DATA_PATH to a location containing tokenizers/."
+            )
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.base_bytes_lut, self.has_leading_space_lut, self.is_boundary_token_lut = (
+            build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        self.shard_coherent_batches = getattr(h, "art_shard_coherent_batches", False)
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        self._phase_epoch = [0] * len(self.files)
+        self._phase_order = [self.rng.permutation(8).tolist() for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        if max_phase > 0:
+            k = self._phase_order[si][self._phase_epoch[si] % 8]
+            self._phase_epoch[si] += 1
+            phase = min(k * (max_phase + 1) // 8, max_phase)
+        else:
+            phase = 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        num_shards = len(self.files)
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        total = remaining.sum()
+        if total <= 0:
+            for si in range(num_shards):
+                self._reset_shard(si)
+            remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+            total = remaining.sum()
+        target = device_batch_size * remaining / total
+        quotas = np.floor(target).astype(np.int64)
+        leftover = device_batch_size - int(quotas.sum())
+        if leftover > 0:
+            order = np.argsort(-(target - quotas))
+            for i in order[:leftover]:
+                quotas[int(i)] += 1
+        quotas = np.minimum(quotas, remaining.astype(np.int64))
+        shortfall = device_batch_size - int(quotas.sum())
+        if shortfall > 0:
+            extra = remaining.astype(np.int64) - quotas
+            order = np.argsort(-extra)
+            fill = 0
+            while shortfall > 0 and fill < num_shards:
+                j = int(order[fill])
+                if extra[j] > 0:
+                    quotas[j] += 1
+                    extra[j] -= 1
+                    shortfall -= 1
+                else:
+                    fill += 1
+        shard_plan = np.concatenate(
+            [np.full(int(q), s, dtype=np.int64) for s, q in enumerate(quotas)]
+        )
+        if self.shard_coherent_batches:
+            if shard_plan.size > 1:
+                shard_plan = np.roll(
+                    shard_plan, int(self.rng.integers(0, shard_plan.size))
+                )
+        else:
+            self.rng.shuffle(shard_plan)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            si = int(shard_plan[bi])
+            if not self.start_inds[si]:
+                for si2 in range(num_shards):
+                    self._reset_shard(si2)
+            start_ind = self.start_inds[si].pop()
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            base = self.base
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                base = self.base * scale ** (rd / (rd - 2))
+            # Recompute in fp32. The non-persistent buffer is affected by
+            # module-wide bf16 conversion and made fresh reloads non-equivalent.
+            inv_freq = 1.0 / base ** (
+                torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+            )
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads, 2), qk_gain_init, dtype=torch.float32)
+        )
+        self.attn_out_gate_width = 12
+        self.attn_out_gate_w = nn.Parameter(
+            torch.zeros(num_heads, self.attn_out_gate_width, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        rd = self.rope_dims
+        gain = self.q_gain.to(dtype=q.dtype)
+        if 0 < rd < q.size(-1):
+            q_rope = q[..., :rd] * gain[None, None, :, 0:1]
+            q_nope = q[..., rd:] * gain[None, None, :, 1:2]
+            q = torch.cat((q_rope, q_nope), dim=-1)
+        else:
+            q = q * gain[None, None, :, 0:1]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        gate_w = self.attn_out_gate_w.to(dtype=x.dtype)
+        g = 2.0 * torch.sigmoid(F.linear(x[..., : self.attn_out_gate_width], gate_w))
+        y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x):
+        return self.proj(F.silu(self.fc(x)).square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        self.parallel = False
+
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor)
+        if self.parallel:
+            mlp_out = self.mlp(self.mlp_norm(x_in) * self.ln_scale_factor)
+            x_out = (
+                x_in
+                + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+                + self.mlp_scale.to(dtype=x_in.dtype)[None, None, :] * mlp_out
+            )
+        else:
+            x_out = (
+                x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+            )
+            x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+                None, None, :
+            ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+
+class ARTHaltRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, 2)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, features: Tensor) -> Tensor:
+        return self.proj(F.gelu(self.fc(features.float())))
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        self.embed_scale = nn.Parameter(
+            torch.ones(h.embedding_dim, dtype=torch.float32)
+        )
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.rope_train_seq_len,
+                    rope_dims=h.rope_dims,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        if h.parallel_residual_start >= 0:
+            for i in range(h.parallel_residual_start, h.num_layers):
+                self.blocks[i].parallel = True
+        if h.num_loops > 0 and h.ln_scale:
+            loop_scale = 1.0 / math.sqrt(h.num_loops + 1)
+            for i in range(h.loop_start, h.loop_end + 1):
+                self.blocks[i].ln_scale_factor = (
+                    self.blocks[i].ln_scale_factor * loop_scale
+                )
+
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+
+        self.art_halt_enabled = h.art_halt_enabled
+        self.art_halt_runtime_active = False
+        self.art_router_entropy_bonus = h.art_router_entropy_start
+        self.art_cycle_penalty = h.art_cycle_penalty
+        self.art_router_first = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_early = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_continue_idx = 0
+        self.art_router_stop_idx = 1
+        self.art_route_group_size = h.art_route_group_size
+        self.art_eval_sample_routes = h.art_eval_sample_routes
+        self.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        self.art_eval_route_threshold = h.art_eval_route_threshold
+        self.art_eval_force_depth = -1
+        self._art_eval_gate_index = 0
+        self.use_routed_compiled_blocks = False
+        self._routed_compiled_blocks = None
+        self._compiled_art_prefix_dual = None
+        self._compiled_art_tail_dual = None
+        self.last_art_avg_cycles = 3.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_policy_loss = 0.0
+        self.art_gate_names = ("cycle1", "cycle2", "cycle3")
+        self._last_art_log_probs: Tensor | None = None
+        self._last_art_entropies: Tensor | None = None
+        self._last_art_cycles: Tensor | None = None
+        self._last_art_gate_continue_stats: Tensor | None = None
+        self._last_art_avg_cycles_stat: Tensor | None = None
+        self._last_art_continue_rate_stat: Tensor | None = None
+        self._last_art_router_entropy_stat: Tensor | None = None
+        self._last_art_router_loss_stat: Tensor | None = None
+        self._last_art_policy_loss_stat: Tensor | None = None
+        self._art_early_cycle_boundary_encoder_pos = 5
+        self._art_early_encoder_cycle_positions = (6, 7)
+        self._art_late_cycle_boundary_decoder_pos = 0
+        self._art_late_decoder_cycle_positions = (1, 2, 3)
+
+        if self.art_halt_enabled:
+            if (h.num_loops, h.loop_start, h.loop_end) != (2, 3, 5):
+                raise ValueError(
+                    "Triple ART halt requires NUM_LOOPS=2, LOOP_START=3, LOOP_END=5"
+                )
+            expected_encoder = [0, 1, 2, 3, 4, 5, 3, 4]
+            if self.encoder_indices != expected_encoder:
+                raise ValueError(
+                    f"Triple ART halt expects encoder {expected_encoder}, got {self.encoder_indices}"
+                )
+            expected_decoder = [5, 3, 4, 5]
+            if self.decoder_indices[:4] != expected_decoder:
+                raise ValueError(
+                    f"Triple ART halt expects decoder prefix {expected_decoder}, got {self.decoder_indices[:4]}"
+                )
+
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _art_router_features(self, x: Tensor) -> Tensor:
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled), dim=-1)
+
+    def _next_art_eval_gate_index(self) -> int:
+        gate_idx = int(self._art_eval_gate_index)
+        self._art_eval_gate_index = gate_idx + 1
+        return gate_idx
+
+    def _art_eval_action_ids(self, probs: Tensor) -> Tensor:
+        mode = self.art_eval_route_mode
+        if mode == "sample":
+            return torch.multinomial(probs, num_samples=1).squeeze(1)
+        if mode == "threshold":
+            continue_probs = probs[:, self.art_router_continue_idx]
+            return torch.where(
+                continue_probs >= self.art_eval_route_threshold,
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_continue_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_stop_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+            )
+        if mode == "force":
+            continue_gate = self._next_art_eval_gate_index() < self.art_eval_force_depth
+            action_id = (
+                self.art_router_continue_idx
+                if continue_gate
+                else self.art_router_stop_idx
+            )
+            return torch.full(
+                (probs.size(0),), action_id, device=probs.device, dtype=torch.long
+            )
+        return probs.argmax(dim=-1)
+
+    def _art_router_decision(
+        self, router: ARTHaltRouter, x: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        features = self._art_router_features(x)
+        if self.art_route_group_size != 1 and features.size(0) > 1:
+            return self._art_router_decision_grouped(router, features)
+        logits = router(features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            selected_log_probs = log_probs.gather(1, action_ids.unsqueeze(1)).squeeze(1)
+        else:
+            action_ids = self._art_eval_action_ids(probs)
+            selected_log_probs = None
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_decision_grouped(
+        self, router: ARTHaltRouter, features: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        batch_size = features.size(0)
+        group_size = (
+            batch_size
+            if self.art_route_group_size <= 0
+            else min(self.art_route_group_size, batch_size)
+        )
+        num_groups = (batch_size + group_size - 1) // group_size
+        group_ids = torch.arange(batch_size, device=features.device) // group_size
+        if batch_size % group_size == 0:
+            group_features = features.reshape(num_groups, group_size, -1).mean(dim=1)
+        else:
+            group_features = features.new_zeros(num_groups, features.size(-1))
+            group_features.index_add_(0, group_ids, features)
+            group_counts = torch.bincount(group_ids, minlength=num_groups).to(
+                dtype=features.dtype
+            )
+            group_features = group_features / group_counts.clamp_min(1.0).unsqueeze(1)
+
+        logits = router(group_features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        group_entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            group_action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            group_selected_log_probs = log_probs.gather(
+                1, group_action_ids.unsqueeze(1)
+            ).squeeze(1)
+        else:
+            group_action_ids = self._art_eval_action_ids(probs)
+            group_selected_log_probs = None
+
+        action_ids = group_action_ids.index_select(0, group_ids)
+        selected_log_probs = (
+            group_selected_log_probs.index_select(0, group_ids)
+            if group_selected_log_probs is not None
+            else None
+        )
+        entropies = group_entropies.index_select(0, group_ids)
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_anchor(self, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in self.art_router_first.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router_early.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _art_single_router_anchor(self, router: ARTHaltRouter, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _block_param_anchor(
+        self, block_indices: tuple[int, ...], ref: Tensor
+    ) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx in block_indices:
+            for param in self.blocks[block_idx].parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def prepare_routed_compiled_blocks(self) -> None:
+        if _SMOKE_TEST:
+            return
+        if self._routed_compiled_blocks is None:
+            self._routed_compiled_blocks = [
+                torch.compile(block, dynamic=True, fullgraph=True)
+                for block in self.blocks
+            ]
+
+    def _run_block(self, x: Tensor, x0: Tensor, block_idx: int) -> Tensor:
+        if self.use_routed_compiled_blocks and self._routed_compiled_blocks is not None:
+            return self._routed_compiled_blocks[block_idx](x, x0)
+        return self.blocks[block_idx](x, x0)
+
+    def warm_routed_compiled_blocks(
+        self, batch_size: int, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        if _SMOKE_TEST:
+            return
+        self.prepare_routed_compiled_blocks()
+        previous_enabled = self.use_routed_compiled_blocks
+        previous_training = self.training
+        self.use_routed_compiled_blocks = True
+        self.train()
+        dim = int(self.skip_weights.size(1))
+        block_indices = sorted(set(self.encoder_indices + self.decoder_indices))
+        for block_idx in block_indices:
+            x = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            x0 = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            loss = self._run_block(x, x0, block_idx).float().mean()
+            loss.backward()
+            self.zero_grad(set_to_none=True)
+        self.use_routed_compiled_blocks = previous_enabled
+        self.train(previous_training)
+
+    def _project_logits(self, x: Tensor) -> Tensor:
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _forward_art_prefix_triple(self, input_ids: Tensor):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        for i in self.encoder_indices[:3]:
+            x = self._run_block(x, x0, i)
+            skips.append(x)
+        return x, x0, skips[0], skips[1], skips[2]
+
+    def _forward_art_tail_triple(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        s0: Tensor,
+        s1: Tensor,
+        s2: Tensor,
+        first_continue_idx: Tensor,
+        active_s3: Tensor | None,
+    ) -> Tensor:
+        if first_continue_idx.numel() > 0 and active_s3 is not None:
+            scaled_s3 = (
+                self.skip_weights[4].to(dtype=x.dtype)[None, None, :] * active_s3
+            )
+            if first_continue_idx.numel() == x.size(0):
+                x = self._apply_skip(x, scaled_s3, 4)
+            else:
+                full_scaled_s3 = torch.zeros_like(x)
+                full_scaled_s3.index_copy_(0, first_continue_idx, scaled_s3)
+                x = self._apply_skip_subset(x, full_scaled_s3, 4, first_continue_idx)
+        x = self._run_block(x, x0, self.decoder_indices[4])
+        for skip_idx, block_idx, skip in (
+            (5, self.decoder_indices[5], s2),
+            (6, self.decoder_indices[6], s1),
+            (7, self.decoder_indices[7], s0),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :] * skip
+            )
+            x = self._apply_skip(x, scaled_skip, skip_idx)
+            x = self._run_block(x, x0, block_idx)
+        x = self._run_block(x, x0, self.decoder_indices[8])
+        return self._project_logits(x)
+
+    def _forward_logits_trunk_only(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        empty_idx = torch.empty(0, device=x.device, dtype=torch.long)
+        if self.training and torch.is_grad_enabled():
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+            x = x + self._block_param_anchor((3, 4, 5), x).view(1, 1, 1)
+        return self._forward_art_tail_triple(x, x0, s0, s1, s2, empty_idx, None)
+
+    def _forward_logits_art_triple_segmented(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        (
+            first_continue_mask,
+            first_log_probs,
+            first_entropies,
+        ) = self._art_router_decision(self.art_router_first, x)
+        first_continue_idx = first_continue_mask.nonzero(as_tuple=False).flatten()
+        art_cycles = first_continue_mask.to(dtype=torch.float32)
+        art_log_prob_accum = first_log_probs
+        art_entropy_accum = first_entropies
+        active_s3_for_tail = None
+        early_continue_rate = x.new_zeros((), dtype=torch.float32)
+        late_continue_rate = x.new_zeros((), dtype=torch.float32)
+
+        if first_continue_idx.numel() > 0:
+            if first_continue_idx.numel() == x.size(0):
+                active_x = x
+                active_x0 = x0
+            else:
+                active_x = x.index_select(0, first_continue_idx)
+                active_x0 = x0.index_select(0, first_continue_idx)
+
+            active_x, active_s3, active_s4, active_s5 = (
+                self._run_art_first_cycle_active(active_x, active_x0)
+            )
+            active_s3_for_tail = active_s3
+            (
+                early_continue_subset,
+                early_log_probs,
+                early_entropies,
+            ) = self._art_router_decision(self.art_router_early, active_x)
+            early_continue_mask = torch.zeros_like(first_continue_mask)
+            early_continue_mask.index_copy_(
+                0, first_continue_idx, early_continue_subset
+            )
+            early_continue_subset_idx = early_continue_subset.nonzero(
+                as_tuple=False
+            ).flatten()
+            early_continue_rate = early_continue_subset.to(dtype=torch.float32).mean()
+            art_cycles = art_cycles + early_continue_mask.to(dtype=torch.float32)
+            if early_log_probs is not None:
+                if art_log_prob_accum is None:
+                    art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                art_log_prob_accum = art_log_prob_accum.index_copy(
+                    0,
+                    first_continue_idx,
+                    art_log_prob_accum.index_select(0, first_continue_idx)
+                    + early_log_probs,
+                )
+            art_entropy_accum = art_entropy_accum.index_copy(
+                0,
+                first_continue_idx,
+                art_entropy_accum.index_select(0, first_continue_idx) + early_entropies,
+            )
+
+            if early_continue_subset_idx.numel() > 0:
+                second_x = active_x.index_select(0, early_continue_subset_idx)
+                second_x0 = active_x0.index_select(0, early_continue_subset_idx)
+                second_s5 = active_s5.index_select(0, early_continue_subset_idx)
+                second_s4 = active_s4.index_select(0, early_continue_subset_idx)
+                second_x, second_s6 = self._run_art_second_cycle_active(
+                    second_x, second_x0
+                )
+                (
+                    late_continue_subset,
+                    late_log_probs,
+                    late_entropies,
+                ) = self._art_router_decision(self.art_router, second_x)
+                second_continue_idx = first_continue_idx.index_select(
+                    0, early_continue_subset_idx
+                )
+                late_continue_mask = torch.zeros_like(first_continue_mask)
+                late_continue_mask.index_copy_(
+                    0, second_continue_idx, late_continue_subset
+                )
+                late_continue_subset_idx = late_continue_subset.nonzero(
+                    as_tuple=False
+                ).flatten()
+                late_continue_rate = late_continue_subset.to(dtype=torch.float32).mean()
+                art_cycles = art_cycles + late_continue_mask.to(dtype=torch.float32)
+                if late_log_probs is not None:
+                    if art_log_prob_accum is None:
+                        art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_log_prob_accum = art_log_prob_accum.index_copy(
+                        0,
+                        second_continue_idx,
+                        art_log_prob_accum.index_select(0, second_continue_idx)
+                        + late_log_probs,
+                    )
+                art_entropy_accum = art_entropy_accum.index_copy(
+                    0,
+                    second_continue_idx,
+                    art_entropy_accum.index_select(0, second_continue_idx)
+                    + late_entropies,
+                )
+
+                if late_continue_subset_idx.numel() > 0:
+                    if late_continue_subset_idx.numel() == second_x.size(0):
+                        second_x = self._run_art_third_cycle_active(
+                            second_x, second_x0, second_s6, second_s5, second_s4
+                        )
+                    else:
+                        late_x = second_x.index_select(0, late_continue_subset_idx)
+                        late_x0 = second_x0.index_select(0, late_continue_subset_idx)
+                        late_s6 = second_s6.index_select(0, late_continue_subset_idx)
+                        late_s5 = second_s5.index_select(0, late_continue_subset_idx)
+                        late_s4 = second_s4.index_select(0, late_continue_subset_idx)
+                        late_x = self._run_art_third_cycle_active(
+                            late_x, late_x0, late_s6, late_s5, late_s4
+                        )
+                        second_x = second_x.index_copy(
+                            0, late_continue_subset_idx, late_x
+                        )
+                active_x = active_x.index_copy(0, early_continue_subset_idx, second_x)
+            elif self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+            x = self._scatter_subset(x, first_continue_idx, active_x)
+        else:
+            if self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router_early, x).view(
+                    1, 1, 1
+                )
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+
+        self._last_art_log_probs = art_log_prob_accum
+        self._last_art_entropies = art_entropy_accum
+        self._last_art_cycles = art_cycles
+        self._last_art_gate_continue_stats = torch.stack(
+            (
+                first_continue_mask.to(dtype=torch.float32).mean(),
+                early_continue_rate,
+                late_continue_rate,
+            )
+        ).detach()
+        self._last_art_continue_rate_stat = (art_cycles / 3.0).mean().detach()
+        self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+        self._last_art_router_entropy_stat = art_entropy_accum.mean().detach()
+
+        return self._forward_art_tail_triple(
+            x, x0, s0, s1, s2, first_continue_idx, active_s3_for_tail
+        )
+
+    def sync_art_logging_stats(self) -> None:
+        if self._last_art_avg_cycles_stat is not None:
+            self.last_art_avg_cycles = float(self._last_art_avg_cycles_stat.item())
+        if self._last_art_continue_rate_stat is not None:
+            self.last_art_continue_rate = float(
+                self._last_art_continue_rate_stat.item()
+            )
+        if self._last_art_router_entropy_stat is not None:
+            self.last_art_router_entropy = float(
+                self._last_art_router_entropy_stat.item()
+            )
+        if self._last_art_router_loss_stat is not None:
+            self.last_art_router_loss = float(self._last_art_router_loss_stat.item())
+        if self._last_art_policy_loss_stat is not None:
+            self.last_art_policy_loss = float(self._last_art_policy_loss_stat.item())
+
+    def _apply_skip(self, x: Tensor, scaled_skip: Tensor, skip_idx: int) -> Tensor:
+        if self.skip_gates is not None:
+            g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                None, None, :
+            ]
+            return torch.lerp(scaled_skip, x, g)
+        return x + scaled_skip
+
+    def _apply_skip_subset(
+        self,
+        x: Tensor,
+        scaled_skip: Tensor,
+        skip_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._apply_skip(x, scaled_skip, skip_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._apply_skip(
+                x.index_select(0, active_idx),
+                scaled_skip.index_select(0, active_idx),
+                skip_idx,
+            ),
+        )
+        return next_x
+
+    def _scatter_subset(
+        self, x: Tensor, active_idx: Tensor, active_x: Tensor
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return active_x
+        return x.index_copy(0, active_idx, active_x)
+
+    def _run_block_subset(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        block_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._run_block(x, x0, block_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._run_block(
+                x.index_select(0, active_idx),
+                x0.index_select(0, active_idx),
+                block_idx,
+            ),
+        )
+        return next_x
+
+    def _run_art_first_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[3])
+        active_s3 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[4])
+        active_s4 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[5])
+        active_s5 = active_x
+        return active_x, active_s3, active_s4, active_s5
+
+    def _run_art_second_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[6])
+        active_s6 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[7])
+        scaled_skip = (
+            self.skip_weights[0].to(dtype=active_x.dtype)[None, None, :] * active_x
+        )
+        active_x = self._apply_skip(active_x, scaled_skip, 0)
+        active_x = self._run_block(active_x, active_x0, self.decoder_indices[0])
+        return active_x, active_s6
+
+    def _run_art_third_cycle_active(
+        self,
+        active_x: Tensor,
+        active_x0: Tensor,
+        active_s6: Tensor,
+        active_s5: Tensor,
+        active_s4: Tensor,
+    ) -> Tensor:
+        for skip_idx, block_idx, skip in (
+            (1, self.decoder_indices[1], active_s6),
+            (2, self.decoder_indices[2], active_s5),
+            (3, self.decoder_indices[3], active_s4),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=active_x.dtype)[None, None, :]
+                * skip
+            )
+            active_x = self._apply_skip(active_x, scaled_skip, skip_idx)
+            active_x = self._run_block(active_x, active_x0, block_idx)
+        return active_x
+
+    def forward_logits(
+        self, input_ids: Tensor, art_halt_active: bool | None = None
+    ) -> Tensor:
+        art_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+        )
+        art_early_continue_mask: Tensor | None = None
+        art_early_continue_idx: Tensor | None = None
+        art_late_continue_mask: Tensor | None = None
+        art_late_continue_idx: Tensor | None = None
+        art_cycles: Tensor | None = None
+        art_log_prob_accum: Tensor | None = None
+        art_entropy_accum: Tensor | None = None
+        art_early_decision_made = False
+        art_late_decision_made = False
+        self._last_art_log_probs = None
+        self._last_art_entropies = None
+        self._last_art_cycles = None
+        self._last_art_gate_continue_stats = None
+        self._last_art_avg_cycles_stat = None
+        self._last_art_continue_rate_stat = None
+        self._last_art_router_entropy_stat = None
+        self._last_art_router_loss_stat = None
+        self._last_art_policy_loss_stat = None
+        self.last_art_policy_loss = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_avg_cycles = 3.0 if self.looping_active else 0.0
+        if not (self.training and torch.is_grad_enabled()):
+            self._art_eval_gate_index = 0
+        if art_active:
+            return self._forward_logits_art_triple_segmented(input_ids)
+        if not self.looping_active:
+            return self._forward_logits_trunk_only(input_ids)
+
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = self.encoder_indices if self.looping_active else (0, 1, 2)
+        dec_iter = self.decoder_indices if self.looping_active else (6, 7, 8, 9, 10)
+        for enc_pos, i in enumerate(enc_iter):
+            in_early_cycle = (
+                art_active
+                and art_early_decision_made
+                and enc_pos in self._art_early_encoder_cycle_positions
+                and art_early_continue_idx is not None
+            )
+            if in_early_cycle:
+                x = self._run_block_subset(x, x0, i, art_early_continue_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            skips.append(x)
+            if (
+                art_active
+                and not art_early_decision_made
+                and enc_pos == self._art_early_cycle_boundary_encoder_pos
+            ):
+                (
+                    art_early_continue_mask,
+                    selected_log_probs,
+                    entropies,
+                ) = self._art_router_decision(self.art_router_early, x)
+                art_early_continue_idx = art_early_continue_mask.nonzero(
+                    as_tuple=False
+                ).flatten()
+                art_cycles = 1.0 + art_early_continue_mask.to(dtype=torch.float32)
+                if selected_log_probs is not None:
+                    art_log_prob_accum = selected_log_probs
+                art_entropy_accum = entropies
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                self._last_art_router_entropy_stat = entropies.mean().detach()
+                art_early_decision_made = True
+        for skip_idx, i in enumerate(dec_iter):
+            in_second_cycle = (
+                art_active
+                and art_early_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+            )
+            in_late_cycle = (
+                art_active
+                and art_late_decision_made
+                and skip_idx in self._art_late_decoder_cycle_positions
+                and art_late_continue_idx is not None
+            )
+            art_slot_idx = None
+            if in_second_cycle:
+                art_slot_idx = art_early_continue_idx
+            elif in_late_cycle:
+                art_slot_idx = art_late_continue_idx
+            if skip_idx < self.num_skip_weights and skips:
+                scaled_skip = (
+                    self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                    * skips.pop()
+                )
+                if art_slot_idx is not None:
+                    x = self._apply_skip_subset(x, scaled_skip, skip_idx, art_slot_idx)
+                else:
+                    x = self._apply_skip(x, scaled_skip, skip_idx)
+            if art_slot_idx is not None:
+                x = self._run_block_subset(x, x0, i, art_slot_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            if (
+                art_active
+                and art_early_decision_made
+                and not art_late_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+                and art_cycles is not None
+            ):
+                active_idx = art_early_continue_idx
+                art_late_continue_mask = torch.zeros_like(art_early_continue_mask)
+                if active_idx.numel() > 0:
+                    (
+                        late_continue_subset,
+                        selected_log_probs,
+                        entropies,
+                    ) = self._art_router_decision(
+                        self.art_router, x.index_select(0, active_idx)
+                    )
+                    art_late_continue_mask.index_copy_(
+                        0, active_idx, late_continue_subset
+                    )
+                    late_continue_subset_idx = late_continue_subset.nonzero(
+                        as_tuple=False
+                    ).flatten()
+                    art_late_continue_idx = active_idx.index_select(
+                        0, late_continue_subset_idx
+                    )
+                    art_cycles = art_cycles + art_late_continue_mask.to(
+                        dtype=torch.float32
+                    )
+                    if selected_log_probs is not None:
+                        if art_log_prob_accum is None:
+                            art_log_prob_accum = x.new_zeros(
+                                x.size(0), dtype=torch.float32
+                            )
+                        art_log_prob_accum = art_log_prob_accum.index_copy(
+                            0,
+                            active_idx,
+                            art_log_prob_accum.index_select(0, active_idx)
+                            + selected_log_probs,
+                        )
+                    if art_entropy_accum is None:
+                        art_entropy_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_entropy_accum = art_entropy_accum.index_copy(
+                        0,
+                        active_idx,
+                        art_entropy_accum.index_select(0, active_idx) + entropies,
+                    )
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                if art_entropy_accum is not None:
+                    self._last_art_router_entropy_stat = (
+                        art_entropy_accum.mean().detach()
+                    )
+                art_late_decision_made = True
+
+        x = self.final_norm(x)
+        if (
+            not art_early_decision_made
+            and not art_late_decision_made
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        art_halt_active: bool | None = None,
+    ) -> Tensor:
+        logits = self.forward_logits(input_ids, art_halt_active=art_halt_active)
+        art_loss_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if not art_loss_active:
+            return F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                target_ids.reshape(-1),
+                reduction="mean",
+            )
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        seq_losses = token_losses.mean(dim=1)
+        main_loss = seq_losses.mean()
+        total_loss = main_loss
+        router_policy_loss = main_loss.new_zeros(())
+        router_loss = main_loss.new_zeros(())
+        if (
+            self.art_halt_enabled
+            and self.art_halt_runtime_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_art_log_probs is not None
+            and self._last_art_entropies is not None
+            and self._last_art_cycles is not None
+        ):
+            router_costs = (
+                seq_losses.detach() + self.art_cycle_penalty * self._last_art_cycles
+            )
+            advantages = router_costs - router_costs.mean()
+            router_policy_loss = (advantages * self._last_art_log_probs).mean()
+            router_mean_entropy = self._last_art_entropies.mean()
+            router_loss = (
+                router_policy_loss - self.art_router_entropy_bonus * router_mean_entropy
+            )
+            total_loss = total_loss + router_loss
+        self._last_art_policy_loss_stat = router_policy_loss.detach()
+        self._last_art_router_loss_stat = router_loss.detach()
+        if (
+            self._last_art_entropies is not None
+            and self._last_art_entropies.numel() > 0
+        ):
+            self._last_art_router_entropy_stat = (
+                self._last_art_entropies.mean().detach()
+            )
+        return total_loss
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = (
+                            g.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                        )
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,attn_out_gate",
+    ).split(",")
+    if pattern
+)
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        block_named_params = list(base_model.blocks.named_parameters())
+        matrix_attn_params = []
+        matrix_mlp_params = []
+        for name, p in block_named_params:
+            if p.ndim != 2 or any(
+                pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS
+            ):
+                continue
+            if ".mlp." in name:
+                matrix_mlp_params.append(p)
+            else:
+                matrix_attn_params.append(p)
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if hasattr(base_model, "embed_scale"):
+            scalar_params.append(base_model.embed_scale)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            [
+                {"params": matrix_attn_params, "weight_decay": h.muon_wd},
+                {"params": matrix_mlp_params, "weight_decay": h.muon_wd_mlp},
+            ],
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if h.art_halt_enabled:
+            router_params = (
+                list(base_model.art_router_first.parameters())
+                + list(base_model.art_router_early.parameters())
+                + list(base_model.art_router.parameters())
+            )
+            self.optimizer_art_router = torch.optim.AdamW(
+                [
+                    {
+                        "params": router_params,
+                        "lr": h.art_router_lr,
+                        "base_lr": h.art_router_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                weight_decay=h.art_router_wd,
+                fused=True,
+            )
+            self.optimizers.append(self.optimizer_art_router)
+        else:
+            self.optimizer_art_router = None
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def step(self):
+        for opt in self.optimizers:
+            opt.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, (CastedLinear, ARTHaltRouter)):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hessian_divisors = {}
+    expected_hessian_names = []
+    hooks = []
+    capture_names = None
+    capture_divisor = max(int(n_calibration_batches), 1)
+    previous_routed_blocks = getattr(model, "use_routed_compiled_blocks", None)
+    previous_looping_active = getattr(model, "looping_active", None)
+    previous_art_runtime_active = getattr(model, "art_halt_runtime_active", None)
+    previous_training = model.training
+
+    def make_hook(name):
+        def hook_fn(module, inp, out):
+            if capture_names is not None and name not in capture_names:
+                return
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+                hessian_divisors[name] = capture_divisor
+            hessians[name].addmm_(x.T, x)
+
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > 65536:
+            cat = classify_param(name + ".weight")
+            if cat in ("mlp", "attn"):
+                hessian_name = name + ".weight"
+                expected_hessian_names.append(hessian_name)
+                hooks.append(module.register_forward_hook(make_hook(hessian_name)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                if capture_names is not None and name not in capture_names:
+                    return
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                    hessian_divisors[name] = capture_divisor
+                hessians[name].addmm_(x.T, x)
+
+            return hook_fn
+
+        expected_hessian_names.append("tok_emb.weight")
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+
+    def run_calibration_pass(num_batches, routed_art):
+        nonlocal capture_divisor
+        capture_divisor = max(int(num_batches), 1)
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = False
+        if previous_looping_active is not None:
+            model.looping_active = True
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = bool(routed_art)
+        with torch.no_grad():
+            for _ in range(num_batches):
+                x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+                model.forward_logits(x)
+
+    routed_calibration = bool(
+        h.art_halt_enabled and getattr(h, "art_gptq_calibrate_routed", True)
+    )
+    model.eval()
+    try:
+        if routed_calibration:
+            log("GPTQ:calibration path routed_art")
+            run_calibration_pass(n_calibration_batches, routed_art=True)
+            missing = sorted(set(expected_hessian_names) - set(hessians))
+            if missing:
+                fallback_batches = max(4, min(n_calibration_batches, 16))
+                log(
+                    "GPTQ:routed calibration missed "
+                    f"{len(missing)} tensors; fallback fixed_full batches={fallback_batches}"
+                )
+                capture_names = set(missing)
+                run_calibration_pass(fallback_batches, routed_art=False)
+                capture_names = None
+        else:
+            log("GPTQ:calibration path fixed_full")
+            run_calibration_pass(n_calibration_batches, routed_art=False)
+    finally:
+        capture_names = None
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = previous_routed_blocks
+        if previous_looping_active is not None:
+            model.looping_active = previous_looping_active
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = previous_art_runtime_active
+        model.train(previous_training)
+        for hook in hooks:
+            hook.remove()
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / max(float(hessian_divisors[name]), 1.0)
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=32):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    H.diagonal().mul_(1.01)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _parse_lowbit_map(spec):
+    m = {}
+    for item in (spec or "").split(","):
+        item = item.strip()
+        if item:
+            pat, b = item.rsplit(":", 1)
+            m[pat.strip()] = int(b)
+    return m
+
+
+def _is_art_router_tensor(name):
+    return name.startswith("art_router")
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    lowbit_map = _parse_lowbit_map(getattr(h, "lowbit_layers", ""))
+    result = {}
+    meta = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            if (
+                t.is_floating_point()
+                and getattr(h, "art_quant_router_fp32", True)
+                and _is_art_router_tensor(name)
+            ):
+                result[name] = t.to(torch.float32)
+                meta[name] = "passthrough (float32)"
+            else:
+                result[name] = t.to(torch.float16) if t.is_floating_point() else t
+                meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        if "tok_emb" in name:
+            bits = h.embed_bits
+        else:
+            bits = h.matrix_bits
+            for pat, b in lowbit_map.items():
+                if pat in name:
+                    bits = b
+                    break
+        if name not in hessians:
+            raise KeyError(
+                f"Missing GPTQ Hessian for {name}. "
+                "Routed calibration should collect this or fill it via fixed-full fallback."
+            )
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for name, cat in meta.items():
+        short = re.sub(r"\.\d+$", "", re.sub(r"blocks\.\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "brotli":
+        import brotli
+
+        return _byte_unshuffle(brotli.decompress(data))
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def serialize(h, base_model):
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+    return quant_file_bytes
+
+
+def _move_state_to_device(state, device):
+    return {
+        name: tensor.to(device=device, non_blocking=True)
+        if isinstance(tensor, torch.Tensor)
+        else tensor
+        for name, tensor in state.items()
+    }
+
+
+def load_state_exact(model, state, device):
+    state = _move_state_to_device(state, device)
+    try:
+        model.load_state_dict(state, strict=True, assign=True)
+    except TypeError:
+        model.load_state_dict(state, strict=True)
+    restore_fp32_params(model)
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    sd_cpu = {k: v.detach().cpu() for k, v in eval_model.state_dict().items()}
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_state = dequantize_mixed(quant_state["w"], quant_state["m"], sd_cpu)
+    load_state_exact(eval_model, deq_state, device)
+    return eval_model
+
+
+def deserialize_raw_checkpoint(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    raw_state = torch.load(h.model_path, map_location="cpu")
+    load_state_exact(eval_model, raw_state, device)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def compile_target(target, allow_graph_breaks: bool):
+    if _SMOKE_TEST:
+        return target
+    if allow_graph_breaks:
+        # ART routing uses dynamic subset execution. Letting Dynamo graph-break there
+        # recompiles helper frames for per-layer constants until it hits the limit.
+        return target
+    return torch.compile(target, dynamic=False, fullgraph=not allow_graph_breaks)
+
+
+def configure_art_eval_runtime(model, h):
+    if h.num_loops > 0:
+        model.looping_active = True
+    if h.art_halt_enabled:
+        model.art_halt_runtime_active = True
+        model.art_router_entropy_bonus = h.art_router_entropy_end
+        model.art_eval_sample_routes = h.art_eval_sample_routes
+        model.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        model.art_eval_route_threshold = h.art_eval_route_threshold
+        model.art_eval_force_depth = -1
+        # Keep post-serialization eval eager for triple ART. Per-block compiled
+        # routing recompiles across block-local constants and can hit Dynamo's limit.
+        model.use_routed_compiled_blocks = False
+
+
+def compare_model_states(label, reference_model, candidate_model):
+    reference_sd = reference_model.state_dict()
+    candidate_sd = candidate_model.state_dict()
+    missing = sorted(set(reference_sd) ^ set(candidate_sd))
+    dtype_mismatches = 0
+    max_abs = 0.0
+    for name, ref in reference_sd.items():
+        if name not in candidate_sd:
+            continue
+        cand = candidate_sd[name]
+        if ref.dtype != cand.dtype:
+            dtype_mismatches += 1
+        if ref.is_floating_point() or cand.is_floating_point():
+            diff = (
+                ref.detach().float()
+                - cand.detach().to(device=ref.device, dtype=torch.float32)
+            ).abs()
+            max_abs = max(max_abs, float(diff.max().item()) if diff.numel() else 0.0)
+        else:
+            mismatch = ref.detach() != cand.detach().to(device=ref.device)
+            max_abs = max(max_abs, float(mismatch.any().item()))
+    log(
+        f"{label}_state_compare:tensors:{len(reference_sd)} "
+        f"missing:{len(missing)} dtype_mismatches:{dtype_mismatches} "
+        f"max_abs:{max_abs:.9g}"
+    )
+
+
+def format_art_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    continue_sum: float,
+    entropy_sum: float,
+) -> str:
+    if depth_count <= 0:
+        return (
+            f"step:{step}/{total_steps} art_probe "
+            f"window_steps:{window_steps} avg_cycles:none extra_cycle_frac:none "
+            f"avg_stop:none router_entropy:none"
+        )
+    avg_depth = depth_sum / depth_count
+    avg_continue = continue_sum / depth_count
+    avg_stop = 1.0 - avg_continue
+    avg_entropy = entropy_sum / depth_count
+    return (
+        f"step:{step}/{total_steps} art_probe "
+        f"window_steps:{window_steps} avg_cycles:{avg_depth:.3f} "
+        f"extra_cycle_frac:{avg_continue:.3f} avg_stop:{avg_stop:.3f} "
+        f"router_entropy:{avg_entropy:.4f}"
+    )
+
+
+def unwrap_model_for_stats(model):
+    unwrapped = model
+    if hasattr(unwrapped, "module"):
+        unwrapped = unwrapped.module
+    return getattr(unwrapped, "_orig_mod", unwrapped)
+
+
+def format_eval_art_route_stats(label, stats):
+    gates = stats.get("gates") or {}
+    gate_text = ",".join(f"{name}={value:.3f}" for name, value in gates.items())
+    if not gate_text:
+        gate_text = "none"
+    return (
+        f"{label}_art_routes avg_cycles:{stats['avg_cycles']:.3f} "
+        f"extra_cycle_frac:{stats['extra_cycle_frac']:.3f} "
+        f"art_entropy:{stats['entropy']:.4f} art_continue:{gate_text}"
+    )
+
+
+def eval_val(h, device, val_data, model):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_TOKENS must provide at least one sequence per rank; got "
+            f"VAL_BATCH_TOKENS={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, "
+            f"GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_gate_sum = None
+    route_gate_names = None
+    stats_model = unwrap_model_for_stats(model)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            if getattr(h, "art_eval_route_stats", True):
+                art_avg_cycles = getattr(stats_model, "_last_art_avg_cycles_stat", None)
+                art_continue = getattr(
+                    stats_model, "_last_art_continue_rate_stat", None
+                )
+                art_entropy = getattr(
+                    stats_model, "_last_art_router_entropy_stat", None
+                )
+                if (
+                    art_avg_cycles is not None
+                    and art_continue is not None
+                    and art_entropy is not None
+                ):
+                    batch_seq_count = float(x.size(0))
+                    route_depth_sum += (
+                        art_avg_cycles.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_continue_sum += (
+                        art_continue.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_entropy_sum += (
+                        art_entropy.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_count += batch_seq_count
+                    gate_stats = getattr(
+                        stats_model, "_last_art_gate_continue_stats", None
+                    )
+                    if gate_stats is not None:
+                        gate_stats = gate_stats.detach().to(
+                            device=device, dtype=torch.float64
+                        )
+                        if route_gate_sum is None:
+                            route_gate_sum = torch.zeros_like(gate_stats)
+                            route_gate_names = getattr(
+                                stats_model, "art_gate_names", None
+                            )
+                        route_gate_sum += gate_stats * batch_seq_count
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_depth_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_continue_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_entropy_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_count, op=dist.ReduceOp.SUM)
+        if route_gate_sum is not None:
+            dist.all_reduce(route_gate_sum, op=dist.ReduceOp.SUM)
+    h._last_eval_art_route_stats = None
+    if route_count.item() > 0:
+        gates = {}
+        if route_gate_sum is not None:
+            gate_values = (route_gate_sum / route_count.clamp_min(1.0)).detach().cpu()
+            names = route_gate_names or tuple(
+                f"gate{i + 1}" for i in range(int(gate_values.numel()))
+            )
+            gates = {
+                name: float(value)
+                for name, value in zip(names, gate_values.tolist(), strict=False)
+            }
+        h._last_eval_art_route_stats = {
+            "avg_cycles": float((route_depth_sum / route_count).item()),
+            "extra_cycle_frac": float((route_continue_sum / route_count).item()),
+            "entropy": float((route_entropy_sum / route_count).item()),
+            "gates": gates,
+        }
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, batch_seqs=32):
+    base_model.eval()
+    logits_fn = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    seq_len = h.eval_seq_len
+    context_size = seq_len - h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, h.eval_stride)
+        if ws + context_size < total_tokens
+    ]
+    total_windows = len(window_starts)
+    my_s = total_windows * h.rank // h.world_size
+    my_e = total_windows * (h.rank + 1) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens = []
+            for i, ws in enumerate(batch_ws):
+                we = min(ws + seq_len, total_tokens)
+                wlen = we - ws
+                wlens.append(wlen)
+                chunk = val_data.val_tokens[ws : we + 1].to(
+                    dtype=torch.int64, device=device
+                )
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = logits_fn(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else context_size
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (
+                    val_data.has_leading_space_lut[tgt]
+                    & ~val_data.is_boundary_token_lut[prev]
+                ).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def eval_val_ttt(h, device, val_data, base_model, batch_seqs=32):
+    rank = h.rank
+    world_size = h.world_size
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    ttt_chunk = h.ttt_chunk_tokens
+    context_size = seq_len - stride
+    window_starts = [
+        ws for ws in range(0, total_tokens, stride) if ws + context_size < total_tokens
+    ]
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        wlen = min(ws + seq_len, total_tokens) - ws
+        s = 0 if ws == 0 else context_size
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+    total_windows = len(window_starts)
+    log(
+        f"ttt:start chunks={num_chunks} windows={total_windows} "
+        f"ttt_lr={h.ttt_lr} ttt_epochs={h.ttt_epochs}"
+    )
+    compiled_logits = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    _all_ttt_candidates = [p for p in base_model.parameters()]
+    ttt_params = [p for p in _all_ttt_candidates if p.numel() >= 10000]
+    for p in _all_ttt_candidates:
+        p.requires_grad_(p.numel() >= 10000)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.ttt_lr, momentum=h.ttt_momentum, nesterov=True
+    )
+    ttt_start_time = time.perf_counter()
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_should_log = h.ttt_log_every_chunks > 0 and (
+            ci == 0 or (ci + 1) % h.ttt_log_every_chunks == 0 or ci == num_chunks - 1
+        )
+        chunk_t0 = time.perf_counter()
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        my_s = len(windows) * rank // world_size
+        my_e = len(windows) * (rank + 1) // world_size
+        my_windows = windows[my_s:my_e]
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_start "
+                f"windows={len(windows)} local_windows={len(my_windows)}"
+            )
+        base_model.eval()
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi : bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens = []
+                for i, ws in enumerate(batch_ws):
+                    we = min(ws + seq_len, total_tokens)
+                    wlen = we - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_data.val_tokens[ws : we + 1].to(
+                        dtype=torch.int64, device=device
+                    )
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = compiled_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1),
+                    reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else context_size
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (
+                        val_data.has_leading_space_lut[tgt]
+                        & ~val_data.is_boundary_token_lut[prev]
+                    ).to(torch.float64)
+                    byte_count += tb.sum()
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_done "
+                f"elapsed:{time.perf_counter() - chunk_t0:.1f}s"
+            )
+        is_last_chunk = ci == num_chunks - 1
+        if not is_last_chunk and h.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = (
+                    h.ttt_lr
+                    * 0.5
+                    * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                )
+                for pg in optimizer.param_groups:
+                    pg["lr"] = cos_lr
+                my_seq_s = chunk_seqs * rank // world_size
+                my_seq_e = chunk_seqs * (rank + 1) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                if chunk_should_log:
+                    log(
+                        f"ttt:chunk {ci + 1}/{num_chunks} adapt_start "
+                        f"seqs={chunk_seqs} local_seqs={my_chunk_seqs} lr={cos_lr:.6g}"
+                    )
+                for _ep in range(h.ttt_epochs):
+                    epoch_t0 = time.perf_counter()
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_data.val_tokens.numel():
+                            continue
+                        local = val_data.val_tokens[start_tok:end_tok].to(
+                            device=device, dtype=torch.int64
+                        )
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            _lf = base_model.forward_logits(x).reshape(-1, 8192).float()
+                            loss = (
+                                F.cross_entropy(_lf, y.reshape(-1))
+                                + 1e-5 * torch.logsumexp(_lf, dim=-1).pow(2).mean()
+                            )
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+                    if chunk_should_log:
+                        log(
+                            f"ttt:chunk {ci + 1}/{num_chunks} "
+                            f"epoch:{_ep + 1}/{h.ttt_epochs} "
+                            f"elapsed:{time.perf_counter() - epoch_t0:.1f}s"
+                        )
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} done "
+                f"total_elapsed:{time.perf_counter() - ttt_start_time:.1f}s"
+            )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    h = args[0] if args else kwargs.get("h")
+    if h is not None:
+        h._last_eval_art_route_stats = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    stats = getattr(h, "_last_eval_art_route_stats", None) if h is not None else None
+    if stats is not None:
+        log(format_eval_art_route_stats(label, stats))
+    return val_loss, val_bpb
+
+
+def parse_art_eval_mode(mode_spec: str):
+    token = mode_spec.strip().lower()
+    if token in ("sample", "sampled", "stochastic"):
+        return "sample", None, "sample"
+    if token in ("argmax", "greedy", "deterministic"):
+        return "argmax", None, "argmax"
+    if token.startswith("force"):
+        depth_text = token[len("force") :].lstrip("_:= ")
+        if not depth_text:
+            raise ValueError(f"Missing force depth in ART diag mode {mode_spec!r}")
+        depth = int(depth_text)
+        if depth < 0 or depth > 3:
+            raise ValueError(f"ART force depth must be in [0, 3], got {depth}")
+        return "force", depth, f"force{depth}"
+    for prefix in ("threshold", "thresh", "thr"):
+        if token.startswith(prefix):
+            value_text = token[len(prefix) :].lstrip("_:= ")
+            if not value_text:
+                raise ValueError(
+                    f"Missing threshold value in ART diag mode {mode_spec!r}"
+                )
+            threshold = float(value_text)
+            return "threshold", threshold, f"threshold{threshold:g}".replace(".", "p")
+    raise ValueError(f"Unknown ART diag mode {mode_spec!r}")
+
+
+def set_art_eval_mode(model, mode_spec: str):
+    base_model = unwrap_model_for_stats(model)
+    old_state = (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    )
+    mode, value, label = parse_art_eval_mode(mode_spec)
+    base_model.art_eval_route_mode = mode
+    if mode == "threshold":
+        base_model.art_eval_route_threshold = float(value)
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = False
+    elif mode == "force":
+        base_model.art_eval_force_depth = int(value)
+        base_model.art_eval_sample_routes = False
+    else:
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = mode == "sample"
+    return label, old_state
+
+
+def restore_art_eval_mode(model, old_state):
+    base_model = unwrap_model_for_stats(model)
+    (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    ) = old_state
+
+
+def seed_art_diag_eval(h, label):
+    seed = int(h.seed) + 100_000 + sum(ord(ch) for ch in label)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def run_art_quant_diagnostics(stage, h, device, val_data, model):
+    if not (h.art_halt_enabled and h.art_quant_diag_enabled):
+        return
+    modes = [m.strip() for m in h.art_quant_diag_modes.split(",") if m.strip()]
+    if not modes:
+        return
+    log(f"{stage}_quant_diag:start modes={','.join(modes)}")
+    results = getattr(h, "_art_quant_diag_results", {})
+    for mode_spec in modes:
+        label, old_state = set_art_eval_mode(model, mode_spec)
+        try:
+            seed_art_diag_eval(h, label)
+            _, val_bpb = timed_eval(
+                f"{stage}_diag_{label}", eval_val, h, device, val_data, model
+            )
+        finally:
+            restore_art_eval_mode(model, old_state)
+        if stage == "prequant":
+            results[label] = val_bpb
+        elif label in results:
+            pre_bpb = results[label]
+            log(
+                f"quant_diag_delta mode:{label} "
+                f"pre_bpb:{pre_bpb:.8f} post_bpb:{val_bpb:.8f} "
+                f"delta_bpb:{val_bpb - pre_bpb:.8f}"
+            )
+    h._art_quant_diag_results = results
+    log(f"{stage}_quant_diag:done")
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = compile_target(base_model, allow_graph_breaks=False)
+    if _SMOKE_TEST:
+        log("smoke_test: torch.compile disabled (eager mode)")
+    if h.distributed:
+        model = DDP(compiled_model, device_ids=[h.local_rank], broadcast_buffers=False)
+    else:
+        model = compiled_model
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+    log(
+        "router_params:"
+        f"{sum(p.numel() for p in base_model.art_router_first.parameters()) + sum(p.numel() for p in base_model.art_router_early.parameters()) + sum(p.numel() for p in base_model.art_router.parameters())}"
+    )
+    if h.art_halt_enabled:
+        log(
+            "triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; "
+            "fixed triple recurrence activates at ENABLE_LOOPING_AT; "
+            "routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; "
+            f"route_group_size:{h.art_route_group_size} "
+            f"cycle_penalty:{h.art_cycle_penalty:g} "
+            f"shard_coherent_batches:{int(h.art_shard_coherent_batches)}"
+        )
+        log(
+            "triple_art_ropefix_quant:"
+            f"gptq_calibrate_routed:{int(h.art_gptq_calibrate_routed)} "
+            f"router_fp32:{int(h.art_quant_router_fp32)} "
+            f"eval_route_stats:{int(h.art_eval_route_stats)} "
+            f"eval_sample_routes:{int(h.art_eval_sample_routes)} "
+            "reload_diag:raw_checkpoint_state_and_eval "
+            f"ema_reset_on_looping:{int(h.ema_reset_on_looping)} "
+            f"ema_reset_on_art:{int(h.ema_reset_on_art)} "
+            f"entropy_start:{h.art_router_entropy_start:g} "
+            f"entropy_end:{h.art_router_entropy_end:g}"
+        )
+    optimizers = Optimizers(h, base_model)
+    train_loader = ShuffledSequenceLoader(h, device)
+    probe_window_size = max(h.recurrence_probe_every, 1)
+    recent_depth_sums = collections.deque(maxlen=probe_window_size)
+    recent_depth_counts = collections.deque(maxlen=probe_window_size)
+    recent_continue_sums = collections.deque(maxlen=probe_window_size)
+    recent_entropy_sums = collections.deque(maxlen=probe_window_size)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def muon_momentum_frac(elapsed_ms):
+        if h.muon_momentum_warmup_fraction <= 0 or max_wallclock_ms is None:
+            return 1.0
+        warmup_ms = max_wallclock_ms * h.muon_momentum_warmup_fraction
+        return min(elapsed_ms / max(warmup_ms, 1e-9), 1.0)
+
+    def art_router_entropy_value(frac):
+        clamped = min(max(frac, 0.0), 1.0)
+        return (
+            1.0 - clamped
+        ) * h.art_router_entropy_start + clamped * h.art_router_entropy_end
+
+    def step_fn(step, lr_scale, elapsed_ms):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        step_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_gate_continue_sum = None
+        step_art_count = 0.0
+        for micro_step in range(h.grad_accum_steps):
+            if h.distributed:
+                model.require_backward_grad_sync = micro_step == h.grad_accum_steps - 1
+            x, y = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            if (
+                base_model.art_halt_runtime_active
+                and base_model._last_art_avg_cycles_stat is not None
+                and base_model._last_art_continue_rate_stat is not None
+                and base_model._last_art_router_entropy_stat is not None
+            ):
+                step_depth_sum = (
+                    step_depth_sum
+                    + base_model._last_art_avg_cycles_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_continue_sum = (
+                    step_continue_sum
+                    + base_model._last_art_continue_rate_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_entropy_sum = (
+                    step_entropy_sum
+                    + base_model._last_art_router_entropy_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                gate_stats = getattr(base_model, "_last_art_gate_continue_stats", None)
+                if gate_stats is not None:
+                    gate_stats = gate_stats.detach().to(
+                        device=device, dtype=torch.float64
+                    )
+                    if step_gate_continue_sum is None:
+                        step_gate_continue_sum = torch.zeros_like(gate_stats)
+                    step_gate_continue_sum = step_gate_continue_sum + gate_stats
+                step_art_count += 1.0
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac_mm = muon_momentum_frac(elapsed_ms)
+        muon_momentum = (
+            1 - frac_mm
+        ) * h.muon_momentum_warmup_start + frac_mm * h.muon_momentum
+        mm_blend = max(lr_scale, 0.25)
+        muon_momentum = (
+            mm_blend * muon_momentum + (1.0 - mm_blend) * h.muon_momentum_warmup_start
+        )
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step()
+        return (
+            train_loss,
+            step_depth_sum,
+            step_continue_sum,
+            step_entropy_sum,
+            step_gate_continue_sum,
+            step_art_count,
+        )
+
+    def sum_recent_stats(values):
+        total = torch.zeros((), device=device, dtype=torch.float64)
+        for value in values:
+            if isinstance(value, torch.Tensor):
+                total = total + value.detach().to(device=device, dtype=torch.float64)
+            else:
+                total = total + torch.tensor(
+                    float(value), device=device, dtype=torch.float64
+                )
+        return total
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: t.detach().cpu().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0, 0.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0, 0.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        if h.distributed:
+            model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(h, device)
+
+    if h.art_halt_enabled:
+        log("art_halt:warming routed compiled blocks")
+        warm_batch_size = max(
+            1, h.train_batch_tokens // (h.grad_accum_steps * h.train_seq_len)
+        )
+        base_model.warm_routed_compiled_blocks(
+            warm_batch_size, h.train_seq_len, device, torch.bfloat16
+        )
+        optimizers.zero_grad_all()
+        log("art_halt:warmed routed compiled blocks")
+
+    ema_state = {
+        name: t.detach().float().clone() for name, t in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+
+    def reset_ema_state(reason):
+        nonlocal ema_state
+        ema_state = {
+            name: t.detach().float().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        log(f"ema:reset reason:{reason}")
+
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == h.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+        should_validate = last_step or (
+            h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            if _SMOKE_TEST and last_step:
+                break
+            val_loss, val_bpb = eval_val(h, device, val_data, model)
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms "
+                    f"step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} "
+                f"encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            if h.ema_reset_on_looping:
+                reset_ema_state("looping_enabled")
+        if h.art_halt_enabled:
+            base_model.art_router_entropy_bonus = art_router_entropy_value(frac)
+        if (
+            h.art_halt_enabled
+            and base_model.looping_active
+            and not base_model.art_halt_runtime_active
+            and frac >= h.art_halt_enable_at
+        ):
+            base_model.art_halt_runtime_active = True
+            if compiled_model is not base_model:
+                del model
+                torch._dynamo.reset()
+                base_model.prepare_routed_compiled_blocks()
+                base_model.use_routed_compiled_blocks = True
+                compiled_model = base_model
+                if h.distributed:
+                    model = DDP(
+                        base_model, device_ids=[h.local_rank], broadcast_buffers=False
+                    )
+                else:
+                    model = base_model
+                model.train()
+            log(
+                f"art_halt:enabled step:{step} frac:{frac:.3f} "
+                f"entropy_bonus:{base_model.art_router_entropy_bonus:.4f}"
+            )
+            log("art_halt:training switched to eager routers with compiled segments")
+            if h.ema_reset_on_art:
+                reset_ema_state("art_halt_enabled")
+        (
+            train_loss,
+            local_step_depth_sum,
+            local_step_continue_sum,
+            local_step_entropy_sum,
+            local_step_gate_continue_sum,
+            local_step_art_count,
+        ) = step_fn(step, scale, elapsed_ms)
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        if local_step_art_count > 0:
+            recent_depth_sums.append(local_step_depth_sum)
+            recent_depth_counts.append(local_step_art_count)
+            recent_continue_sums.append(local_step_continue_sum)
+            recent_entropy_sums.append(local_step_entropy_sum)
+        should_probe_recurrence = (
+            h.art_halt_enabled
+            and base_model.art_halt_runtime_active
+            and h.recurrence_probe_every > 0
+            and step % h.recurrence_probe_every == 0
+        )
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        step_art_avg_depth = 0.0
+        step_art_avg_continue = 0.0
+        step_art_avg_entropy = 0.0
+        step_art_gate_continue = None
+        if (should_probe_recurrence or should_log_train) and local_step_art_count > 0:
+            step_stats = torch.stack(
+                (
+                    local_step_depth_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_continue_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_entropy_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    torch.tensor(
+                        local_step_art_count, device=device, dtype=torch.float64
+                    ),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_art_avg_depth = float(
+                (step_stats[0] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_continue = float(
+                (step_stats[1] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_entropy = float(
+                (step_stats[2] / step_stats[3].clamp_min(1.0)).item()
+            )
+            if local_step_gate_continue_sum is not None:
+                gate_stats = local_step_gate_continue_sum.detach().to(
+                    device=device, dtype=torch.float64
+                )
+                if h.distributed:
+                    dist.all_reduce(gate_stats, op=dist.ReduceOp.SUM)
+                step_art_gate_continue = (
+                    (gate_stats / step_stats[3].clamp_min(1.0)).detach().cpu()
+                )
+        if should_probe_recurrence:
+            window_stats = torch.stack(
+                (
+                    sum_recent_stats(recent_depth_sums),
+                    sum_recent_stats(recent_depth_counts),
+                    sum_recent_stats(recent_continue_sums),
+                    sum_recent_stats(recent_entropy_sums),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+        if should_log_train:
+            step_avg_ms = approx_training_time_ms / max(step, 1)
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            art_suffix = ""
+            if h.art_halt_enabled and base_model.art_halt_runtime_active:
+                base_model.sync_art_logging_stats()
+                gate_suffix = ""
+                if step_art_gate_continue is not None:
+                    gate_suffix = " art_continue:" + ",".join(
+                        f"{name}={float(value):.3f}"
+                        for name, value in zip(
+                            base_model.art_gate_names,
+                            step_art_gate_continue.tolist(),
+                            strict=False,
+                        )
+                    )
+                art_suffix = (
+                    f" art_cycles:{step_art_avg_depth:.3f}"
+                    f" extra_cycle_frac:{step_art_avg_continue:.3f}"
+                    f"{gate_suffix}"
+                    f" art_entropy:{step_art_avg_entropy:.4f}"
+                    f" art_router_loss:{base_model.last_art_router_loss:.4f}"
+                )
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} "
+                f"train_time: {approx_training_time_ms / 60000:.1f}m "
+                f"step_avg: {step_avg_ms:.2f}ms tok/s: {tok_per_sec:.0f}"
+                f"{art_suffix}"
+            )
+        if (
+            should_probe_recurrence
+            and (not h.distributed or h.rank == 0)
+            and window_stats is not None
+        ):
+            log(
+                format_art_probe_summary(
+                    step,
+                    h.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                )
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+    base_model, compiled_model = train_model(h, device, val_data)
+    if _SMOKE_TEST:
+        log("smoke_test: training complete — running GPTQ+brotli pack for size check")
+        serialize(h, base_model)
+        if h.is_main_process:
+            import sys as _sys
+            from pathlib import Path as _Path
+
+            _proj = _Path(__file__).resolve().parent
+            if str(_proj) not in _sys.path:
+                _sys.path.insert(0, str(_proj))
+            from pack_submission import pack_code as _pack_code
+
+            code_b = len(_pack_code(_Path(__file__).read_text(encoding="utf-8")))
+            model_b = os.path.getsize(h.quantized_model_path)
+            total = code_b + model_b
+            log(f"smoke_pack_bytes: code={code_b} model={model_b} total={total}")
+        log(
+            "smoke_test:complete (code ran successfully; val_bpb not computed in smoke mode)"
+        )
+        return
+    torch._dynamo.reset()
+    timed_eval(
+        "pre-quantization post-ema", eval_val, h, device, val_data, compiled_model
+    )
+    serialize(h, base_model)
+    if h.distributed:
+        dist.barrier()
+    if h.raw_roundtrip_check_enabled:
+        raw_eval_model = deserialize_raw_checkpoint(h, device)
+        configure_art_eval_runtime(raw_eval_model, h)
+        compare_model_states("raw_checkpoint_roundtrip", base_model, raw_eval_model)
+        timed_eval(
+            "raw_checkpoint_roundtrip",
+            eval_val,
+            h,
+            device,
+            val_data,
+            raw_eval_model,
+        )
+        del raw_eval_model
+        torch.cuda.empty_cache()
+    eval_model = deserialize(h, device)
+    configure_art_eval_runtime(eval_model, h)
+    compiled_model = compile_target(eval_model, allow_graph_breaks=h.art_halt_enabled)
+    timed_eval("quantized", eval_val, h, device, val_data, compiled_model)
+    if h.sliding_window_enabled:
+        timed_eval(
+            "quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        configure_art_eval_runtime(ttt_model, h)
+        log("post_quant_ttt:enabled using RoPE reload fix and routed ART eval runtime")
+        timed_eval("quantized_ttt", eval_val_ttt, h, device, val_data, ttt_model)
+        del ttt_model
+    else:
+        log("post_quant_ttt:disabled via TTT_ENABLED=0")
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs("logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        if h.requested_vocab_size != h.vocab_size:
+            log(
+                f"sp8192_override: requested_vocab_size={h.requested_vocab_size} "
+                f"forcing_vocab_size={h.vocab_size}",
+                console=True,
+            )
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    if _SMOKE_TEST:
+        log(f"[SMOKE_TEST] attention_backend=sdpa_fallback  FA3=False  smoke_test=True")
+        log(f"[SMOKE_TEST] val_bpb from this run is NOT comparable to proxy/full runs")
+    log(
+        f"attention_backend:{'flash_attn_3' if _USE_FA3 else 'sdpa_fallback(smoke)'} smoke_test:{_SMOKE_TEST}"
+    )
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1812_art.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1812_art.py
@@ -1,0 +1,3659 @@
+"""PR1812+ART Attempt 1: triple ART RoPE-fix full 8x evaluation recipe."""
+
+from __future__ import annotations
+
+import collections
+import copy
+import datetime
+import glob
+import io
+import math
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+_SMOKE_TEST: bool = bool(int(os.environ.get("SMOKE_TEST", "0")))
+try:
+    if _SMOKE_TEST:
+        raise ImportError("SMOKE_TEST: forcing SDPA fallback")
+    from flash_attn_interface import flash_attn_func as _fa3_impl
+
+    _USE_FA3 = True
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        return _fa3_impl(q, k, v, causal=causal)
+
+except ImportError:
+    _USE_FA3 = False
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        B, T, Hq, D = q.shape
+        Hkv = k.shape[2]
+        q_ = q.permute(0, 2, 1, 3).contiguous()
+        k_ = k.permute(0, 2, 1, 3).contiguous()
+        v_ = v.permute(0, 2, 1, 3).contiguous()
+        if Hkv != Hq:
+            repeat = Hq // Hkv
+            k_ = k_.repeat_interleave(repeat, dim=1)
+            v_ = v_.repeat_interleave(repeat, dim=1)
+        out = F.scaled_dot_product_attention(q_, k_, v_, is_causal=causal)
+        return out.permute(0, 2, 1, 3).contiguous()
+
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start.parent, *start.parents):
+        if (candidate / "experiments").exists() and (candidate / "data").exists():
+            return candidate
+    return start.parent
+
+
+_REPO_ROOT = _find_repo_root(_SCRIPT_PATH)
+
+
+def _unique_paths(paths) -> list[Path]:
+    seen = set()
+    unique = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _is_safe_recursive_search_root(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if resolved == resolved.parent:
+        return False
+    return str(resolved) not in {"/proc", "/sys", "/dev"}
+
+
+def _with_vocab_substitution(raw_path: str, vocab_size: int | None) -> list[str]:
+    paths = [raw_path]
+    if vocab_size is not None:
+        replaced = re.sub(r"fineweb10B_sp\d+", f"fineweb10B_sp{vocab_size}", raw_path)
+        replaced = re.sub(
+            r"fineweb_\d+_bpe\.model", f"fineweb_{vocab_size}_bpe.model", replaced
+        )
+        paths.insert(0, replaced)
+    return list(dict.fromkeys(paths))
+
+
+def _expand_path_candidates(raw_path: str, vocab_size: int | None = None) -> list[Path]:
+    candidates = []
+    for candidate_path in _with_vocab_substitution(raw_path, vocab_size):
+        path = Path(candidate_path).expanduser()
+        if path.is_absolute():
+            candidates.append(path)
+        else:
+            candidates.append((Path.cwd() / path).resolve())
+            candidates.append((_REPO_ROOT / path).resolve())
+    return _unique_paths(candidates)
+
+
+def _data_root_candidates_from_path(path: Path) -> list[Path]:
+    text = str(path)
+    base = path.parent if any(ch in text for ch in "*?[") else path
+    candidates = []
+    if base.name.startswith("fineweb10B_sp") and base.parent.name == "datasets":
+        candidates.append(base.parent.parent)
+    if base.name == "datasets":
+        candidates.append(base.parent)
+    if base.name == "tokenizers":
+        candidates.append(base.parent)
+    if base.parent.name == "tokenizers":
+        candidates.append(base.parent.parent)
+    candidates.append(base)
+    return _unique_paths(candidates)
+
+
+def _path_mentions_other_vocab(path: Path, vocab_size: int) -> bool:
+    text = str(path)
+    for pattern in (r"fineweb10B_sp(\d+)", r"fineweb_(\d+)_bpe\.model"):
+        for match in re.finditer(pattern, text):
+            if int(match.group(1)) != vocab_size:
+                return True
+    return False
+
+
+def _tokenizer_matches_vocab(path: Path, vocab_size: int) -> bool:
+    if not path.exists():
+        return False
+    try:
+        sp = spm.SentencePieceProcessor(model_file=str(path))
+    except Exception:
+        return False
+    return int(sp.vocab_size()) == vocab_size
+
+
+def _candidate_search_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend([path, *path.parents])
+    candidates.extend([_SCRIPT_PATH.parent, *_SCRIPT_PATH.parents])
+    cwd = Path.cwd().resolve()
+    candidates.extend([cwd, *cwd.parents])
+    candidates.extend(
+        [
+            _REPO_ROOT,
+            Path("/workspace"),
+            Path("/workspace/parameter-golf"),
+            Path("/workspace/caseops_data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(
+        [path for path in candidates if _is_safe_recursive_search_root(path)]
+    )
+
+
+def _candidate_data_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend(_data_root_candidates_from_path(path))
+    candidates.extend(
+        [
+            _REPO_ROOT / "data",
+            Path.cwd() / "data",
+            Path("/workspace/parameter-golf/data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(candidates)
+
+
+def _resolve_existing_path(candidates: list[Path]) -> Path | None:
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_data_dir(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> str:
+    candidates = _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _resolve_existing_path(candidates)
+    return str(resolved if resolved is not None else candidates[0])
+
+
+def _resolve_glob_candidates(
+    patterns: list[Path], vocab_size: int | None = None
+) -> Path | None:
+    for pattern in patterns:
+        matches = [Path(path) for path in glob.glob(str(pattern))]
+        if vocab_size is not None:
+            matches = [
+                path
+                for path in matches
+                if not _path_mentions_other_vocab(path, vocab_size)
+            ]
+        if matches:
+            return pattern
+    return None
+
+
+def _search_dataset_pattern(
+    split: str, vocab_size: int, roots: list[Path]
+) -> Path | None:
+    target_dir = f"fineweb10B_sp{vocab_size}"
+    filename = f"fineweb_{split}_*.bin"
+    direct_patterns = []
+    for root in roots:
+        direct_patterns.extend(
+            [
+                root / "data" / "datasets" / target_dir / filename,
+                root / "datasets" / target_dir / filename,
+                root / "dashboard_data" / "smoke_data" / target_dir / filename,
+                root / filename,
+            ]
+        )
+    resolved = _resolve_glob_candidates(
+        _unique_paths(direct_patterns), vocab_size=vocab_size
+    )
+    if resolved is not None:
+        return resolved
+
+    for root in roots:
+        try:
+            recursive = sorted(root.glob(f"**/{target_dir}/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        usable = [path for path in recursive if "_bytes_" not in path.name]
+        if usable:
+            return usable[0].parent / filename
+    return None
+
+
+def _resolve_data_pattern(
+    split: str,
+    vocab_size: int,
+    explicit_pattern: str | None,
+    explicit_data_dir: str | None,
+) -> str:
+    if explicit_pattern:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(explicit_pattern, vocab_size=vocab_size)
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        resolved = _resolve_glob_candidates(explicit_candidates, vocab_size=vocab_size)
+        if resolved is not None:
+            return str(resolved)
+        if explicit_candidates:
+            return str(explicit_candidates[0])
+
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _search_dataset_pattern(split, vocab_size, search_roots)
+    if resolved is not None:
+        return str(resolved)
+
+    candidates = [
+        root / "datasets" / f"fineweb10B_sp{vocab_size}" / f"fineweb_{split}_*.bin"
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if glob.glob(str(candidate)):
+            return str(candidate)
+    return str(candidates[0])
+
+
+def _resolve_tokenizer_path(
+    vocab_size: int, explicit_tokenizer_path: str | None, explicit_data_dir: str | None
+) -> str:
+    if explicit_tokenizer_path:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(
+                explicit_tokenizer_path, vocab_size=vocab_size
+            )
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        for candidate in explicit_candidates:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+    filename = f"fineweb_{vocab_size}_bpe.model"
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    candidates = []
+    for root in search_roots:
+        candidates.extend(
+            [
+                root / "data" / "tokenizers" / filename,
+                root / "tokenizers" / filename,
+            ]
+        )
+    for candidate in _unique_paths(candidates):
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+
+    for root in search_roots:
+        try:
+            recursive = sorted(root.glob(f"**/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        for candidate in recursive:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+
+    candidates = [
+        root / "tokenizers" / filename
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+    return str(_unique_paths(candidates)[0])
+
+
+class Hyperparameters:
+    _ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    _short = uuid.uuid4().hex[:8]
+    run_id = os.environ.get("RUN_ID", f"{_ts}_{_short}")
+    seed = int(os.environ.get("SEED", 1337))
+
+    requested_vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    vocab_size = 8192
+    data_root_hint = os.environ.get("DATA_DIR") or os.environ.get("DATA_PATH")
+    data_dir = _resolve_data_dir(data_root_hint, vocab_size=vocab_size)
+    datasets_dir = os.path.dirname(
+        _resolve_data_pattern(
+            "train",
+            vocab_size,
+            os.environ.get("TRAIN_FILES"),
+            data_root_hint,
+        )
+    )
+    train_files = _resolve_data_pattern(
+        "train",
+        vocab_size,
+        os.environ.get("TRAIN_FILES"),
+        data_root_hint,
+    )
+    val_files = _resolve_data_pattern(
+        "val",
+        vocab_size,
+        os.environ.get("VAL_FILES"),
+        data_root_hint,
+    )
+    tokenizer_path = _resolve_tokenizer_path(
+        vocab_size,
+        os.environ.get("TOKENIZER_PATH"),
+        data_root_hint,
+    )
+
+    iterations = int(os.environ.get("ITERATIONS", 50000))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524_288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.25))
+
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.15))
+    art_halt_enabled = bool(int(os.environ.get("ART_HALT_ENABLED", "1")))
+    art_halt_enable_at = float(os.environ.get("ART_HALT_ENABLE_AT", 0.30))
+    art_router_hidden_dim = int(os.environ.get("ART_ROUTER_HIDDEN_DIM", 64))
+    art_router_lr = float(os.environ.get("ART_ROUTER_LR", 5e-4))
+    art_router_wd = float(os.environ.get("ART_ROUTER_WD", 0.01))
+    art_router_entropy_start = float(os.environ.get("ART_ROUTER_ENTROPY_START", 0.05))
+    art_router_entropy_end = float(os.environ.get("ART_ROUTER_ENTROPY_END", 0.0))
+    art_cycle_penalty = float(os.environ.get("ART_CYCLE_PENALTY", 0.002))
+    art_route_group_size = int(os.environ.get("ART_ROUTE_GROUP_SIZE", 1))
+    art_shard_coherent_batches = bool(
+        int(os.environ.get("ART_SHARD_COHERENT_BATCHES", "0"))
+    )
+    _art_routed_compile_default = (
+        "0" if int(os.environ.get("WORLD_SIZE", "1")) > 1 else "1"
+    )
+    art_routed_compile_enabled = bool(
+        int(os.environ.get("ART_ROUTED_COMPILE_ENABLED", _art_routed_compile_default))
+    )
+    art_gptq_calibrate_routed = bool(
+        int(os.environ.get("ART_GPTQ_CALIBRATE_ROUTED", "0"))
+    )
+    art_quant_router_fp32 = bool(int(os.environ.get("ART_QUANT_ROUTER_FP32", "0")))
+    art_eval_route_stats = bool(int(os.environ.get("ART_EVAL_ROUTE_STATS", "1")))
+    art_eval_sample_routes = bool(int(os.environ.get("ART_EVAL_SAMPLE_ROUTES", "1")))
+    art_eval_route_threshold = float(os.environ.get("ART_EVAL_ROUTE_THRESHOLD", 0.5))
+    art_quant_diag_enabled = bool(int(os.environ.get("ART_QUANT_DIAG_ENABLED", "0")))
+    art_quant_diag_modes = os.environ.get(
+        "ART_QUANT_DIAG_MODES", "sample,argmax,force0,force1,force2,force3"
+    )
+    raw_roundtrip_check_enabled = bool(
+        int(os.environ.get("RAW_ROUNDTRIP_CHECK_ENABLED", "0"))
+    )
+    parallel_residual_start = int(os.environ.get("PARALLEL_RESIDUAL_START", 7))
+
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_fraction = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_FRACTION", 0.22)
+    )
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.005))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    muon_wd_mlp = float(os.environ.get("MUON_WD_MLP", 0.115))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_reset_on_looping = bool(int(os.environ.get("EMA_RESET_ON_LOOPING", "1")))
+    ema_reset_on_art = bool(int(os.environ.get("EMA_RESET_ON_ART", "1")))
+
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.005))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 4))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 65536))
+    ttt_log_every_chunks = int(os.environ.get("TTT_LOG_EVERY_CHUNKS", 1))
+
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 20.0))
+    lowbit_layers = os.environ.get("LOWBIT_LAYERS", "")
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = max(1, 8 // world_size)
+
+    logfile = f"logs/{run_id}.txt"
+    os.makedirs("ckpt", exist_ok=True)
+    model_path = "ckpt/final_model.pt"
+    quantized_model_path = "ckpt/final_model.int6.ptz"
+
+
+if _SMOKE_TEST:
+    Hyperparameters.iterations = int(os.environ.get("ITERATIONS", "30"))
+    Hyperparameters.train_batch_tokens = int(
+        os.environ.get("TRAIN_BATCH_TOKENS", "32768")
+    )
+    Hyperparameters.train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", "512"))
+    Hyperparameters.eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", "512"))
+    Hyperparameters.max_wallclock_seconds = float(
+        os.environ.get("MAX_WALLCLOCK_SECONDS", "120.0")
+    )
+    Hyperparameters.val_batch_tokens = int(
+        os.environ.get("VAL_BATCH_TOKENS", "2097152")
+    )
+    Hyperparameters.warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", "0.2"))
+    Hyperparameters.val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", "0"))
+    Hyperparameters.train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", "5"))
+    Hyperparameters.warmup_steps = int(os.environ.get("WARMUP_STEPS", "0"))
+    Hyperparameters.ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    Hyperparameters.gptq_calibration_batches = int(
+        os.environ.get("GPTQ_CALIBRATION_BATCHES", "2")
+    )
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(f) for f in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for seq_len={seq_len}")
+    return tokens[: usable + 1]
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert sp.piece_to_id("▁") != sp.unk_id(), (
+        "Tokenizer must have '▁' as a token for BPB byte counting"
+    )
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        if not Path(h.tokenizer_path).exists():
+            raise FileNotFoundError(
+                f"Tokenizer model not found: {h.tokenizer_path}. "
+                "Set TOKENIZER_PATH or DATA_DIR/DATA_PATH to a location containing tokenizers/."
+            )
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.base_bytes_lut, self.has_leading_space_lut, self.is_boundary_token_lut = (
+            build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        self.shard_coherent_batches = getattr(h, "art_shard_coherent_batches", False)
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        self._phase_epoch = [0] * len(self.files)
+        self._phase_order = [self.rng.permutation(8).tolist() for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        if max_phase > 0:
+            k = self._phase_order[si][self._phase_epoch[si] % 8]
+            self._phase_epoch[si] += 1
+            phase = min(k * (max_phase + 1) // 8, max_phase)
+        else:
+            phase = 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        num_shards = len(self.files)
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        total = remaining.sum()
+        if total <= 0:
+            for si in range(num_shards):
+                self._reset_shard(si)
+            remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+            total = remaining.sum()
+        target = device_batch_size * remaining / total
+        quotas = np.floor(target).astype(np.int64)
+        leftover = device_batch_size - int(quotas.sum())
+        if leftover > 0:
+            order = np.argsort(-(target - quotas))
+            for i in order[:leftover]:
+                quotas[int(i)] += 1
+        quotas = np.minimum(quotas, remaining.astype(np.int64))
+        shortfall = device_batch_size - int(quotas.sum())
+        if shortfall > 0:
+            extra = remaining.astype(np.int64) - quotas
+            order = np.argsort(-extra)
+            fill = 0
+            while shortfall > 0 and fill < num_shards:
+                j = int(order[fill])
+                if extra[j] > 0:
+                    quotas[j] += 1
+                    extra[j] -= 1
+                    shortfall -= 1
+                else:
+                    fill += 1
+        shard_plan = np.concatenate(
+            [np.full(int(q), s, dtype=np.int64) for s, q in enumerate(quotas)]
+        )
+        if self.shard_coherent_batches:
+            if shard_plan.size > 1:
+                shard_plan = np.roll(
+                    shard_plan, int(self.rng.integers(0, shard_plan.size))
+                )
+        else:
+            self.rng.shuffle(shard_plan)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            si = int(shard_plan[bi])
+            if not self.start_inds[si]:
+                for si2 in range(num_shards):
+                    self._reset_shard(si2)
+            start_ind = self.start_inds[si].pop()
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            base = self.base
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                base = self.base * scale ** (rd / (rd - 2))
+            # Recompute in fp32. The non-persistent buffer is affected by
+            # module-wide bf16 conversion and made fresh reloads non-equivalent.
+            inv_freq = 1.0 / base ** (
+                torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+            )
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads, 2), qk_gain_init, dtype=torch.float32)
+        )
+        self.attn_out_gate_width = 12
+        self.attn_out_gate_w = nn.Parameter(
+            torch.zeros(num_heads, self.attn_out_gate_width, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        rd = self.rope_dims
+        gain = self.q_gain.to(dtype=q.dtype)
+        if 0 < rd < q.size(-1):
+            q_rope = q[..., :rd] * gain[None, None, :, 0:1]
+            q_nope = q[..., rd:] * gain[None, None, :, 1:2]
+            q = torch.cat((q_rope, q_nope), dim=-1)
+        else:
+            q = q * gain[None, None, :, 0:1]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        gate_w = self.attn_out_gate_w.to(dtype=x.dtype)
+        g = 2.0 * torch.sigmoid(F.linear(x[..., : self.attn_out_gate_width], gate_w))
+        y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x):
+        return self.proj(F.silu(self.fc(x)).square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        self.parallel = False
+
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor)
+        if self.parallel:
+            mlp_out = self.mlp(self.mlp_norm(x_in) * self.ln_scale_factor)
+            x_out = (
+                x_in
+                + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+                + self.mlp_scale.to(dtype=x_in.dtype)[None, None, :] * mlp_out
+            )
+        else:
+            x_out = (
+                x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+            )
+            x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+                None, None, :
+            ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+
+class ARTHaltRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, 2)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, features: Tensor) -> Tensor:
+        return self.proj(F.gelu(self.fc(features.float())))
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        self.embed_scale = nn.Parameter(
+            torch.ones(h.embedding_dim, dtype=torch.float32)
+        )
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.rope_train_seq_len,
+                    rope_dims=h.rope_dims,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        if h.parallel_residual_start >= 0:
+            for i in range(h.parallel_residual_start, h.num_layers):
+                self.blocks[i].parallel = True
+        if h.num_loops > 0 and h.ln_scale:
+            loop_scale = 1.0 / math.sqrt(h.num_loops + 1)
+            for i in range(h.loop_start, h.loop_end + 1):
+                self.blocks[i].ln_scale_factor = (
+                    self.blocks[i].ln_scale_factor * loop_scale
+                )
+
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+
+        self.art_halt_enabled = h.art_halt_enabled
+        self.art_halt_runtime_active = False
+        self.art_router_entropy_bonus = h.art_router_entropy_start
+        self.art_cycle_penalty = h.art_cycle_penalty
+        self.art_router_first = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_early = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_continue_idx = 0
+        self.art_router_stop_idx = 1
+        self.art_route_group_size = h.art_route_group_size
+        self.art_eval_sample_routes = h.art_eval_sample_routes
+        self.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        self.art_eval_route_threshold = h.art_eval_route_threshold
+        self.art_eval_force_depth = -1
+        self._art_eval_gate_index = 0
+        self.use_routed_compiled_blocks = False
+        self._routed_compiled_blocks = None
+        self._compiled_art_prefix_dual = None
+        self._compiled_art_tail_dual = None
+        self.last_art_avg_cycles = 3.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_policy_loss = 0.0
+        self.art_gate_names = ("cycle1", "cycle2", "cycle3")
+        self._last_art_log_probs: Tensor | None = None
+        self._last_art_entropies: Tensor | None = None
+        self._last_art_cycles: Tensor | None = None
+        self._last_art_gate_continue_stats: Tensor | None = None
+        self._last_art_avg_cycles_stat: Tensor | None = None
+        self._last_art_continue_rate_stat: Tensor | None = None
+        self._last_art_router_entropy_stat: Tensor | None = None
+        self._last_art_router_loss_stat: Tensor | None = None
+        self._last_art_policy_loss_stat: Tensor | None = None
+        self._art_early_cycle_boundary_encoder_pos = 5
+        self._art_early_encoder_cycle_positions = (6, 7)
+        self._art_late_cycle_boundary_decoder_pos = 0
+        self._art_late_decoder_cycle_positions = (1, 2, 3)
+
+        if self.art_halt_enabled:
+            if (h.num_loops, h.loop_start, h.loop_end) != (2, 3, 5):
+                raise ValueError(
+                    "Triple ART halt requires NUM_LOOPS=2, LOOP_START=3, LOOP_END=5"
+                )
+            expected_encoder = [0, 1, 2, 3, 4, 5, 3, 4]
+            if self.encoder_indices != expected_encoder:
+                raise ValueError(
+                    f"Triple ART halt expects encoder {expected_encoder}, got {self.encoder_indices}"
+                )
+            expected_decoder = [5, 3, 4, 5]
+            if self.decoder_indices[:4] != expected_decoder:
+                raise ValueError(
+                    f"Triple ART halt expects decoder prefix {expected_decoder}, got {self.decoder_indices[:4]}"
+                )
+
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _art_router_features(self, x: Tensor) -> Tensor:
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled), dim=-1)
+
+    def _next_art_eval_gate_index(self) -> int:
+        gate_idx = int(self._art_eval_gate_index)
+        self._art_eval_gate_index = gate_idx + 1
+        return gate_idx
+
+    def _art_eval_action_ids(self, probs: Tensor) -> Tensor:
+        mode = self.art_eval_route_mode
+        if mode == "sample":
+            return torch.multinomial(probs, num_samples=1).squeeze(1)
+        if mode == "threshold":
+            continue_probs = probs[:, self.art_router_continue_idx]
+            return torch.where(
+                continue_probs >= self.art_eval_route_threshold,
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_continue_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_stop_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+            )
+        if mode == "force":
+            continue_gate = self._next_art_eval_gate_index() < self.art_eval_force_depth
+            action_id = (
+                self.art_router_continue_idx
+                if continue_gate
+                else self.art_router_stop_idx
+            )
+            return torch.full(
+                (probs.size(0),), action_id, device=probs.device, dtype=torch.long
+            )
+        return probs.argmax(dim=-1)
+
+    def _art_router_decision(
+        self, router: ARTHaltRouter, x: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        features = self._art_router_features(x)
+        if self.art_route_group_size != 1 and features.size(0) > 1:
+            return self._art_router_decision_grouped(router, features)
+        logits = router(features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            selected_log_probs = log_probs.gather(1, action_ids.unsqueeze(1)).squeeze(1)
+        else:
+            action_ids = self._art_eval_action_ids(probs)
+            selected_log_probs = None
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_decision_grouped(
+        self, router: ARTHaltRouter, features: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        batch_size = features.size(0)
+        group_size = (
+            batch_size
+            if self.art_route_group_size <= 0
+            else min(self.art_route_group_size, batch_size)
+        )
+        num_groups = (batch_size + group_size - 1) // group_size
+        group_ids = torch.arange(batch_size, device=features.device) // group_size
+        if batch_size % group_size == 0:
+            group_features = features.reshape(num_groups, group_size, -1).mean(dim=1)
+        else:
+            group_features = features.new_zeros(num_groups, features.size(-1))
+            group_features.index_add_(0, group_ids, features)
+            group_counts = torch.bincount(group_ids, minlength=num_groups).to(
+                dtype=features.dtype
+            )
+            group_features = group_features / group_counts.clamp_min(1.0).unsqueeze(1)
+
+        logits = router(group_features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        group_entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            group_action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            group_selected_log_probs = log_probs.gather(
+                1, group_action_ids.unsqueeze(1)
+            ).squeeze(1)
+        else:
+            group_action_ids = self._art_eval_action_ids(probs)
+            group_selected_log_probs = None
+
+        action_ids = group_action_ids.index_select(0, group_ids)
+        selected_log_probs = (
+            group_selected_log_probs.index_select(0, group_ids)
+            if group_selected_log_probs is not None
+            else None
+        )
+        entropies = group_entropies.index_select(0, group_ids)
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_anchor(self, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in self.art_router_first.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router_early.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _art_single_router_anchor(self, router: ARTHaltRouter, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _block_param_anchor(
+        self, block_indices: tuple[int, ...], ref: Tensor
+    ) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx in block_indices:
+            for param in self.blocks[block_idx].parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def prepare_routed_compiled_blocks(self) -> None:
+        if _SMOKE_TEST:
+            return
+        if self._routed_compiled_blocks is None:
+            self._routed_compiled_blocks = [
+                torch.compile(block, dynamic=True, fullgraph=True)
+                for block in self.blocks
+            ]
+
+    def _run_block(self, x: Tensor, x0: Tensor, block_idx: int) -> Tensor:
+        if self.use_routed_compiled_blocks and self._routed_compiled_blocks is not None:
+            return self._routed_compiled_blocks[block_idx](x, x0)
+        return self.blocks[block_idx](x, x0)
+
+    def warm_routed_compiled_blocks(
+        self, batch_size: int, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        if _SMOKE_TEST:
+            return
+        self.prepare_routed_compiled_blocks()
+        previous_enabled = self.use_routed_compiled_blocks
+        previous_training = self.training
+        self.use_routed_compiled_blocks = True
+        self.train()
+        dim = int(self.skip_weights.size(1))
+        block_indices = sorted(set(self.encoder_indices + self.decoder_indices))
+        for block_idx in block_indices:
+            x = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            x0 = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            loss = self._run_block(x, x0, block_idx).float().mean()
+            loss.backward()
+            self.zero_grad(set_to_none=True)
+        self.use_routed_compiled_blocks = previous_enabled
+        self.train(previous_training)
+
+    def _project_logits(self, x: Tensor) -> Tensor:
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _forward_art_prefix_triple(self, input_ids: Tensor):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        for i in self.encoder_indices[:3]:
+            x = self._run_block(x, x0, i)
+            skips.append(x)
+        return x, x0, skips[0], skips[1], skips[2]
+
+    def _forward_art_tail_triple(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        s0: Tensor,
+        s1: Tensor,
+        s2: Tensor,
+        first_continue_idx: Tensor,
+        active_s3: Tensor | None,
+    ) -> Tensor:
+        if first_continue_idx.numel() > 0 and active_s3 is not None:
+            scaled_s3 = (
+                self.skip_weights[4].to(dtype=x.dtype)[None, None, :] * active_s3
+            )
+            if first_continue_idx.numel() == x.size(0):
+                x = self._apply_skip(x, scaled_s3, 4)
+            else:
+                full_scaled_s3 = torch.zeros_like(x)
+                full_scaled_s3.index_copy_(0, first_continue_idx, scaled_s3)
+                x = self._apply_skip_subset(x, full_scaled_s3, 4, first_continue_idx)
+        x = self._run_block(x, x0, self.decoder_indices[4])
+        for skip_idx, block_idx, skip in (
+            (5, self.decoder_indices[5], s2),
+            (6, self.decoder_indices[6], s1),
+            (7, self.decoder_indices[7], s0),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :] * skip
+            )
+            x = self._apply_skip(x, scaled_skip, skip_idx)
+            x = self._run_block(x, x0, block_idx)
+        x = self._run_block(x, x0, self.decoder_indices[8])
+        return self._project_logits(x)
+
+    def _forward_logits_trunk_only(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        empty_idx = torch.empty(0, device=x.device, dtype=torch.long)
+        if self.training and torch.is_grad_enabled():
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+            x = x + self._block_param_anchor((3, 4, 5), x).view(1, 1, 1)
+        return self._forward_art_tail_triple(x, x0, s0, s1, s2, empty_idx, None)
+
+    def _forward_logits_art_triple_segmented(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        (
+            first_continue_mask,
+            first_log_probs,
+            first_entropies,
+        ) = self._art_router_decision(self.art_router_first, x)
+        first_continue_idx = first_continue_mask.nonzero(as_tuple=False).flatten()
+        art_cycles = first_continue_mask.to(dtype=torch.float32)
+        art_log_prob_accum = first_log_probs
+        art_entropy_accum = first_entropies
+        active_s3_for_tail = None
+        early_continue_rate = x.new_zeros((), dtype=torch.float32)
+        late_continue_rate = x.new_zeros((), dtype=torch.float32)
+
+        if first_continue_idx.numel() > 0:
+            if first_continue_idx.numel() == x.size(0):
+                active_x = x
+                active_x0 = x0
+            else:
+                active_x = x.index_select(0, first_continue_idx)
+                active_x0 = x0.index_select(0, first_continue_idx)
+
+            active_x, active_s3, active_s4, active_s5 = (
+                self._run_art_first_cycle_active(active_x, active_x0)
+            )
+            active_s3_for_tail = active_s3
+            (
+                early_continue_subset,
+                early_log_probs,
+                early_entropies,
+            ) = self._art_router_decision(self.art_router_early, active_x)
+            early_continue_mask = torch.zeros_like(first_continue_mask)
+            early_continue_mask.index_copy_(
+                0, first_continue_idx, early_continue_subset
+            )
+            early_continue_subset_idx = early_continue_subset.nonzero(
+                as_tuple=False
+            ).flatten()
+            early_continue_rate = early_continue_subset.to(dtype=torch.float32).mean()
+            art_cycles = art_cycles + early_continue_mask.to(dtype=torch.float32)
+            if early_log_probs is not None:
+                if art_log_prob_accum is None:
+                    art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                art_log_prob_accum = art_log_prob_accum.index_copy(
+                    0,
+                    first_continue_idx,
+                    art_log_prob_accum.index_select(0, first_continue_idx)
+                    + early_log_probs,
+                )
+            art_entropy_accum = art_entropy_accum.index_copy(
+                0,
+                first_continue_idx,
+                art_entropy_accum.index_select(0, first_continue_idx) + early_entropies,
+            )
+
+            if early_continue_subset_idx.numel() > 0:
+                second_x = active_x.index_select(0, early_continue_subset_idx)
+                second_x0 = active_x0.index_select(0, early_continue_subset_idx)
+                second_s5 = active_s5.index_select(0, early_continue_subset_idx)
+                second_s4 = active_s4.index_select(0, early_continue_subset_idx)
+                second_x, second_s6 = self._run_art_second_cycle_active(
+                    second_x, second_x0
+                )
+                (
+                    late_continue_subset,
+                    late_log_probs,
+                    late_entropies,
+                ) = self._art_router_decision(self.art_router, second_x)
+                second_continue_idx = first_continue_idx.index_select(
+                    0, early_continue_subset_idx
+                )
+                late_continue_mask = torch.zeros_like(first_continue_mask)
+                late_continue_mask.index_copy_(
+                    0, second_continue_idx, late_continue_subset
+                )
+                late_continue_subset_idx = late_continue_subset.nonzero(
+                    as_tuple=False
+                ).flatten()
+                late_continue_rate = late_continue_subset.to(dtype=torch.float32).mean()
+                art_cycles = art_cycles + late_continue_mask.to(dtype=torch.float32)
+                if late_log_probs is not None:
+                    if art_log_prob_accum is None:
+                        art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_log_prob_accum = art_log_prob_accum.index_copy(
+                        0,
+                        second_continue_idx,
+                        art_log_prob_accum.index_select(0, second_continue_idx)
+                        + late_log_probs,
+                    )
+                art_entropy_accum = art_entropy_accum.index_copy(
+                    0,
+                    second_continue_idx,
+                    art_entropy_accum.index_select(0, second_continue_idx)
+                    + late_entropies,
+                )
+
+                if late_continue_subset_idx.numel() > 0:
+                    if late_continue_subset_idx.numel() == second_x.size(0):
+                        second_x = self._run_art_third_cycle_active(
+                            second_x, second_x0, second_s6, second_s5, second_s4
+                        )
+                    else:
+                        late_x = second_x.index_select(0, late_continue_subset_idx)
+                        late_x0 = second_x0.index_select(0, late_continue_subset_idx)
+                        late_s6 = second_s6.index_select(0, late_continue_subset_idx)
+                        late_s5 = second_s5.index_select(0, late_continue_subset_idx)
+                        late_s4 = second_s4.index_select(0, late_continue_subset_idx)
+                        late_x = self._run_art_third_cycle_active(
+                            late_x, late_x0, late_s6, late_s5, late_s4
+                        )
+                        second_x = second_x.index_copy(
+                            0, late_continue_subset_idx, late_x
+                        )
+                active_x = active_x.index_copy(0, early_continue_subset_idx, second_x)
+            elif self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+            x = self._scatter_subset(x, first_continue_idx, active_x)
+        else:
+            if self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router_early, x).view(
+                    1, 1, 1
+                )
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+
+        self._last_art_log_probs = art_log_prob_accum
+        self._last_art_entropies = art_entropy_accum
+        self._last_art_cycles = art_cycles
+        self._last_art_gate_continue_stats = torch.stack(
+            (
+                first_continue_mask.to(dtype=torch.float32).mean(),
+                early_continue_rate,
+                late_continue_rate,
+            )
+        ).detach()
+        self._last_art_continue_rate_stat = (art_cycles / 3.0).mean().detach()
+        self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+        self._last_art_router_entropy_stat = art_entropy_accum.mean().detach()
+
+        return self._forward_art_tail_triple(
+            x, x0, s0, s1, s2, first_continue_idx, active_s3_for_tail
+        )
+
+    def sync_art_logging_stats(self) -> None:
+        if self._last_art_avg_cycles_stat is not None:
+            self.last_art_avg_cycles = float(self._last_art_avg_cycles_stat.item())
+        if self._last_art_continue_rate_stat is not None:
+            self.last_art_continue_rate = float(
+                self._last_art_continue_rate_stat.item()
+            )
+        if self._last_art_router_entropy_stat is not None:
+            self.last_art_router_entropy = float(
+                self._last_art_router_entropy_stat.item()
+            )
+        if self._last_art_router_loss_stat is not None:
+            self.last_art_router_loss = float(self._last_art_router_loss_stat.item())
+        if self._last_art_policy_loss_stat is not None:
+            self.last_art_policy_loss = float(self._last_art_policy_loss_stat.item())
+
+    def _apply_skip(self, x: Tensor, scaled_skip: Tensor, skip_idx: int) -> Tensor:
+        if self.skip_gates is not None:
+            g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                None, None, :
+            ]
+            return torch.lerp(scaled_skip, x, g)
+        return x + scaled_skip
+
+    def _apply_skip_subset(
+        self,
+        x: Tensor,
+        scaled_skip: Tensor,
+        skip_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._apply_skip(x, scaled_skip, skip_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._apply_skip(
+                x.index_select(0, active_idx),
+                scaled_skip.index_select(0, active_idx),
+                skip_idx,
+            ),
+        )
+        return next_x
+
+    def _scatter_subset(
+        self, x: Tensor, active_idx: Tensor, active_x: Tensor
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return active_x
+        return x.index_copy(0, active_idx, active_x)
+
+    def _run_block_subset(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        block_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._run_block(x, x0, block_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._run_block(
+                x.index_select(0, active_idx),
+                x0.index_select(0, active_idx),
+                block_idx,
+            ),
+        )
+        return next_x
+
+    def _run_art_first_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[3])
+        active_s3 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[4])
+        active_s4 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[5])
+        active_s5 = active_x
+        return active_x, active_s3, active_s4, active_s5
+
+    def _run_art_second_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[6])
+        active_s6 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[7])
+        scaled_skip = (
+            self.skip_weights[0].to(dtype=active_x.dtype)[None, None, :] * active_x
+        )
+        active_x = self._apply_skip(active_x, scaled_skip, 0)
+        active_x = self._run_block(active_x, active_x0, self.decoder_indices[0])
+        return active_x, active_s6
+
+    def _run_art_third_cycle_active(
+        self,
+        active_x: Tensor,
+        active_x0: Tensor,
+        active_s6: Tensor,
+        active_s5: Tensor,
+        active_s4: Tensor,
+    ) -> Tensor:
+        for skip_idx, block_idx, skip in (
+            (1, self.decoder_indices[1], active_s6),
+            (2, self.decoder_indices[2], active_s5),
+            (3, self.decoder_indices[3], active_s4),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=active_x.dtype)[None, None, :]
+                * skip
+            )
+            active_x = self._apply_skip(active_x, scaled_skip, skip_idx)
+            active_x = self._run_block(active_x, active_x0, block_idx)
+        return active_x
+
+    def forward_logits(
+        self, input_ids: Tensor, art_halt_active: bool | None = None
+    ) -> Tensor:
+        art_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+        )
+        art_early_continue_mask: Tensor | None = None
+        art_early_continue_idx: Tensor | None = None
+        art_late_continue_mask: Tensor | None = None
+        art_late_continue_idx: Tensor | None = None
+        art_cycles: Tensor | None = None
+        art_log_prob_accum: Tensor | None = None
+        art_entropy_accum: Tensor | None = None
+        art_early_decision_made = False
+        art_late_decision_made = False
+        self._last_art_log_probs = None
+        self._last_art_entropies = None
+        self._last_art_cycles = None
+        self._last_art_gate_continue_stats = None
+        self._last_art_avg_cycles_stat = None
+        self._last_art_continue_rate_stat = None
+        self._last_art_router_entropy_stat = None
+        self._last_art_router_loss_stat = None
+        self._last_art_policy_loss_stat = None
+        self.last_art_policy_loss = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_avg_cycles = 3.0 if self.looping_active else 0.0
+        if not (self.training and torch.is_grad_enabled()):
+            self._art_eval_gate_index = 0
+        if art_active:
+            return self._forward_logits_art_triple_segmented(input_ids)
+        if not self.looping_active:
+            return self._forward_logits_trunk_only(input_ids)
+
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = self.encoder_indices if self.looping_active else (0, 1, 2)
+        dec_iter = self.decoder_indices if self.looping_active else (6, 7, 8, 9, 10)
+        for enc_pos, i in enumerate(enc_iter):
+            in_early_cycle = (
+                art_active
+                and art_early_decision_made
+                and enc_pos in self._art_early_encoder_cycle_positions
+                and art_early_continue_idx is not None
+            )
+            if in_early_cycle:
+                x = self._run_block_subset(x, x0, i, art_early_continue_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            skips.append(x)
+            if (
+                art_active
+                and not art_early_decision_made
+                and enc_pos == self._art_early_cycle_boundary_encoder_pos
+            ):
+                (
+                    art_early_continue_mask,
+                    selected_log_probs,
+                    entropies,
+                ) = self._art_router_decision(self.art_router_early, x)
+                art_early_continue_idx = art_early_continue_mask.nonzero(
+                    as_tuple=False
+                ).flatten()
+                art_cycles = 1.0 + art_early_continue_mask.to(dtype=torch.float32)
+                if selected_log_probs is not None:
+                    art_log_prob_accum = selected_log_probs
+                art_entropy_accum = entropies
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                self._last_art_router_entropy_stat = entropies.mean().detach()
+                art_early_decision_made = True
+        for skip_idx, i in enumerate(dec_iter):
+            in_second_cycle = (
+                art_active
+                and art_early_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+            )
+            in_late_cycle = (
+                art_active
+                and art_late_decision_made
+                and skip_idx in self._art_late_decoder_cycle_positions
+                and art_late_continue_idx is not None
+            )
+            art_slot_idx = None
+            if in_second_cycle:
+                art_slot_idx = art_early_continue_idx
+            elif in_late_cycle:
+                art_slot_idx = art_late_continue_idx
+            if skip_idx < self.num_skip_weights and skips:
+                scaled_skip = (
+                    self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                    * skips.pop()
+                )
+                if art_slot_idx is not None:
+                    x = self._apply_skip_subset(x, scaled_skip, skip_idx, art_slot_idx)
+                else:
+                    x = self._apply_skip(x, scaled_skip, skip_idx)
+            if art_slot_idx is not None:
+                x = self._run_block_subset(x, x0, i, art_slot_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            if (
+                art_active
+                and art_early_decision_made
+                and not art_late_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+                and art_cycles is not None
+            ):
+                active_idx = art_early_continue_idx
+                art_late_continue_mask = torch.zeros_like(art_early_continue_mask)
+                if active_idx.numel() > 0:
+                    (
+                        late_continue_subset,
+                        selected_log_probs,
+                        entropies,
+                    ) = self._art_router_decision(
+                        self.art_router, x.index_select(0, active_idx)
+                    )
+                    art_late_continue_mask.index_copy_(
+                        0, active_idx, late_continue_subset
+                    )
+                    late_continue_subset_idx = late_continue_subset.nonzero(
+                        as_tuple=False
+                    ).flatten()
+                    art_late_continue_idx = active_idx.index_select(
+                        0, late_continue_subset_idx
+                    )
+                    art_cycles = art_cycles + art_late_continue_mask.to(
+                        dtype=torch.float32
+                    )
+                    if selected_log_probs is not None:
+                        if art_log_prob_accum is None:
+                            art_log_prob_accum = x.new_zeros(
+                                x.size(0), dtype=torch.float32
+                            )
+                        art_log_prob_accum = art_log_prob_accum.index_copy(
+                            0,
+                            active_idx,
+                            art_log_prob_accum.index_select(0, active_idx)
+                            + selected_log_probs,
+                        )
+                    if art_entropy_accum is None:
+                        art_entropy_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_entropy_accum = art_entropy_accum.index_copy(
+                        0,
+                        active_idx,
+                        art_entropy_accum.index_select(0, active_idx) + entropies,
+                    )
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                if art_entropy_accum is not None:
+                    self._last_art_router_entropy_stat = (
+                        art_entropy_accum.mean().detach()
+                    )
+                art_late_decision_made = True
+
+        x = self.final_norm(x)
+        if (
+            not art_early_decision_made
+            and not art_late_decision_made
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        art_halt_active: bool | None = None,
+    ) -> Tensor:
+        logits = self.forward_logits(input_ids, art_halt_active=art_halt_active)
+        art_loss_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if not art_loss_active:
+            return F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                target_ids.reshape(-1),
+                reduction="mean",
+            )
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        seq_losses = token_losses.mean(dim=1)
+        main_loss = seq_losses.mean()
+        total_loss = main_loss
+        router_policy_loss = main_loss.new_zeros(())
+        router_loss = main_loss.new_zeros(())
+        if (
+            self.art_halt_enabled
+            and self.art_halt_runtime_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_art_log_probs is not None
+            and self._last_art_entropies is not None
+            and self._last_art_cycles is not None
+        ):
+            router_costs = (
+                seq_losses.detach() + self.art_cycle_penalty * self._last_art_cycles
+            )
+            advantages = router_costs - router_costs.mean()
+            router_policy_loss = (advantages * self._last_art_log_probs).mean()
+            router_mean_entropy = self._last_art_entropies.mean()
+            router_loss = (
+                router_policy_loss - self.art_router_entropy_bonus * router_mean_entropy
+            )
+            total_loss = total_loss + router_loss
+        self._last_art_policy_loss_stat = router_policy_loss.detach()
+        self._last_art_router_loss_stat = router_loss.detach()
+        if (
+            self._last_art_entropies is not None
+            and self._last_art_entropies.numel() > 0
+        ):
+            self._last_art_router_entropy_stat = (
+                self._last_art_entropies.mean().detach()
+            )
+        return total_loss
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = (
+                            g.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                        )
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,attn_out_gate",
+    ).split(",")
+    if pattern
+)
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        block_named_params = list(base_model.blocks.named_parameters())
+        matrix_attn_params = []
+        matrix_mlp_params = []
+        for name, p in block_named_params:
+            if p.ndim != 2 or any(
+                pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS
+            ):
+                continue
+            if ".mlp." in name:
+                matrix_mlp_params.append(p)
+            else:
+                matrix_attn_params.append(p)
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if hasattr(base_model, "embed_scale"):
+            scalar_params.append(base_model.embed_scale)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            [
+                {"params": matrix_attn_params, "weight_decay": h.muon_wd},
+                {"params": matrix_mlp_params, "weight_decay": h.muon_wd_mlp},
+            ],
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if h.art_halt_enabled:
+            router_params = (
+                list(base_model.art_router_first.parameters())
+                + list(base_model.art_router_early.parameters())
+                + list(base_model.art_router.parameters())
+            )
+            self.optimizer_art_router = torch.optim.AdamW(
+                [
+                    {
+                        "params": router_params,
+                        "lr": h.art_router_lr,
+                        "base_lr": h.art_router_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                weight_decay=h.art_router_wd,
+                fused=True,
+            )
+            self.optimizers.append(self.optimizer_art_router)
+        else:
+            self.optimizer_art_router = None
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def step(self):
+        for opt in self.optimizers:
+            opt.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, (CastedLinear, ARTHaltRouter)):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hessian_divisors = {}
+    expected_hessian_names = []
+    hooks = []
+    capture_names = None
+    capture_divisor = max(int(n_calibration_batches), 1)
+    previous_routed_blocks = getattr(model, "use_routed_compiled_blocks", None)
+    previous_looping_active = getattr(model, "looping_active", None)
+    previous_art_runtime_active = getattr(model, "art_halt_runtime_active", None)
+    previous_training = model.training
+
+    def make_hook(name):
+        def hook_fn(module, inp, out):
+            if capture_names is not None and name not in capture_names:
+                return
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+                hessian_divisors[name] = capture_divisor
+            hessians[name].addmm_(x.T, x)
+
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > 65536:
+            cat = classify_param(name + ".weight")
+            if cat in ("mlp", "attn"):
+                hessian_name = name + ".weight"
+                expected_hessian_names.append(hessian_name)
+                hooks.append(module.register_forward_hook(make_hook(hessian_name)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                if capture_names is not None and name not in capture_names:
+                    return
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                    hessian_divisors[name] = capture_divisor
+                hessians[name].addmm_(x.T, x)
+
+            return hook_fn
+
+        expected_hessian_names.append("tok_emb.weight")
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+
+    def run_calibration_pass(num_batches, routed_art):
+        nonlocal capture_divisor
+        capture_divisor = max(int(num_batches), 1)
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = False
+        if previous_looping_active is not None:
+            model.looping_active = True
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = bool(routed_art)
+        with torch.no_grad():
+            for _ in range(num_batches):
+                x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+                model.forward_logits(x)
+
+    routed_calibration = bool(
+        h.art_halt_enabled and getattr(h, "art_gptq_calibrate_routed", True)
+    )
+    model.eval()
+    try:
+        if routed_calibration:
+            log("GPTQ:calibration path routed_art")
+            run_calibration_pass(n_calibration_batches, routed_art=True)
+            missing = sorted(set(expected_hessian_names) - set(hessians))
+            if missing:
+                fallback_batches = max(4, min(n_calibration_batches, 16))
+                log(
+                    "GPTQ:routed calibration missed "
+                    f"{len(missing)} tensors; fallback fixed_full batches={fallback_batches}"
+                )
+                capture_names = set(missing)
+                run_calibration_pass(fallback_batches, routed_art=False)
+                capture_names = None
+        else:
+            log("GPTQ:calibration path fixed_full")
+            run_calibration_pass(n_calibration_batches, routed_art=False)
+    finally:
+        capture_names = None
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = previous_routed_blocks
+        if previous_looping_active is not None:
+            model.looping_active = previous_looping_active
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = previous_art_runtime_active
+        model.train(previous_training)
+        for hook in hooks:
+            hook.remove()
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / max(float(hessian_divisors[name]), 1.0)
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=32):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    H.diagonal().mul_(1.01)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _parse_lowbit_map(spec):
+    m = {}
+    for item in (spec or "").split(","):
+        item = item.strip()
+        if item:
+            pat, b = item.rsplit(":", 1)
+            m[pat.strip()] = int(b)
+    return m
+
+
+def _is_art_router_tensor(name):
+    return name.startswith("art_router")
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    lowbit_map = _parse_lowbit_map(getattr(h, "lowbit_layers", ""))
+    result = {}
+    meta = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            if (
+                t.is_floating_point()
+                and getattr(h, "art_quant_router_fp32", True)
+                and _is_art_router_tensor(name)
+            ):
+                result[name] = t.to(torch.float32)
+                meta[name] = "passthrough (float32)"
+            else:
+                result[name] = t.to(torch.float16) if t.is_floating_point() else t
+                meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        if "tok_emb" in name:
+            bits = h.embed_bits
+        else:
+            bits = h.matrix_bits
+            for pat, b in lowbit_map.items():
+                if pat in name:
+                    bits = b
+                    break
+        if name not in hessians:
+            raise KeyError(
+                f"Missing GPTQ Hessian for {name}. "
+                "Routed calibration should collect this or fill it via fixed-full fallback."
+            )
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for name, cat in meta.items():
+        short = re.sub(r"\.\d+$", "", re.sub(r"blocks\.\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "brotli":
+        import brotli
+
+        return _byte_unshuffle(brotli.decompress(data))
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def serialize(h, base_model):
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+    return quant_file_bytes
+
+
+def _move_state_to_device(state, device):
+    return {
+        name: tensor.to(device=device, non_blocking=True)
+        if isinstance(tensor, torch.Tensor)
+        else tensor
+        for name, tensor in state.items()
+    }
+
+
+def load_state_exact(model, state, device):
+    state = _move_state_to_device(state, device)
+    try:
+        model.load_state_dict(state, strict=True, assign=True)
+    except TypeError:
+        model.load_state_dict(state, strict=True)
+    restore_fp32_params(model)
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    sd_cpu = {k: v.detach().cpu() for k, v in eval_model.state_dict().items()}
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_state = dequantize_mixed(quant_state["w"], quant_state["m"], sd_cpu)
+    load_state_exact(eval_model, deq_state, device)
+    return eval_model
+
+
+def deserialize_raw_checkpoint(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    raw_state = torch.load(h.model_path, map_location="cpu")
+    load_state_exact(eval_model, raw_state, device)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def compile_target(target, allow_graph_breaks: bool):
+    if _SMOKE_TEST:
+        return target
+    if allow_graph_breaks:
+        # ART routing uses dynamic subset execution. Letting Dynamo graph-break there
+        # recompiles helper frames for per-layer constants until it hits the limit.
+        return target
+    return torch.compile(target, dynamic=False, fullgraph=not allow_graph_breaks)
+
+
+def configure_art_eval_runtime(model, h):
+    if h.num_loops > 0:
+        model.looping_active = True
+    if h.art_halt_enabled:
+        model.art_halt_runtime_active = True
+        model.art_router_entropy_bonus = h.art_router_entropy_end
+        model.art_eval_sample_routes = h.art_eval_sample_routes
+        model.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        model.art_eval_route_threshold = h.art_eval_route_threshold
+        model.art_eval_force_depth = -1
+        # Keep post-serialization eval eager for triple ART. Per-block compiled
+        # routing recompiles across block-local constants and can hit Dynamo's limit.
+        model.use_routed_compiled_blocks = False
+
+
+def compare_model_states(label, reference_model, candidate_model):
+    reference_sd = reference_model.state_dict()
+    candidate_sd = candidate_model.state_dict()
+    missing = sorted(set(reference_sd) ^ set(candidate_sd))
+    dtype_mismatches = 0
+    max_abs = 0.0
+    for name, ref in reference_sd.items():
+        if name not in candidate_sd:
+            continue
+        cand = candidate_sd[name]
+        if ref.dtype != cand.dtype:
+            dtype_mismatches += 1
+        if ref.is_floating_point() or cand.is_floating_point():
+            diff = (
+                ref.detach().float()
+                - cand.detach().to(device=ref.device, dtype=torch.float32)
+            ).abs()
+            max_abs = max(max_abs, float(diff.max().item()) if diff.numel() else 0.0)
+        else:
+            mismatch = ref.detach() != cand.detach().to(device=ref.device)
+            max_abs = max(max_abs, float(mismatch.any().item()))
+    log(
+        f"{label}_state_compare:tensors:{len(reference_sd)} "
+        f"missing:{len(missing)} dtype_mismatches:{dtype_mismatches} "
+        f"max_abs:{max_abs:.9g}"
+    )
+
+
+def format_art_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    continue_sum: float,
+    entropy_sum: float,
+) -> str:
+    if depth_count <= 0:
+        return (
+            f"step:{step}/{total_steps} art_probe "
+            f"window_steps:{window_steps} avg_cycles:none extra_cycle_frac:none "
+            f"avg_stop:none router_entropy:none"
+        )
+    avg_depth = depth_sum / depth_count
+    avg_continue = continue_sum / depth_count
+    avg_stop = 1.0 - avg_continue
+    avg_entropy = entropy_sum / depth_count
+    return (
+        f"step:{step}/{total_steps} art_probe "
+        f"window_steps:{window_steps} avg_cycles:{avg_depth:.3f} "
+        f"extra_cycle_frac:{avg_continue:.3f} avg_stop:{avg_stop:.3f} "
+        f"router_entropy:{avg_entropy:.4f}"
+    )
+
+
+def unwrap_model_for_stats(model):
+    unwrapped = model
+    if hasattr(unwrapped, "module"):
+        unwrapped = unwrapped.module
+    return getattr(unwrapped, "_orig_mod", unwrapped)
+
+
+def format_eval_art_route_stats(label, stats):
+    gates = stats.get("gates") or {}
+    gate_text = ",".join(f"{name}={value:.3f}" for name, value in gates.items())
+    if not gate_text:
+        gate_text = "none"
+    return (
+        f"{label}_art_routes avg_cycles:{stats['avg_cycles']:.3f} "
+        f"extra_cycle_frac:{stats['extra_cycle_frac']:.3f} "
+        f"art_entropy:{stats['entropy']:.4f} art_continue:{gate_text}"
+    )
+
+
+def eval_val(h, device, val_data, model):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_TOKENS must provide at least one sequence per rank; got "
+            f"VAL_BATCH_TOKENS={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, "
+            f"GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_gate_sum = None
+    route_gate_names = None
+    stats_model = unwrap_model_for_stats(model)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            if getattr(h, "art_eval_route_stats", True):
+                art_avg_cycles = getattr(stats_model, "_last_art_avg_cycles_stat", None)
+                art_continue = getattr(
+                    stats_model, "_last_art_continue_rate_stat", None
+                )
+                art_entropy = getattr(
+                    stats_model, "_last_art_router_entropy_stat", None
+                )
+                if (
+                    art_avg_cycles is not None
+                    and art_continue is not None
+                    and art_entropy is not None
+                ):
+                    batch_seq_count = float(x.size(0))
+                    route_depth_sum += (
+                        art_avg_cycles.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_continue_sum += (
+                        art_continue.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_entropy_sum += (
+                        art_entropy.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_count += batch_seq_count
+                    gate_stats = getattr(
+                        stats_model, "_last_art_gate_continue_stats", None
+                    )
+                    if gate_stats is not None:
+                        gate_stats = gate_stats.detach().to(
+                            device=device, dtype=torch.float64
+                        )
+                        if route_gate_sum is None:
+                            route_gate_sum = torch.zeros_like(gate_stats)
+                            route_gate_names = getattr(
+                                stats_model, "art_gate_names", None
+                            )
+                        route_gate_sum += gate_stats * batch_seq_count
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_depth_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_continue_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_entropy_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_count, op=dist.ReduceOp.SUM)
+        if route_gate_sum is not None:
+            dist.all_reduce(route_gate_sum, op=dist.ReduceOp.SUM)
+    h._last_eval_art_route_stats = None
+    if route_count.item() > 0:
+        gates = {}
+        if route_gate_sum is not None:
+            gate_values = (route_gate_sum / route_count.clamp_min(1.0)).detach().cpu()
+            names = route_gate_names or tuple(
+                f"gate{i + 1}" for i in range(int(gate_values.numel()))
+            )
+            gates = {
+                name: float(value)
+                for name, value in zip(names, gate_values.tolist(), strict=False)
+            }
+        h._last_eval_art_route_stats = {
+            "avg_cycles": float((route_depth_sum / route_count).item()),
+            "extra_cycle_frac": float((route_continue_sum / route_count).item()),
+            "entropy": float((route_entropy_sum / route_count).item()),
+            "gates": gates,
+        }
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, batch_seqs=32):
+    base_model.eval()
+    logits_fn = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    seq_len = h.eval_seq_len
+    context_size = seq_len - h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, h.eval_stride)
+        if ws + context_size < total_tokens
+    ]
+    total_windows = len(window_starts)
+    my_s = total_windows * h.rank // h.world_size
+    my_e = total_windows * (h.rank + 1) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens = []
+            for i, ws in enumerate(batch_ws):
+                we = min(ws + seq_len, total_tokens)
+                wlen = we - ws
+                wlens.append(wlen)
+                chunk = val_data.val_tokens[ws : we + 1].to(
+                    dtype=torch.int64, device=device
+                )
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = logits_fn(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else context_size
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (
+                    val_data.has_leading_space_lut[tgt]
+                    & ~val_data.is_boundary_token_lut[prev]
+                ).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def eval_val_ttt(h, device, val_data, base_model, batch_seqs=32):
+    rank = h.rank
+    world_size = h.world_size
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    ttt_chunk = h.ttt_chunk_tokens
+    context_size = seq_len - stride
+    window_starts = [
+        ws for ws in range(0, total_tokens, stride) if ws + context_size < total_tokens
+    ]
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        wlen = min(ws + seq_len, total_tokens) - ws
+        s = 0 if ws == 0 else context_size
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+    total_windows = len(window_starts)
+    log(
+        f"ttt:start chunks={num_chunks} windows={total_windows} "
+        f"ttt_lr={h.ttt_lr} ttt_epochs={h.ttt_epochs}"
+    )
+    compiled_logits = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    _all_ttt_candidates = [p for p in base_model.parameters()]
+    ttt_params = [p for p in _all_ttt_candidates if p.numel() >= 10000]
+    for p in _all_ttt_candidates:
+        p.requires_grad_(p.numel() >= 10000)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.ttt_lr, momentum=h.ttt_momentum, nesterov=True
+    )
+    ttt_start_time = time.perf_counter()
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_should_log = h.ttt_log_every_chunks > 0 and (
+            ci == 0 or (ci + 1) % h.ttt_log_every_chunks == 0 or ci == num_chunks - 1
+        )
+        chunk_t0 = time.perf_counter()
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        my_s = len(windows) * rank // world_size
+        my_e = len(windows) * (rank + 1) // world_size
+        my_windows = windows[my_s:my_e]
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_start "
+                f"windows={len(windows)} local_windows={len(my_windows)}"
+            )
+        base_model.eval()
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi : bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens = []
+                for i, ws in enumerate(batch_ws):
+                    we = min(ws + seq_len, total_tokens)
+                    wlen = we - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_data.val_tokens[ws : we + 1].to(
+                        dtype=torch.int64, device=device
+                    )
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = compiled_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1),
+                    reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else context_size
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (
+                        val_data.has_leading_space_lut[tgt]
+                        & ~val_data.is_boundary_token_lut[prev]
+                    ).to(torch.float64)
+                    byte_count += tb.sum()
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_done "
+                f"elapsed:{time.perf_counter() - chunk_t0:.1f}s"
+            )
+        is_last_chunk = ci == num_chunks - 1
+        if not is_last_chunk and h.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = (
+                    h.ttt_lr
+                    * 0.5
+                    * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                )
+                for pg in optimizer.param_groups:
+                    pg["lr"] = cos_lr
+                my_seq_s = chunk_seqs * rank // world_size
+                my_seq_e = chunk_seqs * (rank + 1) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                if chunk_should_log:
+                    log(
+                        f"ttt:chunk {ci + 1}/{num_chunks} adapt_start "
+                        f"seqs={chunk_seqs} local_seqs={my_chunk_seqs} lr={cos_lr:.6g}"
+                    )
+                for _ep in range(h.ttt_epochs):
+                    epoch_t0 = time.perf_counter()
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_data.val_tokens.numel():
+                            continue
+                        local = val_data.val_tokens[start_tok:end_tok].to(
+                            device=device, dtype=torch.int64
+                        )
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            _lf = base_model.forward_logits(x).reshape(-1, 8192).float()
+                            loss = (
+                                F.cross_entropy(_lf, y.reshape(-1))
+                                + 1e-5 * torch.logsumexp(_lf, dim=-1).pow(2).mean()
+                            )
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+                    if chunk_should_log:
+                        log(
+                            f"ttt:chunk {ci + 1}/{num_chunks} "
+                            f"epoch:{_ep + 1}/{h.ttt_epochs} "
+                            f"elapsed:{time.perf_counter() - epoch_t0:.1f}s"
+                        )
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} done "
+                f"total_elapsed:{time.perf_counter() - ttt_start_time:.1f}s"
+            )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    h = args[0] if args else kwargs.get("h")
+    if h is not None:
+        h._last_eval_art_route_stats = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    stats = getattr(h, "_last_eval_art_route_stats", None) if h is not None else None
+    if stats is not None:
+        log(format_eval_art_route_stats(label, stats))
+    return val_loss, val_bpb
+
+
+def parse_art_eval_mode(mode_spec: str):
+    token = mode_spec.strip().lower()
+    if token in ("sample", "sampled", "stochastic"):
+        return "sample", None, "sample"
+    if token in ("argmax", "greedy", "deterministic"):
+        return "argmax", None, "argmax"
+    if token.startswith("force"):
+        depth_text = token[len("force") :].lstrip("_:= ")
+        if not depth_text:
+            raise ValueError(f"Missing force depth in ART diag mode {mode_spec!r}")
+        depth = int(depth_text)
+        if depth < 0 or depth > 3:
+            raise ValueError(f"ART force depth must be in [0, 3], got {depth}")
+        return "force", depth, f"force{depth}"
+    for prefix in ("threshold", "thresh", "thr"):
+        if token.startswith(prefix):
+            value_text = token[len(prefix) :].lstrip("_:= ")
+            if not value_text:
+                raise ValueError(
+                    f"Missing threshold value in ART diag mode {mode_spec!r}"
+                )
+            threshold = float(value_text)
+            return "threshold", threshold, f"threshold{threshold:g}".replace(".", "p")
+    raise ValueError(f"Unknown ART diag mode {mode_spec!r}")
+
+
+def set_art_eval_mode(model, mode_spec: str):
+    base_model = unwrap_model_for_stats(model)
+    old_state = (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    )
+    mode, value, label = parse_art_eval_mode(mode_spec)
+    base_model.art_eval_route_mode = mode
+    if mode == "threshold":
+        base_model.art_eval_route_threshold = float(value)
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = False
+    elif mode == "force":
+        base_model.art_eval_force_depth = int(value)
+        base_model.art_eval_sample_routes = False
+    else:
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = mode == "sample"
+    return label, old_state
+
+
+def restore_art_eval_mode(model, old_state):
+    base_model = unwrap_model_for_stats(model)
+    (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    ) = old_state
+
+
+def seed_art_diag_eval(h, label):
+    seed = int(h.seed) + 100_000 + sum(ord(ch) for ch in label)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def run_art_quant_diagnostics(stage, h, device, val_data, model):
+    if not (h.art_halt_enabled and h.art_quant_diag_enabled):
+        return
+    modes = [m.strip() for m in h.art_quant_diag_modes.split(",") if m.strip()]
+    if not modes:
+        return
+    log(f"{stage}_quant_diag:start modes={','.join(modes)}")
+    results = getattr(h, "_art_quant_diag_results", {})
+    for mode_spec in modes:
+        label, old_state = set_art_eval_mode(model, mode_spec)
+        try:
+            seed_art_diag_eval(h, label)
+            _, val_bpb = timed_eval(
+                f"{stage}_diag_{label}", eval_val, h, device, val_data, model
+            )
+        finally:
+            restore_art_eval_mode(model, old_state)
+        if stage == "prequant":
+            results[label] = val_bpb
+        elif label in results:
+            pre_bpb = results[label]
+            log(
+                f"quant_diag_delta mode:{label} "
+                f"pre_bpb:{pre_bpb:.8f} post_bpb:{val_bpb:.8f} "
+                f"delta_bpb:{val_bpb - pre_bpb:.8f}"
+            )
+    h._art_quant_diag_results = results
+    log(f"{stage}_quant_diag:done")
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = compile_target(base_model, allow_graph_breaks=False)
+    if _SMOKE_TEST:
+        log("smoke_test: torch.compile disabled (eager mode)")
+    if h.distributed:
+        model = DDP(compiled_model, device_ids=[h.local_rank], broadcast_buffers=False)
+    else:
+        model = compiled_model
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+    log(
+        "router_params:"
+        f"{sum(p.numel() for p in base_model.art_router_first.parameters()) + sum(p.numel() for p in base_model.art_router_early.parameters()) + sum(p.numel() for p in base_model.art_router.parameters())}"
+    )
+    if h.art_halt_enabled:
+        log(
+            "triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; "
+            "fixed triple recurrence activates at ENABLE_LOOPING_AT; "
+            "routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; "
+            f"route_group_size:{h.art_route_group_size} "
+            f"cycle_penalty:{h.art_cycle_penalty:g} "
+            f"shard_coherent_batches:{int(h.art_shard_coherent_batches)}"
+        )
+        log(
+            "triple_art_ropefix_quant:"
+            f"gptq_calibrate_routed:{int(h.art_gptq_calibrate_routed)} "
+            f"router_fp32:{int(h.art_quant_router_fp32)} "
+            f"eval_route_stats:{int(h.art_eval_route_stats)} "
+            f"eval_sample_routes:{int(h.art_eval_sample_routes)} "
+            f"routed_compile:{int(h.art_routed_compile_enabled)} "
+            "reload_diag:raw_checkpoint_state_and_eval "
+            f"ema_reset_on_looping:{int(h.ema_reset_on_looping)} "
+            f"ema_reset_on_art:{int(h.ema_reset_on_art)} "
+            f"entropy_start:{h.art_router_entropy_start:g} "
+            f"entropy_end:{h.art_router_entropy_end:g}"
+        )
+    optimizers = Optimizers(h, base_model)
+    train_loader = ShuffledSequenceLoader(h, device)
+    probe_window_size = max(h.recurrence_probe_every, 1)
+    recent_depth_sums = collections.deque(maxlen=probe_window_size)
+    recent_depth_counts = collections.deque(maxlen=probe_window_size)
+    recent_continue_sums = collections.deque(maxlen=probe_window_size)
+    recent_entropy_sums = collections.deque(maxlen=probe_window_size)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def muon_momentum_frac(elapsed_ms):
+        if h.muon_momentum_warmup_fraction <= 0 or max_wallclock_ms is None:
+            return 1.0
+        warmup_ms = max_wallclock_ms * h.muon_momentum_warmup_fraction
+        return min(elapsed_ms / max(warmup_ms, 1e-9), 1.0)
+
+    def art_router_entropy_value(frac):
+        clamped = min(max(frac, 0.0), 1.0)
+        return (
+            1.0 - clamped
+        ) * h.art_router_entropy_start + clamped * h.art_router_entropy_end
+
+    def step_fn(step, lr_scale, elapsed_ms):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        step_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_gate_continue_sum = None
+        step_art_count = 0.0
+        for micro_step in range(h.grad_accum_steps):
+            if h.distributed:
+                model.require_backward_grad_sync = micro_step == h.grad_accum_steps - 1
+            x, y = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            if (
+                base_model.art_halt_runtime_active
+                and base_model._last_art_avg_cycles_stat is not None
+                and base_model._last_art_continue_rate_stat is not None
+                and base_model._last_art_router_entropy_stat is not None
+            ):
+                step_depth_sum = (
+                    step_depth_sum
+                    + base_model._last_art_avg_cycles_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_continue_sum = (
+                    step_continue_sum
+                    + base_model._last_art_continue_rate_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_entropy_sum = (
+                    step_entropy_sum
+                    + base_model._last_art_router_entropy_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                gate_stats = getattr(base_model, "_last_art_gate_continue_stats", None)
+                if gate_stats is not None:
+                    gate_stats = gate_stats.detach().to(
+                        device=device, dtype=torch.float64
+                    )
+                    if step_gate_continue_sum is None:
+                        step_gate_continue_sum = torch.zeros_like(gate_stats)
+                    step_gate_continue_sum = step_gate_continue_sum + gate_stats
+                step_art_count += 1.0
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac_mm = muon_momentum_frac(elapsed_ms)
+        muon_momentum = (
+            1 - frac_mm
+        ) * h.muon_momentum_warmup_start + frac_mm * h.muon_momentum
+        mm_blend = max(lr_scale, 0.25)
+        muon_momentum = (
+            mm_blend * muon_momentum + (1.0 - mm_blend) * h.muon_momentum_warmup_start
+        )
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step()
+        return (
+            train_loss,
+            step_depth_sum,
+            step_continue_sum,
+            step_entropy_sum,
+            step_gate_continue_sum,
+            step_art_count,
+        )
+
+    def sum_recent_stats(values):
+        total = torch.zeros((), device=device, dtype=torch.float64)
+        for value in values:
+            if isinstance(value, torch.Tensor):
+                total = total + value.detach().to(device=device, dtype=torch.float64)
+            else:
+                total = total + torch.tensor(
+                    float(value), device=device, dtype=torch.float64
+                )
+        return total
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: t.detach().cpu().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0, 0.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0, 0.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        if h.distributed:
+            model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(h, device)
+
+    if h.art_halt_enabled and h.art_routed_compile_enabled:
+        log("art_halt:warming routed compiled blocks")
+        warm_batch_size = max(
+            1,
+            h.train_batch_tokens
+            // (h.world_size * h.grad_accum_steps * h.train_seq_len),
+        )
+        base_model.warm_routed_compiled_blocks(
+            warm_batch_size, h.train_seq_len, device, torch.bfloat16
+        )
+        optimizers.zero_grad_all()
+        log("art_halt:warmed routed compiled blocks")
+    elif h.art_halt_enabled:
+        log("art_halt:routed compiled blocks disabled for distributed stability")
+
+    ema_state = {
+        name: t.detach().float().clone() for name, t in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+
+    def reset_ema_state(reason):
+        nonlocal ema_state
+        ema_state = {
+            name: t.detach().float().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        log(f"ema:reset reason:{reason}")
+
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == h.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+        should_validate = last_step or (
+            h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            if _SMOKE_TEST and last_step:
+                break
+            val_loss, val_bpb = eval_val(h, device, val_data, model)
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms "
+                    f"step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        enable_loop_now = (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        )
+        if h.distributed and h.num_loops > 0 and not base_model.looping_active:
+            flag = torch.tensor(int(enable_loop_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_loop_now = bool(flag.item())
+        if enable_loop_now:
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} "
+                f"encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            if h.ema_reset_on_looping:
+                reset_ema_state("looping_enabled")
+        if h.art_halt_enabled:
+            base_model.art_router_entropy_bonus = art_router_entropy_value(frac)
+        enable_art_now = (
+            h.art_halt_enabled
+            and base_model.looping_active
+            and not base_model.art_halt_runtime_active
+            and frac >= h.art_halt_enable_at
+        )
+        if (
+            h.distributed
+            and h.art_halt_enabled
+            and base_model.looping_active
+            and not base_model.art_halt_runtime_active
+        ):
+            flag = torch.tensor(int(enable_art_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_art_now = bool(flag.item())
+        if enable_art_now:
+            base_model.art_halt_runtime_active = True
+            if compiled_model is not base_model:
+                del model
+                if h.art_routed_compile_enabled:
+                    base_model.prepare_routed_compiled_blocks()
+                    base_model.use_routed_compiled_blocks = True
+                else:
+                    base_model.use_routed_compiled_blocks = False
+                compiled_model = base_model
+                if h.distributed:
+                    model = DDP(
+                        base_model, device_ids=[h.local_rank], broadcast_buffers=False
+                    )
+                else:
+                    model = base_model
+                model.train()
+            log(
+                f"art_halt:enabled step:{step} frac:{frac:.3f} "
+                f"entropy_bonus:{base_model.art_router_entropy_bonus:.4f}"
+            )
+            log(
+                "art_halt:training switched to eager routers "
+                f"routed_compile:{int(h.art_routed_compile_enabled)}"
+            )
+            if h.ema_reset_on_art:
+                reset_ema_state("art_halt_enabled")
+        (
+            train_loss,
+            local_step_depth_sum,
+            local_step_continue_sum,
+            local_step_entropy_sum,
+            local_step_gate_continue_sum,
+            local_step_art_count,
+        ) = step_fn(step, scale, elapsed_ms)
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        if local_step_art_count > 0:
+            recent_depth_sums.append(local_step_depth_sum)
+            recent_depth_counts.append(local_step_art_count)
+            recent_continue_sums.append(local_step_continue_sum)
+            recent_entropy_sums.append(local_step_entropy_sum)
+        should_probe_recurrence = (
+            h.art_halt_enabled
+            and base_model.art_halt_runtime_active
+            and h.recurrence_probe_every > 0
+            and step % h.recurrence_probe_every == 0
+        )
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        step_art_avg_depth = 0.0
+        step_art_avg_continue = 0.0
+        step_art_avg_entropy = 0.0
+        step_art_gate_continue = None
+        if (should_probe_recurrence or should_log_train) and local_step_art_count > 0:
+            step_stats = torch.stack(
+                (
+                    local_step_depth_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_continue_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_entropy_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    torch.tensor(
+                        local_step_art_count, device=device, dtype=torch.float64
+                    ),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_art_avg_depth = float(
+                (step_stats[0] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_continue = float(
+                (step_stats[1] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_entropy = float(
+                (step_stats[2] / step_stats[3].clamp_min(1.0)).item()
+            )
+            if local_step_gate_continue_sum is not None:
+                gate_stats = local_step_gate_continue_sum.detach().to(
+                    device=device, dtype=torch.float64
+                )
+                if h.distributed:
+                    dist.all_reduce(gate_stats, op=dist.ReduceOp.SUM)
+                step_art_gate_continue = (
+                    (gate_stats / step_stats[3].clamp_min(1.0)).detach().cpu()
+                )
+        if should_probe_recurrence:
+            window_stats = torch.stack(
+                (
+                    sum_recent_stats(recent_depth_sums),
+                    sum_recent_stats(recent_depth_counts),
+                    sum_recent_stats(recent_continue_sums),
+                    sum_recent_stats(recent_entropy_sums),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+        if should_log_train:
+            step_avg_ms = approx_training_time_ms / max(step, 1)
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            art_suffix = ""
+            if h.art_halt_enabled and base_model.art_halt_runtime_active:
+                base_model.sync_art_logging_stats()
+                gate_suffix = ""
+                if step_art_gate_continue is not None:
+                    gate_suffix = " art_continue:" + ",".join(
+                        f"{name}={float(value):.3f}"
+                        for name, value in zip(
+                            base_model.art_gate_names,
+                            step_art_gate_continue.tolist(),
+                            strict=False,
+                        )
+                    )
+                art_suffix = (
+                    f" art_cycles:{step_art_avg_depth:.3f}"
+                    f" extra_cycle_frac:{step_art_avg_continue:.3f}"
+                    f"{gate_suffix}"
+                    f" art_entropy:{step_art_avg_entropy:.4f}"
+                    f" art_router_loss:{base_model.last_art_router_loss:.4f}"
+                )
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} "
+                f"train_time: {approx_training_time_ms / 60000:.1f}m "
+                f"step_avg: {step_avg_ms:.2f}ms tok/s: {tok_per_sec:.0f}"
+                f"{art_suffix}"
+            )
+        if (
+            should_probe_recurrence
+            and (not h.distributed or h.rank == 0)
+            and window_stats is not None
+        ):
+            log(
+                format_art_probe_summary(
+                    step,
+                    h.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                )
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+    base_model, compiled_model = train_model(h, device, val_data)
+    if _SMOKE_TEST:
+        log("smoke_test: training complete — running GPTQ+brotli pack for size check")
+        serialize(h, base_model)
+        if h.is_main_process:
+            import sys as _sys
+            from pathlib import Path as _Path
+
+            _proj = _Path(__file__).resolve().parent
+            if str(_proj) not in _sys.path:
+                _sys.path.insert(0, str(_proj))
+            from pack_submission import pack_code as _pack_code
+
+            code_b = len(_pack_code(_Path(__file__).read_text(encoding="utf-8")))
+            model_b = os.path.getsize(h.quantized_model_path)
+            total = code_b + model_b
+            log(f"smoke_pack_bytes: code={code_b} model={model_b} total={total}")
+        log(
+            "smoke_test:complete (code ran successfully; val_bpb not computed in smoke mode)"
+        )
+        return
+    torch._dynamo.reset()
+    timed_eval(
+        "pre-quantization post-ema", eval_val, h, device, val_data, compiled_model
+    )
+    serialize(h, base_model)
+    if h.distributed:
+        dist.barrier()
+    if h.raw_roundtrip_check_enabled:
+        raw_eval_model = deserialize_raw_checkpoint(h, device)
+        configure_art_eval_runtime(raw_eval_model, h)
+        compare_model_states("raw_checkpoint_roundtrip", base_model, raw_eval_model)
+        timed_eval(
+            "raw_checkpoint_roundtrip",
+            eval_val,
+            h,
+            device,
+            val_data,
+            raw_eval_model,
+        )
+        del raw_eval_model
+        torch.cuda.empty_cache()
+    eval_model = deserialize(h, device)
+    configure_art_eval_runtime(eval_model, h)
+    compiled_model = compile_target(eval_model, allow_graph_breaks=h.art_halt_enabled)
+    timed_eval("quantized", eval_val, h, device, val_data, compiled_model)
+    if h.sliding_window_enabled:
+        timed_eval(
+            "quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        configure_art_eval_runtime(ttt_model, h)
+        log("post_quant_ttt:enabled using RoPE reload fix and routed ART eval runtime")
+        timed_eval("quantized_ttt", eval_val_ttt, h, device, val_data, ttt_model)
+        del ttt_model
+    else:
+        log("post_quant_ttt:disabled via TTT_ENABLED=0")
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs("logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        if h.requested_vocab_size != h.vocab_size:
+            log(
+                f"sp8192_override: requested_vocab_size={h.requested_vocab_size} "
+                f"forcing_vocab_size={h.vocab_size}",
+                console=True,
+            )
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    if _SMOKE_TEST:
+        log(f"[SMOKE_TEST] attention_backend=sdpa_fallback  FA3=False  smoke_test=True")
+        log(f"[SMOKE_TEST] val_bpb from this run is NOT comparable to proxy/full runs")
+    log(
+        f"attention_backend:{'flash_attn_3' if _USE_FA3 else 'sdpa_fallback(smoke)'} smoke_test:{_SMOKE_TEST}"
+    )
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1855_simple_art.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1855_simple_art.py
@@ -1,0 +1,4010 @@
+import base64, collections, copy, fcntl, glob, io, lzma, math, os
+from pathlib import Path
+import random, re, subprocess, sys, time, uuid, numpy as np, sentencepiece as spm, torch, torch.distributed as dist, torch.nn.functional as F
+from torch import Tensor, nn
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+    flash_attn_varlen_func,
+)
+from concurrent.futures import ThreadPoolExecutor
+import triton
+import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+
+# ===== Fused softcapped cross-entropy (Triton) — training-only path =====
+# Replaces the eager
+#     logits_softcap = softcap * tanh(logits / softcap)
+#     F.cross_entropy(logits_softcap.float(), targets, reduction="mean")
+# sequence with a single fused kernel that reads logits_proj once, applies
+# softcap in-register, and computes (LSE, loss) in one streaming pass. The
+# backward kernel mirrors the forward so there's no stored softcapped logits.
+# Numerically identical to the eager path up to fp32 accumulation differences.
+_FUSED_CE_LIBRARY = "pgsubmission1draft7fusedce"
+_FUSED_CE_BLOCK_SIZE = 1024
+_FUSED_CE_NUM_WARPS = 4
+
+
+@triton.jit
+def _softcapped_ce_fwd_kernel(
+    logits_ptr, losses_ptr, lse_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    max_val = -float("inf")
+    sum_exp = 0.0
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=-float("inf"),
+        ).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C)
+        z = tl.where(mask, z, -float("inf"))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(tl.exp(z - new_max), axis=0)
+        max_val = new_max
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    target_val = tl.load(logits_row_ptr + target * stride_logits_v).to(tl.float32)
+    target_z = A * tl.sigmoid(target_val * inv_C)
+    tl.store(losses_ptr + row_idx, lse - target_z)
+
+
+@triton.jit
+def _softcapped_ce_bwd_kernel(
+    grad_logits_ptr, grad_losses_ptr, lse_ptr, logits_ptr, targets_ptr,
+    stride_logits_n, stride_logits_v,
+    stride_grad_n, stride_grad_v,
+    n_rows, n_cols, softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_logits_ptr + row_idx * stride_grad_n
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_losses_ptr + row_idx).to(tl.float32)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    dz_dx_scale = A * inv_C
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask, other=0.0,
+        ).to(tl.float32)
+        sigmoid_u = tl.sigmoid(val * inv_C)
+        z = A * sigmoid_u
+        probs = tl.exp(z - lse)
+        grad_z = grad_loss * (probs - tl.where(cols == target, 1.0, 0.0))
+        grad_x = grad_z * (dz_dx_scale * sigmoid_u * (1.0 - sigmoid_u))
+        tl.store(grad_row_ptr + cols * stride_grad_v, grad_x, mask=mask)
+
+
+def _validate_softcapped_ce_inputs(
+    logits: Tensor, targets: Tensor, softcap: float,
+) -> tuple[Tensor, Tensor]:
+    if logits.ndim != 2:
+        raise ValueError(f"Expected logits.ndim=2, got {logits.ndim}")
+    if targets.ndim != 1:
+        raise ValueError(f"Expected targets.ndim=1, got {targets.ndim}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    if not logits.is_cuda or not targets.is_cuda:
+        raise ValueError("softcapped_cross_entropy requires CUDA tensors")
+    if softcap <= 0.0:
+        raise ValueError(f"softcap must be positive, got {softcap}")
+    if logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    logits = logits.contiguous()
+    targets = targets.contiguous()
+    if targets.dtype != torch.int64:
+        targets = targets.to(dtype=torch.int64)
+    return logits, targets
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce", mutates_args=())
+def softcapped_ce_op(logits: Tensor, targets: Tensor, softcap: float) -> tuple[Tensor, Tensor]:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    n_rows, n_cols = logits.shape
+    losses = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    lse = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    _softcapped_ce_fwd_kernel[(n_rows,)](
+        logits, losses, lse, targets,
+        logits.stride(0), logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return losses, lse
+
+
+@softcapped_ce_op.register_fake
+def _(logits: Tensor, targets: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1:
+        raise ValueError("softcapped_ce fake impl expects 2D logits and 1D targets")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    n_rows = logits.shape[0]
+    return (
+        logits.new_empty((n_rows,), dtype=torch.float32),
+        logits.new_empty((n_rows,), dtype=torch.float32),
+    )
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce_backward", mutates_args=())
+def softcapped_ce_backward_op(
+    logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float,
+) -> Tensor:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    lse = lse.contiguous()
+    grad_losses = grad_losses.contiguous().to(dtype=torch.float32)
+    if lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("Expected 1D lse and grad_losses")
+    if lse.shape[0] != logits.shape[0] or grad_losses.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"Expected row-aligned lse/grad_losses, got logits={tuple(logits.shape)} "
+            f"lse={tuple(lse.shape)} grad_losses={tuple(grad_losses.shape)}"
+        )
+    grad_logits = torch.empty_like(logits)
+    n_rows, n_cols = logits.shape
+    _softcapped_ce_bwd_kernel[(n_rows,)](
+        grad_logits, grad_losses, lse, logits, targets,
+        logits.stride(0), logits.stride(1),
+        grad_logits.stride(0), grad_logits.stride(1),
+        n_rows, n_cols, float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE, num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return grad_logits
+
+
+@softcapped_ce_backward_op.register_fake
+def _(logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1 or lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("softcapped_ce_backward fake impl expects 2D logits and 1D row tensors")
+    if (
+        logits.shape[0] != targets.shape[0]
+        or logits.shape[0] != lse.shape[0]
+        or logits.shape[0] != grad_losses.shape[0]
+    ):
+        raise ValueError("softcapped_ce_backward fake impl expects row-aligned tensors")
+    return logits.new_empty(logits.shape)
+
+
+def _softcapped_ce_setup_context(
+    ctx: torch.autograd.function.FunctionCtx, inputs, output,
+) -> None:
+    logits, targets, softcap = inputs
+    _losses, lse = output
+    ctx.save_for_backward(logits, targets, lse)
+    ctx.softcap = float(softcap)
+
+
+def _softcapped_ce_backward(
+    ctx: torch.autograd.function.FunctionCtx, grad_losses: Tensor, grad_lse: "Tensor | None",
+):
+    del grad_lse
+    logits, targets, lse = ctx.saved_tensors
+    grad_logits = torch.ops.pgsubmission1draft7fusedce.softcapped_ce_backward(
+        logits, targets, lse, grad_losses, ctx.softcap
+    )
+    return grad_logits, None, None
+
+
+softcapped_ce_op.register_autograd(
+    _softcapped_ce_backward, setup_context=_softcapped_ce_setup_context,
+)
+
+
+def softcapped_cross_entropy(
+    logits: Tensor, targets: Tensor, softcap: float, reduction: str = "mean",
+) -> Tensor:
+    losses, _lse = torch.ops.pgsubmission1draft7fusedce.softcapped_ce(
+        logits, targets, float(softcap)
+    )
+    if reduction == "none":
+        return losses
+    if reduction == "sum":
+        return losses.sum()
+    if reduction == "mean":
+        return losses.mean()
+    raise ValueError(f"Unsupported reduction={reduction!r}")
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    # Fused softcapped CE (Triton). Training-only — forward_logits eval path still uses
+    # eager softcap+F.cross_entropy. Default ON since validated as at-worst neutral.
+    fused_ce_enabled = bool(int(os.environ.get("FUSED_CE_ENABLED", "1")))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    # Simple ART branch control for the record recurrence. After the normal
+    # loop phase has activated, one tiny router samples whether this batch uses
+    # the short record path or the full path with the extra six 3-4-5 blocks.
+    art_simple_enabled = bool(int(os.environ.get("ART_SIMPLE_ENABLED", "1")))
+    art_simple_enable_at = float(os.environ.get("ART_SIMPLE_ENABLE_AT", "0.45"))
+    art_router_hidden_dim = int(os.environ.get("ART_ROUTER_HIDDEN_DIM", "64"))
+    art_router_lr = float(os.environ.get("ART_ROUTER_LR", "0.0005"))
+    art_router_wd = float(os.environ.get("ART_ROUTER_WD", "0.01"))
+    art_router_entropy_start = float(os.environ.get("ART_ROUTER_ENTROPY_START", "0.02"))
+    art_router_entropy_end = float(os.environ.get("ART_ROUTER_ENTROPY_END", "0.002"))
+    art_cycle_penalty = float(os.environ.get("ART_CYCLE_PENALTY", "0.002"))
+    art_baseline_decay = float(os.environ.get("ART_BASELINE_DECAY", "0.98"))
+    art_eval_mode = os.environ.get("ART_EVAL_MODE", "sample")
+    art_probe_every = int(os.environ.get("ART_PROBE_EVERY", "50"))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_activate_at = float(os.environ.get("EMA_ACTIVATE_AT", "0.55"))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 1.0))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 1))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0))
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1")))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 10.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    # AttnOutGate (per-head multiplicative output gate, PR #1667 MarioPaerle).
+    # Zero-init weight: 2*sigmoid(0)=1 -> transparent at start. Source defaults to
+    # block input x ('proj'); 'q' uses raw Q projection output.
+    attn_out_gate_enabled = bool(int(os.environ.get("ATTN_OUT_GATE_ENABLED", "0")))
+    attn_out_gate_src = os.environ.get("ATTN_OUT_GATE_SRC", "proj")
+    # SmearGate (input-dependent forward-1 token smear, modded-nanogpt @classiclarryd
+    # via PR #1667). x_t <- x_t + lam * sigmoid(W*x_t[:gate_window]) * x_{t-1}.
+    # lam=0 + W=0 -> transparent at init.
+    smear_gate_enabled = bool(int(os.environ.get("SMEAR_GATE_ENABLED", "0")))
+    # Window: first GATE_WINDOW dims of the source feed the gate projection.
+    gate_window = int(os.environ.get("GATE_WINDOW", 12))
+    # Gated Attention (Qwen, NeurIPS 2025 Best Paper, arXiv:2505.06708;
+    # qiuzh20/gated_attention). Per-head sigmoid gate on SDPA output, BEFORE
+    # out_proj. Gate input = full block input x (paper's headwise G1 variant
+    # driven from hidden_states). W_g shape (num_heads, dim), plain sigmoid.
+    # Near-zero init gives g~0.5 at step 0 (half attention output); per-block
+    # attn_scale (init 1.0) compensates during training. Name contains
+    # "attn_gate" so CONTROL_TENSOR_NAME_PATTERNS routes it to scalar AdamW.
+    gated_attn_enabled = bool(int(os.environ.get("GATED_ATTN_ENABLED", "0")))
+    gated_attn_init_std = float(os.environ.get("GATED_ATTN_INIT_STD", 0.01))
+    # Dedicated int8-per-row quantization for `attn_gate_w` tensors. These are
+    # small ((num_heads, dim) = (8, 512) = 4096 params) and bypass GPTQ via the
+    # numel<=65536 passthrough branch -> stored as fp16 (8 KB/layer, ~65 KB total
+    # compressed). int8-per-row cuts the raw tensor in half with negligible BPB
+    # impact: scales per head (8 values), symmetric quant over [-127, 127].
+    # No Hessian needed (gate weights not in collect_hessians()).
+    gated_attn_quant_gate = bool(int(os.environ.get("GATED_ATTN_QUANT_GATE", "0")))
+    # Sparse Attention Gate (modded-nanogpt-style). Keeps dense SDPA and only
+    # swaps the output-gate input to the first GATE_WINDOW residual dims.
+    # W_g: (num_heads, gate_window) = (8, 12) = 96 params/layer (~44K total),
+    # vs dense GatedAttn's (8, 512) = 4K/layer (~44K diff). Name "attn_gate_w"
+    # is shared so quant routing and int8 gate passthrough Just Work. Gate
+    # passthrough int8 still applies via GATED_ATTN_QUANT_GATE=1.
+    # Mutually exclusive with ATTN_OUT_GATE_ENABLED and GATED_ATTN_ENABLED.
+    sparse_attn_gate_enabled = bool(int(os.environ.get("SPARSE_ATTN_GATE_ENABLED", "0")))
+    sparse_attn_gate_init_std = float(os.environ.get("SPARSE_ATTN_GATE_INIT_STD", 0.0))
+    sparse_attn_gate_scale = float(os.environ.get("SPARSE_ATTN_GATE_SCALE", 1.0))
+    # LQER asymmetric rank-k correction on top-K quant-error tensors (PR #1530 v2 port).
+    # Computes SVD of E = W_fp - W_quant, packs top-r A,B as INT2/INT4 (asym) or INTk (sym).
+    lqer_enabled = bool(int(os.environ.get("LQER_ENABLED", "1")))
+    lqer_rank = int(os.environ.get("LQER_RANK", 4))
+    lqer_top_k = int(os.environ.get("LQER_TOP_K", 3))
+    lqer_factor_bits = int(os.environ.get("LQER_FACTOR_BITS", 4))
+    lqer_asym_enabled = bool(int(os.environ.get("LQER_ASYM_ENABLED", "1")))
+    lqer_asym_group = int(os.environ.get("LQER_ASYM_GROUP", "64"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    # CaseOps integration: optional override of dataset root + tokenizer path.
+    # When CASEOPS_ENABLED=1, the wrapper loads a per-token byte sidecar
+    # (fineweb_val_bytes_*.bin, identical shard layout to val_*.bin) and uses
+    # it as the canonical raw-byte budget for BPB accounting. The sidecar
+    # REPLACES the build_sentencepiece_luts byte-counting path entirely.
+    caseops_enabled = bool(int(os.environ.get("CASEOPS_ENABLED", "0")))
+    _default_caseops_data = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "datasets",
+        "fineweb10B_sp8192_lossless_caps_caseops_v1_reserved",
+    )
+    _default_caseops_tok = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "tokenizers",
+        "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model",
+    )
+    if caseops_enabled:
+        datasets_dir = os.environ.get("DATA_PATH", _default_caseops_data)
+        tokenizer_path = os.environ.get("TOKENIZER_PATH", _default_caseops_tok)
+    else:
+        datasets_dir = os.environ.get(
+            "DATA_PATH",
+            os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}"),
+        )
+        tokenizer_path = os.environ.get(
+            "TOKENIZER_PATH",
+            os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"),
+        )
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    val_bytes_files = os.path.join(datasets_dir, "fineweb_val_bytes_*.bin")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        (
+            self.base_bytes_lut,
+            self.has_leading_space_lut,
+            self.is_boundary_token_lut,
+        ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        # CaseOps: when enabled, load per-token byte sidecar and stash it as a
+        # CPU tensor aligned 1:1 with self.val_tokens. eval_val/eval_val_ttt
+        # branches use this as the canonical raw-byte budget per token.
+        self.caseops_enabled = bool(getattr(h, "caseops_enabled", False))
+        self.val_bytes = None
+        if self.caseops_enabled:
+            self.val_bytes = load_validation_byte_sidecar(
+                h.val_bytes_files, h.eval_seq_len, self.val_tokens.numel()
+            )
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert (
+        sp.piece_to_id("▁") != sp.unk_id()
+    ), "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    # Filter out CaseOps byte sidecar shards which share the val_*.bin glob.
+    files = [
+        Path(p)
+        for p in sorted(glob.glob(pattern))
+        if "_bytes_" not in Path(p).name
+    ]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_byte_sidecar(pattern, seq_len, expected_len):
+    """Load CaseOps per-token byte sidecar(s). Same shard layout as token shards
+    (256 int32 header + uint16 array). Each entry = canonical raw-text byte
+    budget for that token in the corresponding val shard. Returns a CPU
+    int16 tensor sliced to match expected_len (i.e. val_tokens length)."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No byte sidecar files for pattern: {pattern}")
+    shards = [load_data_shard(file) for file in files]
+    # load_data_shard returns uint16 — that's exactly what the sidecar stores.
+    bytes_full = torch.cat(shards).contiguous()
+    if bytes_full.numel() < expected_len:
+        raise ValueError(
+            f"Byte sidecar too short: {bytes_full.numel()} < val_tokens {expected_len}"
+        )
+    return bytes_full[:expected_len].to(torch.int32)
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._next_batch = None
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = buf[:-1].to(dtype=torch.int64).pin_memory()
+        targets = buf[1:].to(dtype=torch.int64).pin_memory()
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        if self._next_batch is not None:
+            inputs, targets, cu_seqlens, max_seqlen = self._next_batch.result()
+        else:
+            inputs, targets, cu_seqlens, max_seqlen = self._prepare_batch(
+                num_tokens_local, self.max_seq_len
+            )
+        self._next_batch = self._batch_pool.submit(
+            self._prepare_batch, num_tokens_local, self.max_seq_len
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 128, 256, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[:, :seq_len].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=True,
+        attn_out_gate=False, attn_out_gate_src="proj", gate_window=12,
+        gated_attn=False, gated_attn_init_std=0.01,
+        sparse_attn_gate=False, sparse_attn_gate_init_std=0.0, sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        if int(attn_out_gate) + int(gated_attn) + int(sparse_attn_gate) > 1:
+            raise ValueError(
+                "attn_out_gate, gated_attn, and sparse_attn_gate are mutually exclusive"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn)
+        self.use_xsa = False
+        # AttnOutGate (PR #1667 MarioPaerle): per-head multiplicative gate on attention
+        # output. CastedLinear so restore_fp32_params casts back to fp32 for GPTQ.
+        # _zero_init -> 2*sigmoid(0)=1 -> transparent at init.
+        self.attn_out_gate = attn_out_gate
+        self.attn_out_gate_src = attn_out_gate_src
+        self.gate_window = gate_window
+        if attn_out_gate:
+            self.attn_gate_proj = CastedLinear(gate_window, num_heads, bias=False)
+            self.attn_gate_proj._zero_init = True
+        # Gated Attention (arXiv:2505.06708, Qwen, NeurIPS 2025). Per-head sigmoid
+        # gate on SDPA output, BEFORE out_proj. Gate projection W_g: (num_heads, dim).
+        # Name "attn_gate_w" contains "attn_gate" substring so it matches
+        # CONTROL_TENSOR_NAME_PATTERNS and routes to the scalar AdamW group.
+        # fp32 Parameter -> restore_fp32_params path covers it via the ndim<2 OR
+        # name-pattern check (name matches "attn_gate"). Cast to x.dtype on use.
+        self.gated_attn = gated_attn
+        if gated_attn:
+            W = torch.empty(num_heads, dim, dtype=torch.float32)
+            nn.init.normal_(W, mean=0.0, std=gated_attn_init_std)
+            self.attn_gate_w = nn.Parameter(W)
+        # Sparse attention head-output gate (modded-nanogpt style). Keeps dense SDPA
+        # and only narrows the gate input to the first gate_window residual dims.
+        # W_g: (num_heads, gate_window). y_{t,h} <- sigmoid(scale * W_g_h @ x_t[:gate_window]) * y_{t,h}.
+        # Shares attn_gate_w name with dense GatedAttn so the quant routing
+        # (CONTROL_TENSOR_NAME_PATTERNS / attn_gate_w int8 passthrough) is unchanged.
+        self.sparse_attn_gate = sparse_attn_gate
+        self.sparse_attn_gate_scale = sparse_attn_gate_scale
+        if sparse_attn_gate:
+            W = torch.empty(num_heads, gate_window, dtype=torch.float32)
+            if sparse_attn_gate_init_std > 0:
+                nn.init.normal_(W, mean=0.0, std=sparse_attn_gate_init_std)
+            else:
+                nn.init.zeros_(W)
+            self.attn_gate_w = nn.Parameter(W)
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        # q_raw kept around as a tap point for attn_out_gate_src='q' (post-projection,
+        # pre-reshape, pre-RoPE).
+        q_raw = F.linear(x, q_w.to(x.dtype))
+        q = q_raw.reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = F.linear(x, v_w.to(x.dtype)).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        # AttnOutGate inlined (PR #1667). Inline + .contiguous() barrier so torch.compile
+        # fullgraph=True is happy (this avoids the @torch.compiler.disable trap that
+        # crashed gates v3). Per-head gate on (B,T,H,D) tensor: g shape [B,T,H], broadcast
+        # over D via [..., None]. zero-init weight -> 2*sigmoid(0)=1 -> transparent.
+        if self.attn_out_gate:
+            gate_src = q_raw if self.attn_out_gate_src == "q" else x
+            gate_in = gate_src[..., : self.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(self.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (arXiv:2505.06708 G1). Inline + .contiguous() barrier so
+        # torch.compile fullgraph=True is happy. Per-head gate on (B,T,H,D): g shape
+        # [B,T,H], broadcast over D via [..., None]. Paper: g = sigmoid(x @ W_g.T)
+        # where W_g: (H, dim). .to(x.dtype) on fp32 param before broadcast with bf16.
+        if self.gated_attn:
+            x_c = x.contiguous()
+            g = torch.sigmoid(F.linear(x_c, self.attn_gate_w.to(x.dtype)))
+            y = y * g[..., None]
+        # Sparse head-output gate: narrower (gate_window) input, same shape g as GatedAttn.
+        if self.sparse_attn_gate:
+            gate_in = x[..., : self.gate_window].contiguous()
+            g = torch.sigmoid(
+                self.sparse_attn_gate_scale
+                * F.linear(gate_in, self.attn_gate_w.to(x.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(F.linear(x, up_w.to(x.dtype)), negative_slope=0.5).square()
+        self._last_down_input = hidden.detach() if getattr(self, "_calib", False) else None
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len, yarn=yarn,
+            attn_out_gate=attn_out_gate, attn_out_gate_src=attn_out_gate_src, gate_window=gate_window,
+            gated_attn=gated_attn, gated_attn_init_std=gated_attn_init_std,
+            sparse_attn_gate=sparse_attn_gate,
+            sparse_attn_gate_init_std=sparse_attn_gate_init_std,
+            sparse_attn_gate_scale=sparse_attn_gate_scale,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+            None, None, :
+        ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w)
+        return x_out
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.fused_ce_enabled = bool(h.fused_ce_enabled)
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(torch.empty(2 * h.num_layers, h.model_dim, h.model_dim))
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(torch.empty(h.num_layers, hidden_dim, h.model_dim))
+        self.mlp_down_bank = nn.Parameter(torch.empty(h.num_layers, h.model_dim, hidden_dim))
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                    attn_out_gate=h.attn_out_gate_enabled,
+                    attn_out_gate_src=h.attn_out_gate_src,
+                    gate_window=h.gate_window,
+                    gated_attn=h.gated_attn_enabled,
+                    gated_attn_init_std=h.gated_attn_init_std,
+                    sparse_attn_gate=h.sparse_attn_gate_enabled,
+                    sparse_attn_gate_init_std=h.sparse_attn_gate_init_std,
+                    sparse_attn_gate_scale=h.sparse_attn_gate_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        self.default_encoder_indices = tuple(range(self.num_encoder_layers))
+        self.default_decoder_indices = tuple(
+            range(self.num_encoder_layers, self.num_encoder_layers + self.num_decoder_layers)
+        )
+        self.art_simple_enabled = bool(h.art_simple_enabled)
+        self.art_simple_runtime_active = True
+        self.art_last_continue_rate = 1.0
+        self.art_last_entropy = 0.0
+        self.art_last_action = 1.0
+        if self.art_simple_enabled and (
+            h.num_loops != 2 or h.loop_start != 3 or h.loop_end != 5
+        ):
+            raise ValueError(
+                "SimpleART is pinned to num_loops=2, loop_start=3, loop_end=5 "
+                f"for the current record recurrence; got {h.num_loops=}, "
+                f"{h.loop_start=}, {h.loop_end=}."
+            )
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        # SmearGate (PR #1667 / modded-nanogpt @classiclarryd):
+        #   x_t <- x_t + lam * sigmoid(W * x_t[:gate_window]) * x_{t-1}.
+        # Per-token forward-1 smear of the embedding lane. W zero-init + lam=0 ->
+        # transparent at init. Uses CastedLinear so restore_fp32_params handles dtype.
+        self.smear_gate_enabled = h.smear_gate_enabled
+        if self.smear_gate_enabled:
+            self.smear_window = h.gate_window
+            self.smear_gate = CastedLinear(self.smear_window, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        if self.art_simple_enabled:
+            self.art_router_fc = CastedLinear(
+                2 * h.model_dim, h.art_router_hidden_dim, bias=False
+            )
+            self.art_router_proj = CastedLinear(h.art_router_hidden_dim, 2, bias=False)
+            self.art_router_proj._zero_init = True
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self, block_idx, lane0, lane1, x0,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+        cu_seqlens=None, max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w, k_w, v_w, out_w,
+            cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def _forward_hidden(self, input_ids, cu_seqlens=None, max_seqlen=0, enc_iter=None, dec_iter=None):
+        """Run the encoder/decoder stack to the final RMSNorm; returns pre-projection hidden.
+        Shared by eval (softcap+projection via forward_logits) and train (fused CE path)."""
+        x = self.tok_emb(input_ids)
+        # SmearGate (PR #1667). Inline gate compute with .contiguous() on the slice fed
+        # to the projection so torch.compile fullgraph is happy. lam=0 + W=0 -> identity
+        # at init. This block runs unconditionally on the smear path; the cat keeps
+        # position 0 untouched so causality holds.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            bos_mask = (input_ids[:, 1:] == 1).unsqueeze(-1)
+            g = g.masked_fill(bos_mask, 0.0)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        if enc_iter is None:
+            enc_iter = self.encoder_indices if self.looping_active else self.default_encoder_indices
+        if dec_iter is None:
+            dec_iter = self.decoder_indices if self.looping_active else self.default_decoder_indices
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i, lane0, lane1, x0, q_w, k_w, v_w, out_w, up_w, down_w,
+                    cu_seqlens=cu_seqlens, max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self.blocks[i](x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        return x
+
+    def _forward_hidden_short(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        return self._forward_hidden(
+            input_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            enc_iter=self.default_encoder_indices,
+            dec_iter=self.default_decoder_indices,
+        )
+
+    def _forward_hidden_full(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        return self._forward_hidden(
+            input_ids,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+            enc_iter=self.encoder_indices,
+            dec_iter=self.decoder_indices,
+        )
+
+    def _project_logits(self, hidden):
+        if self.tie_embeddings:
+            return F.linear(hidden, self.tok_emb.weight)
+        return self.lm_head(hidden)
+
+    def art_route_logits(self, input_ids):
+        x = self.tok_emb(input_ids).detach()
+        x = F.rms_norm(x, (x.size(-1),))
+        last = x[:, -1, :]
+        max_pool = x.amax(dim=1)
+        feat = torch.cat([last, max_pool], dim=-1).mean(dim=0, keepdim=True)
+        h = F.silu(self.art_router_fc(feat))
+        return self.art_router_proj(h).float().squeeze(0)
+
+    def _loss_from_logits_proj(self, logits_proj, target_ids):
+        flat_targets = target_ids.reshape(-1)
+        if self.fused_ce_enabled:
+            return softcapped_cross_entropy(
+                logits_proj.reshape(-1, logits_proj.size(-1)),
+                flat_targets,
+                self.logit_softcap,
+                reduction="mean",
+            )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            flat_targets,
+            reduction="mean",
+        )
+
+    def forward_short(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_short(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return self._loss_from_logits_proj(self._project_logits(hidden), target_ids)
+
+    def forward_full(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_full(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        return self._loss_from_logits_proj(self._project_logits(hidden), target_ids)
+
+    def forward_logits_short(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_short(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_logits_full(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden_full(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen)
+        logits_proj = self._project_logits(hidden)
+        return self._loss_from_logits_proj(logits_proj, target_ids)
+
+    def forward_ttt(self, input_ids, target_ids, lora, enc_iter=None, dec_iter=None):
+        x = self.tok_emb(input_ids)
+        # SmearGate on the TTT path — same inline compute as forward_logits.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            bos_mask = (input_ids[:, 1:] == 1).unsqueeze(-1)
+            g = g.masked_fill(bos_mask, 0.0)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1]], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        if enc_iter is None:
+            enc_iter = self.encoder_indices if self.looping_active else self.default_encoder_indices
+        if dec_iter is None:
+            dec_iter = self.decoder_indices if self.looping_active else self.default_decoder_indices
+        slot = 0
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=lane0.dtype))[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i, lane0, lane1, x0, lora, slot,
+                    q_w, k_w, v_w, out_w, up_w, down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[None, None, :]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x = self._block_with_lora(self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def forward_ttt_short(self, input_ids, target_ids, lora):
+        return self.forward_ttt(
+            input_ids,
+            target_ids,
+            lora,
+            enc_iter=self.default_encoder_indices,
+            dec_iter=self.default_decoder_indices,
+        )
+
+    def forward_ttt_full(self, input_ids, target_ids, lora):
+        return self.forward_ttt(
+            input_ids,
+            target_ids,
+            lora,
+            enc_iter=self.encoder_indices,
+            dec_iter=self.decoder_indices,
+        )
+
+    def _block_with_lora(self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # Keep raw Q for AttnOutGate src='q' (matches forward path semantics).
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT path) — inline + .contiguous() barrier, same as the eval path.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT path). Gate input is n (post-norm block input), same
+        # as eval path. .to(n.dtype) on fp32 param before bf16 broadcast.
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT path) — must match the eval path in
+        # forward() exactly, else training (which applied the gate) and TTT eval (which
+        # skipped it) produce mismatched representations and catastrophic BPB regression.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self, block_idx, lane0, lane1, x0, lora, slot,
+        q_w, k_w, v_w, out_w, up_w, down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT parallel path) — inline + .contiguous() barrier.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT parallel path). Gate input is n (post-norm block input).
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT parallel path) — must match the
+        # eval path in forward() to keep train/eval semantics in sync.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    # PR-1767: rank-scaled output (alpha/rank), like standard LoRA. Decouples
+    # effective magnitude from rank so changing rank does not change LR scale.
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "144"))
+    # PR-1767: optionally keep A warm across per-doc resets (only B is zeroed).
+    # Accumulates useful feature directions across documents within a TTT phase.
+    _WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = self._ALPHA / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            if not self._WARM_START_A:
+                self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return ((x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [self.q_loras, self.v_loras, self.k_loras,
+                          self.mlp_loras, self.o_loras]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+# Polar Express per-iteration minimax Newton-Schulz coefficients (PR #1344).
+# Replaces the fixed (3.4445, -4.775, 2.0315) coefficients of stock Muon.
+# Applied at backend_steps=5 — taking more than 5 iterations from this list
+# falls back to the final (converged) tuple via the slice guard below.
+_PE_COEFFS = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    coeffs = _PE_COEFFS[:steps] if steps <= len(_PE_COEFFS) else _PE_COEFFS
+    for a, b, c in coeffs:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append({
+                    "p": p,
+                    "B": B,
+                    "padded_grad": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "shard_mom": torch.zeros(shard_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "full_update": torch.zeros(padded_B, *tail, device=dev, dtype=torch.bfloat16),
+                    "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                })
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad.bfloat16())
+            if pg.shape[0] > m["B"]:
+                pg[m["B"] :].zero_()
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update.to(dtype=p.dtype), alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd.to(dtype=pp.dtype), alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas,attn_gate_proj,attn_gate_w,smear_gate,smear_lambda",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        # SmearGate params live on GPT root (not in .blocks), so add them by hand.
+        # Both are tiny (gate_window scalars + 1 lambda). Optimized via scalar Adam.
+        if getattr(base_model, "smear_gate_enabled", False):
+            scalar_params.append(base_model.smear_gate.weight)
+            scalar_params.append(base_model.smear_lambda)
+        router_params = []
+        if getattr(base_model, "art_simple_enabled", False):
+            router_params.extend(
+                [
+                    base_model.art_router_fc.weight,
+                    base_model.art_router_proj.weight,
+                ]
+            )
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizer_router = (
+            torch.optim.AdamW(
+                [
+                    {
+                        "params": router_params,
+                        "lr": h.art_router_lr,
+                        "base_lr": h.art_router_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                weight_decay=h.art_router_wd,
+                fused=True,
+            )
+            if router_params
+            else None
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if self.optimizer_router is not None:
+            self.optimizers.append(self.optimizer_router)
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_params.extend(router_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self.optimizer_tok.step()
+        self.optimizer_scalar.step()
+        if self.optimizer_router is not None:
+            self.optimizer_router.step()
+        self.optimizer_muon.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1], h_act.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _quantize_gate_int8_row(w):
+    # Symmetric int8-per-row quantization for small gate tensors. w shape
+    # (R, C) -> (R,) scales in fp16, int8 values in [-127, 127]. Single scale
+    # per row keeps accuracy high while halving storage vs fp16.
+    W = w.float().contiguous()
+    row_max = W.abs().amax(dim=1).clamp_min(1e-10)
+    s = (row_max / 127.0).to(torch.float16)
+    sf = s.float().view(-1, 1)
+    q = torch.clamp(torch.round(W / sf), -127, 127).to(torch.int8)
+    return q, s
+
+
+def _lqer_pack(A, B, bits):
+    rng = 2 ** (bits - 1) - 1
+    sA = (A.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    sB = (B.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    qB = torch.clamp(torch.round(B / sB.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    return qA, sA, qB, sB
+
+
+def _lqer_pack_asym(A, B, g=64):
+    # A: INT2 per-matrix scalar (signed [-2,1], scale = |A|max/1.5).
+    sA = (A.abs().amax().clamp_min(1e-10) / 1.5).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float()), -2, 1).to(torch.int8)
+    # B: INT4 groupwise g over flattened B (signed [-8,7], per-group scale).
+    Bf = B.reshape(-1, g)
+    Bmax = Bf.abs().amax(dim=-1, keepdim=True).clamp_min(1e-10)
+    sB = (Bmax / 7.5).to(torch.float16).reshape(-1)
+    qB = torch.clamp(torch.round(Bf / sB.float().reshape(-1, 1)), -8, 7).to(
+        torch.int8
+    ).reshape(B.shape)
+    return qA, sA, qB, sB
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    quant_gate = bool(getattr(h, "gated_attn_quant_gate", False))
+    lqer_on = bool(getattr(h, "lqer_enabled", False))
+    lqer_cands = {}
+    for (name, tensor) in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        # Dedicated int8-per-row path for attn_gate_w (bypasses both GPTQ and
+        # fp16 passthrough). Applied BEFORE the numel<=65536 passthrough check
+        # so the gate tensor is routed here instead of to fp16.
+        if (
+            quant_gate
+            and t.is_floating_point()
+            and t.ndim == 2
+            and name.endswith(".attn_gate_w")
+            # Dense GatedAttn: (num_heads, dim) = (8, 512) = 4096.
+            # Sparse gate: (num_heads, gate_window) = (8, 12) = 96.
+            # Both need int8-per-row routing; the 1024 lower bound in stock
+            # PR-1736 presumed dense-only. Widen to catch both.
+            and 32 <= t.numel() <= 8192
+        ):
+            gq, gs = _quantize_gate_int8_row(t)
+            result[name + ".gq"] = gq
+            result[name + ".gs"] = gs
+            meta[name] = "gate_int8_row"
+            continue
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+        if lqer_on:
+            W_q = q.float() * s.float().view(-1, 1)
+            E = t.float() - W_q
+            lqer_cands[name] = (E, float(E.norm()))
+    if lqer_on and lqer_cands:
+        top = sorted(lqer_cands.items(), key=lambda kv: -kv[1][1])[: h.lqer_top_k]
+        asym_on = bool(getattr(h, "lqer_asym_enabled", False))
+        asym_g = int(getattr(h, "lqer_asym_group", 64))
+        for (name, (E, _)) in top:
+            U, S, Vh = torch.linalg.svd(E, full_matrices=False)
+            r = min(h.lqer_rank, S.numel())
+            A = (U[:, :r] * S[:r]).contiguous()
+            B = Vh[:r, :].contiguous()
+            if asym_on and B.numel() % asym_g == 0:
+                qA, sA, qB, sB = _lqer_pack_asym(A, B, asym_g)
+                result[name + ".lqA_a"] = qA
+                result[name + ".lqAs_a"] = sA
+                result[name + ".lqB_a"] = qB
+                result[name + ".lqBs_a"] = sB
+                meta[name] = meta[name] + "+lqer_asym"
+            else:
+                qA, sA, qB, sB = _lqer_pack(A, B, h.lqer_factor_bits)
+                result[name + ".lqA"] = qA
+                result[name + ".lqAs"] = sA
+                result[name + ".lqB"] = qB
+                result[name + ".lqBs"] = sB
+                meta[name] = meta[name] + "+lqer"
+    categories = collections.defaultdict(set)
+    for (name, cat) in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for (name, orig) in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        if info == "gate_int8_row":
+            gq = result[name + ".gq"]
+            gs = result[name + ".gs"]
+            out[name] = (gq.float() * gs.float().view(-1, 1)).to(orig_dtype)
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            W = q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+        else:
+            W = q.float() * float(s.item())
+        if "lqer_asym" in info:
+            qA_t = result[name + ".lqA_a"]
+            sA_t = result[name + ".lqAs_a"]
+            qB_t = result[name + ".lqB_a"]
+            sB_t = result[name + ".lqBs_a"]
+            qA = qA_t.float() * float(sA_t)
+            g_sz = qB_t.numel() // sB_t.numel()
+            qB = (qB_t.reshape(-1, g_sz).float() * sB_t.float().view(-1, 1)).reshape(
+                qB_t.shape
+            )
+            W = W + qA @ qB
+        elif "lqer" in info:
+            qA = result[name + ".lqA"].float() * result[name + ".lqAs"].float().view(-1, 1)
+            qB = result[name + ".lqB"].float() * result[name + ".lqBs"].float().view(-1, 1)
+            W = W + qA @ qB
+        out[name] = W.to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "lzma":
+        return lzma.compress(data, preset=6)
+    elif compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "lzma":
+        raw = lzma.decompress(data)
+    elif compressor == "brotli":
+        import brotli
+
+        raw = brotli.decompress(data)
+    else:
+        raise ValueError(f"Unknown compressor: {compressor!r}")
+    raw = _byte_unshuffle(raw)
+    return raw
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.", ".attn.c_k.", ".attn.c_v.",
+                    ".attn.proj.", ".mlp.fc.", ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+
+def _compressed_code_size(code):
+    code_raw = code.encode("utf-8")
+    try:
+        minified = subprocess.run(
+            ["pyminify", "--no-rename-locals", "--no-hoist-literals", "--remove-literal-statements", "-"],
+            input=code_raw, capture_output=True, check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        minified = code_raw
+    compressed = lzma.compress(minified)
+    encoded = base64.b85encode(compressed)
+    wrapper = b'import lzma as L,base64 as B\nexec(L.decompress(B.b85decode("' + encoded + b'")))\n'
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    log("GPTQ:collecting Hessians from calibration data...")
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter()-t0:.1f}s")
+    t_quant = time.perf_counter()
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    log(f"GPTQ:quantized in {time.perf_counter()-t_quant:.1f}s")
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    t_compress = time.perf_counter()
+    quant_blob = _compress(quant_raw, h.compressor)
+    log(f"GPTQ:compressed+saved in {time.perf_counter()-t_compress:.1f}s")
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_flat = dequantize_mixed(quant_state["w"], quant_state["m"], flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim)
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (model.module.forward_logits if hasattr(model, "module") else model.forward_logits)
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            prev_ids = x
+            tgt_ids = y
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                # CaseOps: read per-token byte budget from sidecar at the same
+                # global positions as the target tokens y. raw_start/raw_end
+                # span [raw_start, raw_end), x = local[:-1], y = local[1:],
+                # so y is at sidecar positions [raw_start + 1, raw_end).
+                sidecar_slice = val_data.val_bytes[raw_start + 1 : raw_end].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                val_byte_count += sidecar_slice.to(torch.float64).sum()
+            else:
+                token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+                token_bytes += (
+                    val_data.has_leading_space_lut[tgt_ids]
+                    & ~val_data.is_boundary_token_lut[prev_ids]
+                ).to(dtype=torch.int16)
+                val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+    y_bytes=None,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if y_bytes is not None:
+        tok_bytes = y_bytes.to(torch.float64)
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+def train_val_ttt_global_sgd_distributed(h, device, val_data, base_model, val_tokens, batch_seqs=None):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = h.global_ttt_lr * 0.5 * (
+                1.0 + math.cos(math.pi * decay_ci / decay_steps)
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(device=device, dtype=torch.int64)
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos, x_flat.numel(), x_flat.device, h.eval_seq_len, 64
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"tttg: c{ci+1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s"
+            )
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size, base_model, h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(), lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1, weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(), lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10, weight_decay=h.ttt_weight_decay, fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+      while True:
+        queue_idx = _claim_next_batch(counter_path, queue_len)
+        if queue_idx >= queue_len:
+            break
+        orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+        batch = [doc for _, doc in batch_entries]
+        bsz = len(batch)
+        prev_loss = loss_sum.item()
+        prev_bytes = byte_sum.item()
+        prev_tokens = token_count.item()
+        if bsz == reusable_lora.bsz:
+            reusable_lora.reset()
+            for s in reusable_opt.state.values():
+                for k, v in s.items():
+                    if isinstance(v, torch.Tensor):
+                        v.zero_()
+                    elif k == "step":
+                        s[k] = 0
+            cur_lora = reusable_lora
+            cur_opt = reusable_opt
+        else:
+            cur_lora = BatchedTTTLoRA(
+                bsz, base_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            cur_opt = _build_opt(cur_lora)
+        pred_lens = [doc_len - 1 for _, doc_len in batch]
+        num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+        max_nc = max(num_chunks)
+        num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+        for ci in range(max_nc):
+            active = [ci < nc for nc in num_chunks]
+            needs_train = any(ci < nc - 1 for nc in num_chunks)
+            tok_starts = torch.zeros(bsz, dtype=torch.int64)
+            tok_wls = torch.zeros(bsz, dtype=torch.int64)
+            chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+            chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+            for b in range(bsz):
+                if not active[b]:
+                    continue
+                doc_start, doc_len = batch[b]
+                win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                    ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                )
+                tok_starts[b] = doc_start + win_start
+                tok_wls[b] = win_len
+                chunk_offsets_cpu[b] = chunk_offset
+                chunk_lens_cpu[b] = chunk_len
+            _, context_size, chunk_offset, _ = _compute_chunk_window(
+                ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+            )
+            col_idx = torch.arange(context_size + 1)
+            idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+            idx.clamp_(max=all_tokens.numel() - 1)
+            gathered_gpu = all_tokens_idx[idx].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                device, non_blocking=True
+            )
+            chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+            chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+            x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+            y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+            ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+            # CaseOps sidecar-driven byte budget. Mirror the index pattern
+            # used to build y from all_tokens: y[b, j] corresponds to the
+            # token at global position tok_starts[b] + 1 + j (when valid).
+            y_bytes_arg = None
+            if val_data.caseops_enabled and val_data.val_bytes is not None:
+                y_idx = (
+                    tok_starts.unsqueeze(1)
+                    + 1
+                    + col_idx[:context_size].unsqueeze(0)
+                )
+                y_idx = y_idx.clamp_(max=val_data.val_bytes.numel() - 1)
+                y_bytes_arg = val_data.val_bytes[y_idx].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                # Mirror the `valid` masking used for y so out-of-range tokens
+                # contribute zero bytes (matches y=0 substitution above).
+                y_bytes_arg = torch.where(
+                    valid, y_bytes_arg, torch.zeros_like(y_bytes_arg)
+                )
+            with torch.no_grad():
+                _accumulate_bpb(
+                    per_tok_loss,
+                    x,
+                    y,
+                    chunk_offsets,
+                    chunk_lens,
+                    ctx_pos,
+                    val_data.base_bytes_lut,
+                    val_data.has_leading_space_lut,
+                    val_data.is_boundary_token_lut,
+                    loss_sum,
+                    byte_sum,
+                    token_count,
+                    y_bytes=y_bytes_arg,
+                )
+            if needs_train:
+                activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                for gi in range(h.ttt_grad_steps):
+                    if gi > 0:
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                    per_doc = per_tok_loss[
+                        :, chunk_offset : chunk_offset + chunk_size
+                    ].mean(dim=-1)
+                    cur_opt.zero_grad(set_to_none=True)
+                    (per_doc * activate_chunk_mask).sum().backward()
+                    cur_opt.step()
+            else:
+                del per_tok_loss
+        batch_num = orig_batch_idx + 1
+        doc_lens = [dl for _, dl in batch]
+        should_report = batch_num in eval_batch_set if eval_batch_set is not None else True
+        if should_report:
+            cur_tokens = token_count.item()
+            cur_loss_val = loss_sum.item()
+            cur_bytes_val = byte_sum.item()
+            dt = cur_tokens - prev_tokens
+            db = cur_bytes_val - prev_bytes
+            if dt > 0 and db > 0:
+                b_loss = (cur_loss_val - prev_loss) / dt
+                b_bpb = b_loss / math.log(2.0) * (dt / db)
+            else:
+                b_loss = b_bpb = 0.0
+            r_loss = cur_loss_val / max(cur_tokens, 1)
+            r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+            elapsed = time.perf_counter() - t_start
+            log(
+                f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                f"gd:{int(global_ttt_done)}"
+            )
+        if not global_ttt_done:
+            local_scored_docs.extend(
+                (orig_batch_idx, pos, doc_start, doc_len)
+                for pos, (doc_start, doc_len) in enumerate(batch)
+            )
+            prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+            if prefix_done >= current_phase_boundary:
+                try:
+                    with open(pause_flag_path, "x"):
+                        pass
+                except FileExistsError:
+                    pass
+            should_pause = os.path.exists(pause_flag_path)
+            if should_pause:
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                gathered_scored_docs = [None] * h.world_size
+                if dist.is_available() and dist.is_initialized():
+                    dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                else:
+                    gathered_scored_docs = [local_scored_docs]
+                scored_docs_for_global = []
+                for rank_docs in gathered_scored_docs:
+                    if rank_docs:
+                        scored_docs_for_global.extend(rank_docs)
+                scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                scored_docs_for_global = scored_docs_for_global[:current_phase_boundary]
+                scored_token_chunks = [
+                    val_data.val_tokens[doc_start : doc_start + doc_len]
+                    for _, _, doc_start, doc_len in scored_docs_for_global
+                ]
+                if scored_token_chunks:
+                    global_ttt_tokens = torch.cat(scored_token_chunks)
+                else:
+                    global_ttt_tokens = val_data.val_tokens[:0]
+                if h.rank == 0:
+                    prefix_done = 0
+                    try:
+                        with open(prefix_counter_path, "rb") as f:
+                            prefix_done = int.from_bytes(
+                                f.read(8), "little", signed=True
+                            )
+                    except FileNotFoundError:
+                        pass
+                    log(
+                        f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                        f"gd:{len(scored_docs_for_global)} "
+                        f"t:{time.perf_counter() - t_start:.1f}s"
+                    )
+                train_val_ttt_global_sgd_distributed(
+                    h, device, val_data, base_model, global_ttt_tokens
+                )
+                for p in base_model.parameters():
+                    p.requires_grad_(False)
+                reusable_lora = BatchedTTTLoRA(
+                    h.ttt_batch_size, base_model, h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+                ).to(device)
+                reusable_opt = _build_opt(reusable_lora)
+                current_phase += 1
+                if current_phase >= num_phases:
+                    global_ttt_done = True
+                else:
+                    current_phase_boundary = phase_boundaries[current_phase]
+                    if h.rank == 0:
+                        try:
+                            os.remove(pause_flag_path)
+                        except FileNotFoundError:
+                            pass
+                if dist.is_available() and dist.is_initialized():
+                    dist.barrier()
+                if h.rank == 0:
+                    log(f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s")
+        del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    if getattr(base_model, "art_simple_enabled", False) and h.art_simple_enable_at > 0.0:
+        base_model.art_simple_runtime_active = False
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    compiled_short_loss = torch.compile(
+        base_model.forward_short, dynamic=False, fullgraph=True
+    )
+    compiled_full_loss = torch.compile(
+        base_model.forward_full, dynamic=False, fullgraph=True
+    )
+    compiled_short_logits = torch.compile(
+        base_model.forward_logits_short, dynamic=False, fullgraph=True
+    )
+    compiled_full_logits = torch.compile(
+        base_model.forward_logits_full, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel()for p in base_model.parameters())}")
+    log(
+        "simple_art:"
+        f"enabled:{int(getattr(base_model, 'art_simple_enabled', False))} "
+        f"enable_at:{h.art_simple_enable_at:g} "
+        f"router_hidden:{h.art_router_hidden_dim} "
+        f"router_lr:{h.art_router_lr:g} "
+        f"cycle_penalty:{h.art_cycle_penalty:g} "
+        f"entropy:{h.art_router_entropy_start:g}->{h.art_router_entropy_end:g} "
+        f"eval_mode:{h.art_eval_mode}"
+    )
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.1f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def art_entropy_coef(frac):
+        t = min(max(frac, 0.0), 1.0)
+        return h.art_router_entropy_start + (
+            h.art_router_entropy_end - h.art_router_entropy_start
+        ) * t
+
+    def select_art_action(input_ids, mode="sample"):
+        logits = base_model.art_route_logits(input_ids)
+        log_probs = F.log_softmax(logits, dim=-1)
+        probs = log_probs.exp()
+        route_probs = probs.detach().clone()
+        if h.distributed:
+            dist.all_reduce(route_probs, op=dist.ReduceOp.AVG)
+        mode = mode.lower()
+        if mode in ("full", "force_full", "continue"):
+            action_t = torch.ones((), device=device, dtype=torch.long)
+        elif mode in ("short", "force_short", "stop"):
+            action_t = torch.zeros((), device=device, dtype=torch.long)
+        elif mode == "argmax":
+            action_t = route_probs.argmax().to(dtype=torch.long)
+        elif mode == "sample":
+            if h.distributed:
+                if h.rank == 0:
+                    action_t = torch.multinomial(route_probs, 1).to(dtype=torch.long)[0]
+                else:
+                    action_t = torch.zeros((), device=device, dtype=torch.long)
+                dist.broadcast(action_t, src=0)
+            else:
+                action_t = torch.multinomial(route_probs, 1).to(dtype=torch.long)[0]
+        else:
+            raise ValueError(
+                f"Unsupported ART_EVAL_MODE={mode!r}; use sample, argmax, full, or short"
+            )
+        action = int(action_t.item())
+        entropy = -(probs * log_probs).sum()
+        base_model.art_last_continue_rate = float(route_probs[1].item())
+        base_model.art_last_entropy = float(entropy.detach().item())
+        base_model.art_last_action = float(action)
+        return action, log_probs[action], entropy, route_probs[1].detach()
+
+    art_loss_baseline = None
+    art_window = {
+        "n": 0,
+        "continue_actions": 0.0,
+        "continue_prob": 0.0,
+        "entropy": 0.0,
+        "policy": 0.0,
+    }
+
+    def step_fn(step, lr_scale, train_frac=0.0):
+        nonlocal art_loss_baseline
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                if getattr(base_model, "art_simple_enabled", False) and getattr(
+                    base_model, "art_simple_runtime_active", True
+                ):
+                    action, log_prob, entropy, continue_prob = select_art_action(
+                        x, mode="sample"
+                    )
+                    if action:
+                        loss = compiled_full_loss(
+                            x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len
+                        )
+                    else:
+                        loss = compiled_short_loss(
+                            x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len
+                        )
+                    cost = loss.detach().float() + h.art_cycle_penalty * float(action)
+                    if art_loss_baseline is None:
+                        art_loss_baseline = cost.detach()
+                    advantage = (cost - art_loss_baseline).detach()
+                    entropy_bonus = art_entropy_coef(train_frac)
+                    policy_loss = advantage * log_prob - entropy_bonus * entropy
+                    art_loss_baseline = (
+                        h.art_baseline_decay * art_loss_baseline
+                        + (1.0 - h.art_baseline_decay) * cost.detach()
+                    )
+                    loss_for_backward = loss + policy_loss.to(dtype=loss.dtype)
+                    art_window["n"] += 1
+                    art_window["continue_actions"] += float(action)
+                    art_window["continue_prob"] += float(continue_prob.item())
+                    art_window["entropy"] += float(entropy.detach().item())
+                    art_window["policy"] += float(policy_loss.detach().float().item())
+                else:
+                    loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+                    loss_for_backward = loss
+            train_loss += loss.detach()
+            (loss_for_backward / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac = (
+            min(step / h.muon_momentum_warmup_steps, 1.0)
+            if h.muon_momentum_warmup_steps > 0
+            else 1.0
+        )
+        muon_momentum = (
+            1 - frac
+        ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    def eval_forward_logits(input_ids, cu_seqlens=None, max_seqlen=0):
+        if getattr(base_model, "art_simple_enabled", False) and getattr(
+            base_model, "art_simple_runtime_active", False
+        ):
+            action, _log_prob, _entropy, _continue_prob = select_art_action(
+                input_ids, mode=h.art_eval_mode
+            )
+            if action:
+                return compiled_full_logits(
+                    input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
+            return compiled_short_logits(
+                input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+            )
+        return compiled_forward_logits(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}")
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        def _run_art_path_warmup():
+            if not getattr(base_model, "art_simple_enabled", False):
+                return
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full((bucket_len,), x.size(1), dtype=torch.int32, device=device)
+                cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+                for fn in (compiled_short_loss, compiled_full_loss):
+                    for _ in range(warmup_cu_iters):
+                        optimizers.zero_grad_all()
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                            wloss = fn(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                        (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            _run_art_path_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step+1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step+1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for (opt, state) in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+        if getattr(base_model, "art_simple_enabled", False):
+            base_model.art_simple_runtime_active = h.art_simple_enable_at <= 0.0
+    _live_state = base_model.state_dict(keep_vars=True)
+    ema_decay = h.ema_decay
+    ema_activate_at = h.ema_activate_at
+    ema_state = None
+    _ema_pairs = None
+    ema_active = False
+
+    def _activate_ema(step, frac):
+        nonlocal ema_state, _ema_pairs, ema_active
+        ema_state = {
+            name: t.detach().float().clone() for (name, t) in _live_state.items()
+        }
+        _ema_pairs = [(ema_state[name], t) for (name, t) in _live_state.items()]
+        ema_active = True
+        log(f"ema:activated step:{step} frac:{frac:.3f} decay:{ema_decay:g}")
+
+    if ema_activate_at <= 0.0:
+        _activate_ema(0, 0.0)
+    else:
+        log(f"ema:delayed activate_at:{ema_activate_at:g} decay:{ema_decay:g}")
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, eval_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+        enable_art_now = (
+            getattr(base_model, "art_simple_enabled", False)
+            and base_model.looping_active
+            and not getattr(base_model, "art_simple_runtime_active", True)
+            and frac >= h.art_simple_enable_at
+        )
+        if h.distributed and getattr(base_model, "art_simple_enabled", False) and not getattr(
+            base_model, "art_simple_runtime_active", True
+        ):
+            flag = torch.tensor(int(enable_art_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_art_now = bool(flag.item())
+        if enable_art_now:
+            base_model.art_simple_runtime_active = True
+            log(f"simple_art:enabled step:{step} frac:{frac:.3f}")
+            if h.distributed:
+                dist.barrier()
+                log("simple_art:sync_done")
+        train_loss = step_fn(step, scale, frac)
+        enable_ema_now = (not ema_active) and frac >= ema_activate_at
+        if h.distributed and not ema_active:
+            flag = torch.tensor(int(enable_ema_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_ema_now = bool(flag.item())
+        if enable_ema_now:
+            _activate_ema(step + 1, frac)
+            if h.distributed:
+                dist.barrier()
+                log("ema:sync_done")
+        if ema_active:
+            with torch.no_grad():
+                for ema_t, t in _ema_pairs:
+                    ema_t.mul_(ema_decay).add_(t.detach(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms/60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+            if (
+                h.art_probe_every > 0
+                and step % h.art_probe_every == 0
+                and art_window["n"] > 0
+            ):
+                n = max(art_window["n"], 1)
+                log(
+                    "simple_art_probe "
+                    f"step:{step} samples:{n} "
+                    f"continue_action:{art_window['continue_actions'] / n:.3f} "
+                    f"continue_prob:{art_window['continue_prob'] / n:.3f} "
+                    f"entropy:{art_window['entropy'] / n:.4f} "
+                    f"policy_loss:{art_window['policy'] / n:.6f} "
+                    f"baseline:{float(art_loss_baseline.item()) if art_loss_baseline is not None else 0.0:.4f}"
+                )
+                for key in art_window:
+                    art_window[key] = 0
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated()//1024//1024} MiB reserved: {torch.cuda.max_memory_reserved()//1024//1024} MiB"
+    )
+    if ema_state is not None:
+        log("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: t.to(dtype=current_state[name].dtype) for (name, t) in ema_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log("ema:inactive using final live weights")
+    return base_model, compiled_model, eval_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel()-1}")
+    # TTT_EVAL_ONLY: skip training + GPTQ, jump straight to TTT eval on a
+    # pre-existing quantized artifact. Used to test TTT-only improvements
+    # (e.g., PR-1767's alpha/warm-start/WD) without retraining.
+    ttt_eval_only = os.environ.get("TTT_EVAL_ONLY", "0") == "1"
+    if ttt_eval_only:
+        log("TTT_EVAL_ONLY=1 — skipping training + GPTQ, loading saved artifact for TTT eval")
+        log(f"ttt_lora_alpha: {BatchedLinearLoRA._ALPHA}")
+        log(f"ttt_warm_start_a: {BatchedLinearLoRA._WARM_START_A}")
+        log(f"ttt_weight_decay: {h.ttt_weight_decay}")
+    else:
+        t_artifact_start = time.perf_counter()
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+        torch._dynamo.reset()
+        if os.environ.get("PREQUANT_ONLY", "0") == "1":
+            timed_eval(
+                "diagnostic pre-quantization post-ema",
+                eval_val,
+                h,
+                device,
+                val_data,
+                compiled_model,
+                compiled_forward_logits,
+            )
+            log("PREQUANT_ONLY=1 — skipping serialize/GPTQ/post-quant eval/TTT")
+            return
+        t_serialize_start = time.perf_counter()
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+        serialize_seconds = time.perf_counter() - t_serialize_start
+        log(f"serialize_wallclock: {serialize_seconds:.3f}s")
+        if h.distributed:
+            dist.barrier()
+        artifact_production_seconds = time.perf_counter() - t_artifact_start
+        log(f"artifact_production_wallclock: {artifact_production_seconds:.3f}s (must be < {h.max_wallclock_seconds})")
+        timed_eval(
+            "diagnostic pre-quantization post-ema",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    if getattr(eval_model, "art_simple_enabled", False):
+        eval_model.art_simple_runtime_active = True
+    if not ttt_eval_only:
+        compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            eval_model.forward_logits, dynamic=False, fullgraph=True
+        )
+        if getattr(eval_model, "art_simple_enabled", False):
+            compiled_short_logits = torch.compile(
+                eval_model.forward_logits_short, dynamic=False, fullgraph=True
+            )
+            compiled_full_logits = torch.compile(
+                eval_model.forward_logits_full, dynamic=False, fullgraph=True
+            )
+
+            def _select_eval_art_action(input_ids):
+                logits = eval_model.art_route_logits(input_ids)
+                probs = F.softmax(logits.float(), dim=-1).detach()
+                if h.distributed:
+                    dist.all_reduce(probs, op=dist.ReduceOp.AVG)
+                mode = h.art_eval_mode.lower()
+                if mode in ("full", "force_full", "continue"):
+                    action_t = torch.ones((), device=device, dtype=torch.long)
+                elif mode in ("short", "force_short", "stop"):
+                    action_t = torch.zeros((), device=device, dtype=torch.long)
+                elif mode == "argmax":
+                    action_t = probs.argmax().to(dtype=torch.long)
+                elif mode == "sample":
+                    if h.distributed:
+                        if h.rank == 0:
+                            action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                        else:
+                            action_t = torch.zeros((), device=device, dtype=torch.long)
+                        dist.broadcast(action_t, src=0)
+                    else:
+                        action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                else:
+                    raise ValueError(
+                        f"Unsupported ART_EVAL_MODE={h.art_eval_mode!r}; use sample, argmax, full, or short"
+                    )
+                return int(action_t.item())
+
+            def compiled_forward_logits_art(input_ids, cu_seqlens=None, max_seqlen=0):
+                if _select_eval_art_action(input_ids):
+                    return compiled_full_logits(
+                        input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                    )
+                return compiled_short_logits(
+                    input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                )
+
+            compiled_forward_logits = compiled_forward_logits_art
+        timed_eval(
+            "diagnostic quantized",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        del eval_model
+    if h.ttt_enabled:
+        if not ttt_eval_only:
+            del compiled_model
+        if ttt_eval_only:
+            del eval_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        if getattr(ttt_model, "art_simple_enabled", False):
+            ttt_model.art_simple_runtime_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _select_ttt_art_action(input_ids):
+            logits = ttt_model.art_route_logits(input_ids)
+            probs = F.softmax(logits.float(), dim=-1).detach()
+            if h.distributed:
+                dist.all_reduce(probs, op=dist.ReduceOp.AVG)
+            mode = h.art_eval_mode.lower()
+            if mode in ("full", "force_full", "continue"):
+                action_t = torch.ones((), device=device, dtype=torch.long)
+            elif mode in ("short", "force_short", "stop"):
+                action_t = torch.zeros((), device=device, dtype=torch.long)
+            elif mode == "argmax":
+                action_t = probs.argmax().to(dtype=torch.long)
+            elif mode == "sample":
+                if h.distributed:
+                    if h.rank == 0:
+                        action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+                    else:
+                        action_t = torch.zeros((), device=device, dtype=torch.long)
+                    dist.broadcast(action_t, src=0)
+                else:
+                    action_t = torch.multinomial(probs, 1).to(dtype=torch.long)[0]
+            else:
+                raise ValueError(
+                    f"Unsupported ART_EVAL_MODE={h.art_eval_mode!r}; use sample, argmax, full, or short"
+                )
+            return int(action_t.item())
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        def _fwd_ttt_short_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt_short(input_ids, target_ids, lora=lora)
+
+        def _fwd_ttt_full_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt_full(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+        _fwd_ttt_compiled_short = None
+        _fwd_ttt_compiled_full = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner, _fwd_ttt_compiled_short, _fwd_ttt_compiled_full
+            if getattr(ttt_model, "art_simple_enabled", False):
+                if _select_ttt_art_action(input_ids):
+                    if _fwd_ttt_compiled_full is None:
+                        _fwd_ttt_compiled_full = torch.compile(
+                            _fwd_ttt_full_inner, dynamic=True
+                        )
+                    return _fwd_ttt_compiled_full(input_ids, target_ids, lora=lora)
+                if _fwd_ttt_compiled_short is None:
+                    _fwd_ttt_compiled_short = torch.compile(
+                        _fwd_ttt_short_inner, dynamic=True
+                    )
+                return _fwd_ttt_compiled_short(input_ids, target_ids, lora=lora)
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz, ttt_model, h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora, mlp_lora=h.ttt_mlp_lora, o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                yw = torch.randint(0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64)
+                if getattr(ttt_model, "art_simple_enabled", False):
+                    if _fwd_ttt_compiled_short is None:
+                        _fwd_ttt_compiled_short = torch.compile(
+                            _fwd_ttt_short_inner, dynamic=True
+                        )
+                    if _fwd_ttt_compiled_full is None:
+                        _fwd_ttt_compiled_full = torch.compile(
+                            _fwd_ttt_full_inner, dynamic=True
+                        )
+                    warmup_fns = (_fwd_ttt_compiled_short, _fwd_ttt_compiled_full)
+                else:
+                    warmup_fns = (fwd_ttt_compiled,)
+                for warmup_fn in warmup_fns:
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        ptl = warmup_fn(xw, yw, lora=wl)
+                    ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                    wo.step()
+                    wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3*ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 16
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for (k, v) in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1855_soft_art.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/pr1855_soft_art.py
@@ -1,0 +1,4356 @@
+import base64
+import collections
+import copy
+import fcntl
+import glob
+import io
+import lzma
+import math
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+from flash_attn_interface import (
+    flash_attn_func as flash_attn_3_func,
+)
+from flash_attn_interface import (
+    flash_attn_varlen_func,
+)
+from torch import Tensor, nn
+from triton.tools.tensor_descriptor import TensorDescriptor
+
+# ===== Fused softcapped cross-entropy (Triton) — training-only path =====
+# Replaces the eager
+#     logits_softcap = softcap * tanh(logits / softcap)
+#     F.cross_entropy(logits_softcap.float(), targets, reduction="mean")
+# sequence with a single fused kernel that reads logits_proj once, applies
+# softcap in-register, and computes (LSE, loss) in one streaming pass. The
+# backward kernel mirrors the forward so there's no stored softcapped logits.
+# Numerically identical to the eager path up to fp32 accumulation differences.
+_FUSED_CE_LIBRARY = "pgsubmission1draft7fusedce"
+_FUSED_CE_BLOCK_SIZE = 1024
+_FUSED_CE_NUM_WARPS = 4
+
+
+@triton.jit
+def _softcapped_ce_fwd_kernel(
+    logits_ptr,
+    losses_ptr,
+    lse_ptr,
+    targets_ptr,
+    stride_logits_n,
+    stride_logits_v,
+    n_rows,
+    n_cols,
+    softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    max_val = -float("inf")
+    sum_exp = 0.0
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask,
+            other=-float("inf"),
+        ).to(tl.float32)
+        z = A * tl.sigmoid(val * inv_C)
+        z = tl.where(mask, z, -float("inf"))
+        curr_max = tl.max(z, axis=0)
+        new_max = tl.maximum(max_val, curr_max)
+        sum_exp = sum_exp * tl.exp(max_val - new_max) + tl.sum(
+            tl.exp(z - new_max), axis=0
+        )
+        max_val = new_max
+    lse = max_val + tl.log(sum_exp)
+    tl.store(lse_ptr + row_idx, lse)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    target_val = tl.load(logits_row_ptr + target * stride_logits_v).to(tl.float32)
+    target_z = A * tl.sigmoid(target_val * inv_C)
+    tl.store(losses_ptr + row_idx, lse - target_z)
+
+
+@triton.jit
+def _softcapped_ce_bwd_kernel(
+    grad_logits_ptr,
+    grad_losses_ptr,
+    lse_ptr,
+    logits_ptr,
+    targets_ptr,
+    stride_logits_n,
+    stride_logits_v,
+    stride_grad_n,
+    stride_grad_v,
+    n_rows,
+    n_cols,
+    softcap,
+    block_size: tl.constexpr,
+):
+    row_idx = tl.program_id(0).to(tl.int64)
+    logits_row_ptr = logits_ptr + row_idx * stride_logits_n
+    grad_row_ptr = grad_logits_ptr + row_idx * stride_grad_n
+    lse = tl.load(lse_ptr + row_idx)
+    grad_loss = tl.load(grad_losses_ptr + row_idx).to(tl.float32)
+    target = tl.load(targets_ptr + row_idx).to(tl.int32)
+    A = 2.0 * softcap
+    inv_C = 2.0 / softcap
+    dz_dx_scale = A * inv_C
+    for off in range(0, n_cols, block_size):
+        cols = off + tl.arange(0, block_size)
+        mask = cols < n_cols
+        val = tl.load(
+            logits_row_ptr + cols * stride_logits_v,
+            mask=mask,
+            other=0.0,
+        ).to(tl.float32)
+        sigmoid_u = tl.sigmoid(val * inv_C)
+        z = A * sigmoid_u
+        probs = tl.exp(z - lse)
+        grad_z = grad_loss * (probs - tl.where(cols == target, 1.0, 0.0))
+        grad_x = grad_z * (dz_dx_scale * sigmoid_u * (1.0 - sigmoid_u))
+        tl.store(grad_row_ptr + cols * stride_grad_v, grad_x, mask=mask)
+
+
+def _validate_softcapped_ce_inputs(
+    logits: Tensor,
+    targets: Tensor,
+    softcap: float,
+) -> tuple[Tensor, Tensor]:
+    if logits.ndim != 2:
+        raise ValueError(f"Expected logits.ndim=2, got {logits.ndim}")
+    if targets.ndim != 1:
+        raise ValueError(f"Expected targets.ndim=1, got {targets.ndim}")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    if not logits.is_cuda or not targets.is_cuda:
+        raise ValueError("softcapped_cross_entropy requires CUDA tensors")
+    if softcap <= 0.0:
+        raise ValueError(f"softcap must be positive, got {softcap}")
+    if logits.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise ValueError(f"Unsupported logits dtype: {logits.dtype}")
+    logits = logits.contiguous()
+    targets = targets.contiguous()
+    if targets.dtype != torch.int64:
+        targets = targets.to(dtype=torch.int64)
+    return logits, targets
+
+
+@torch.library.custom_op(f"{_FUSED_CE_LIBRARY}::softcapped_ce", mutates_args=())
+def softcapped_ce_op(
+    logits: Tensor, targets: Tensor, softcap: float
+) -> tuple[Tensor, Tensor]:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    n_rows, n_cols = logits.shape
+    losses = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    lse = torch.empty((n_rows,), device=logits.device, dtype=torch.float32)
+    _softcapped_ce_fwd_kernel[(n_rows,)](
+        logits,
+        losses,
+        lse,
+        targets,
+        logits.stride(0),
+        logits.stride(1),
+        n_rows,
+        n_cols,
+        float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE,
+        num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return losses, lse
+
+
+@softcapped_ce_op.register_fake
+def _(logits: Tensor, targets: Tensor, softcap: float):
+    if logits.ndim != 2 or targets.ndim != 1:
+        raise ValueError("softcapped_ce fake impl expects 2D logits and 1D targets")
+    if logits.shape[0] != targets.shape[0]:
+        raise ValueError(
+            f"Expected matching rows, got logits={tuple(logits.shape)} targets={tuple(targets.shape)}"
+        )
+    n_rows = logits.shape[0]
+    return (
+        logits.new_empty((n_rows,), dtype=torch.float32),
+        logits.new_empty((n_rows,), dtype=torch.float32),
+    )
+
+
+@torch.library.custom_op(
+    f"{_FUSED_CE_LIBRARY}::softcapped_ce_backward", mutates_args=()
+)
+def softcapped_ce_backward_op(
+    logits: Tensor,
+    targets: Tensor,
+    lse: Tensor,
+    grad_losses: Tensor,
+    softcap: float,
+) -> Tensor:
+    logits, targets = _validate_softcapped_ce_inputs(logits, targets, float(softcap))
+    lse = lse.contiguous()
+    grad_losses = grad_losses.contiguous().to(dtype=torch.float32)
+    if lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError("Expected 1D lse and grad_losses")
+    if lse.shape[0] != logits.shape[0] or grad_losses.shape[0] != logits.shape[0]:
+        raise ValueError(
+            f"Expected row-aligned lse/grad_losses, got logits={tuple(logits.shape)} "
+            f"lse={tuple(lse.shape)} grad_losses={tuple(grad_losses.shape)}"
+        )
+    grad_logits = torch.empty_like(logits)
+    n_rows, n_cols = logits.shape
+    _softcapped_ce_bwd_kernel[(n_rows,)](
+        grad_logits,
+        grad_losses,
+        lse,
+        logits,
+        targets,
+        logits.stride(0),
+        logits.stride(1),
+        grad_logits.stride(0),
+        grad_logits.stride(1),
+        n_rows,
+        n_cols,
+        float(softcap),
+        block_size=_FUSED_CE_BLOCK_SIZE,
+        num_warps=_FUSED_CE_NUM_WARPS,
+    )
+    return grad_logits
+
+
+@softcapped_ce_backward_op.register_fake
+def _(
+    logits: Tensor, targets: Tensor, lse: Tensor, grad_losses: Tensor, softcap: float
+):
+    if logits.ndim != 2 or targets.ndim != 1 or lse.ndim != 1 or grad_losses.ndim != 1:
+        raise ValueError(
+            "softcapped_ce_backward fake impl expects 2D logits and 1D row tensors"
+        )
+    if (
+        logits.shape[0] != targets.shape[0]
+        or logits.shape[0] != lse.shape[0]
+        or logits.shape[0] != grad_losses.shape[0]
+    ):
+        raise ValueError("softcapped_ce_backward fake impl expects row-aligned tensors")
+    return logits.new_empty(logits.shape)
+
+
+def _softcapped_ce_setup_context(
+    ctx: torch.autograd.function.FunctionCtx,
+    inputs,
+    output,
+) -> None:
+    logits, targets, softcap = inputs
+    _losses, lse = output
+    ctx.save_for_backward(logits, targets, lse)
+    ctx.softcap = float(softcap)
+
+
+def _softcapped_ce_backward(
+    ctx: torch.autograd.function.FunctionCtx,
+    grad_losses: Tensor,
+    grad_lse: "Tensor | None",
+):
+    del grad_lse
+    logits, targets, lse = ctx.saved_tensors
+    grad_logits = torch.ops.pgsubmission1draft7fusedce.softcapped_ce_backward(
+        logits, targets, lse, grad_losses, ctx.softcap
+    )
+    return grad_logits, None, None
+
+
+softcapped_ce_op.register_autograd(
+    _softcapped_ce_backward,
+    setup_context=_softcapped_ce_setup_context,
+)
+
+
+def softcapped_cross_entropy(
+    logits: Tensor,
+    targets: Tensor,
+    softcap: float,
+    reduction: str = "mean",
+) -> Tensor:
+    losses, _lse = torch.ops.pgsubmission1draft7fusedce.softcapped_ce(
+        logits, targets, float(softcap)
+    )
+    if reduction == "none":
+        return losses
+    if reduction == "sum":
+        return losses.sum()
+    if reduction == "mean":
+        return losses.mean()
+    raise ValueError(f"Unsupported reduction={reduction!r}")
+
+
+class Hyperparameters:
+    data_dir = os.environ.get("DATA_DIR", "./data/")
+    seed = int(os.environ.get("SEED", 1337))
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.75))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786432))
+    # Fused softcapped CE (Triton). Training-only — forward_logits eval path still uses
+    # eager softcap+F.cross_entropy. Default ON since validated as at-worst neutral.
+    fused_ce_enabled = bool(int(os.environ.get("FUSED_CE_ENABLED", "1")))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 6e2))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 3e1))
+    rope_base = float(os.environ.get("ROPE_BASE", 1e4))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    rope_yarn = bool(int(os.environ.get("ROPE_YARN", "0")))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.0))
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    # ART-style soft recurrence: keep the static loop graph, but let a tiny
+    # zero-init router scale the delta from repeated recursive block calls.
+    # This variant uses alpha = 1 + range*tanh(router(h[:window]) + site_bias),
+    # which initializes exactly to identity and keeps symmetric gradients around
+    # the record recurrence instead of saturating through a sigmoid.
+    art_delta_gate_enabled = bool(int(os.environ.get("ART_DELTA_GATE_ENABLED", "1")))
+    art_delta_gate_window = int(os.environ.get("ART_DELTA_GATE_WINDOW", "12"))
+    art_delta_gate_scale = float(os.environ.get("ART_DELTA_GATE_SCALE", "1.0"))
+    art_delta_repeated_only = bool(int(os.environ.get("ART_DELTA_REPEATED_ONLY", "1")))
+    art_delta_site_gates = bool(int(os.environ.get("ART_DELTA_SITE_GATES", "1")))
+    art_delta_max_scale = float(os.environ.get("ART_DELTA_MAX_SCALE", "3.0"))
+    art_delta_init_alpha = float(os.environ.get("ART_DELTA_INIT_ALPHA", "1.0"))
+    art_delta_tanh_range = float(os.environ.get("ART_DELTA_TANH_RANGE", "1.0"))
+    art_delta_probe_every = int(os.environ.get("ART_DELTA_PROBE_EVERY", "50"))
+    art_delta_probe_tokens = int(os.environ.get("ART_DELTA_PROBE_TOKENS", "2048"))
+    parallel_start_layer = int(os.environ.get("PARALLEL_START_LAYER", 8))
+    parallel_final_lane = os.environ.get("PARALLEL_FINAL_LANE", "mean")
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.026))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.97))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 1500))
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-08))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.02))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_activate_at = float(os.environ.get("EMA_ACTIVATE_AT", "0.55"))
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "1")))
+    ttt_lora_rank = int(os.environ.get("TTT_LORA_RANK", 96))
+    ttt_lora_lr = float(os.environ.get("TTT_LORA_LR", 0.0001))
+    ttt_chunk_size = int(os.environ.get("TTT_CHUNK_SIZE", 48))
+    ttt_eval_seq_len = int(os.environ.get("TTT_EVAL_SEQ_LEN", 2048))
+    ttt_batch_size = int(os.environ.get("TTT_BATCH_SIZE", 64))
+    ttt_grad_steps = int(os.environ.get("TTT_GRAD_STEPS", 1))
+    ttt_weight_decay = float(os.environ.get("TTT_WEIGHT_DECAY", 1.0))
+    ttt_beta1 = float(os.environ.get("TTT_BETA1", 0))
+    ttt_beta2 = float(os.environ.get("TTT_BETA2", 0.999))
+    ttt_k_lora = bool(int(os.environ.get("TTT_K_LORA", "1")))
+    ttt_mlp_lora = bool(int(os.environ.get("TTT_MLP_LORA", "1")))
+    ttt_o_lora = bool(int(os.environ.get("TTT_O_LORA", "1")))
+    ttt_optimizer = os.environ.get("TTT_OPTIMIZER", "adam")
+    ttt_eval_batches = os.environ.get("TTT_EVAL_BATCHES", "")
+    val_doc_fraction = float(os.environ.get("VAL_DOC_FRACTION", 1.0))
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 16))
+    gptq_reserve_seconds = float(os.environ.get("GPTQ_RESERVE_SECONDS", 4.0))
+    phased_ttt_prefix_docs = int(os.environ.get("PHASED_TTT_PREFIX_DOCS", 2000))
+    phased_ttt_num_phases = int(os.environ.get("PHASED_TTT_NUM_PHASES", 1))
+    global_ttt_lr = float(os.environ.get("GLOBAL_TTT_LR", 0.001))
+    global_ttt_momentum = float(os.environ.get("GLOBAL_TTT_MOMENTUM", 0.9))
+    global_ttt_epochs = int(os.environ.get("GLOBAL_TTT_EPOCHS", 1))
+    global_ttt_chunk_tokens = int(os.environ.get("GLOBAL_TTT_CHUNK_TOKENS", 32768))
+    global_ttt_batch_seqs = int(os.environ.get("GLOBAL_TTT_BATCH_SEQS", 32))
+    global_ttt_warmup_start_lr = float(
+        os.environ.get("GLOBAL_TTT_WARMUP_START_LR", 0.0)
+    )
+    global_ttt_warmup_chunks = int(os.environ.get("GLOBAL_TTT_WARMUP_CHUNKS", 0))
+    global_ttt_grad_clip = float(os.environ.get("GLOBAL_TTT_GRAD_CLIP", 1.0))
+    global_ttt_respect_doc_boundaries = bool(
+        int(os.environ.get("GLOBAL_TTT_RESPECT_DOC_BOUNDARIES", "1"))
+    )
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 2e1))
+    mlp_clip_sigmas = float(os.environ.get("MLP_CLIP_SIGMAS", 10.0))
+    attn_clip_sigmas = float(os.environ.get("ATTN_CLIP_SIGMAS", 13.0))
+    # AttnOutGate (per-head multiplicative output gate, PR #1667 MarioPaerle).
+    # Zero-init weight: 2*sigmoid(0)=1 -> transparent at start. Source defaults to
+    # block input x ('proj'); 'q' uses raw Q projection output.
+    attn_out_gate_enabled = bool(int(os.environ.get("ATTN_OUT_GATE_ENABLED", "0")))
+    attn_out_gate_src = os.environ.get("ATTN_OUT_GATE_SRC", "proj")
+    # SmearGate (input-dependent forward-1 token smear, modded-nanogpt @classiclarryd
+    # via PR #1667). x_t <- x_t + lam * sigmoid(W*x_t[:gate_window]) * x_{t-1}.
+    # lam=0 + W=0 -> transparent at init.
+    smear_gate_enabled = bool(int(os.environ.get("SMEAR_GATE_ENABLED", "0")))
+    # Window: first GATE_WINDOW dims of the source feed the gate projection.
+    gate_window = int(os.environ.get("GATE_WINDOW", 12))
+    # Gated Attention (Qwen, NeurIPS 2025 Best Paper, arXiv:2505.06708;
+    # qiuzh20/gated_attention). Per-head sigmoid gate on SDPA output, BEFORE
+    # out_proj. Gate input = full block input x (paper's headwise G1 variant
+    # driven from hidden_states). W_g shape (num_heads, dim), plain sigmoid.
+    # Near-zero init gives g~0.5 at step 0 (half attention output); per-block
+    # attn_scale (init 1.0) compensates during training. Name contains
+    # "attn_gate" so CONTROL_TENSOR_NAME_PATTERNS routes it to scalar AdamW.
+    gated_attn_enabled = bool(int(os.environ.get("GATED_ATTN_ENABLED", "0")))
+    gated_attn_init_std = float(os.environ.get("GATED_ATTN_INIT_STD", 0.01))
+    # Dedicated int8-per-row quantization for `attn_gate_w` tensors. These are
+    # small ((num_heads, dim) = (8, 512) = 4096 params) and bypass GPTQ via the
+    # numel<=65536 passthrough branch -> stored as fp16 (8 KB/layer, ~65 KB total
+    # compressed). int8-per-row cuts the raw tensor in half with negligible BPB
+    # impact: scales per head (8 values), symmetric quant over [-127, 127].
+    # No Hessian needed (gate weights not in collect_hessians()).
+    gated_attn_quant_gate = bool(int(os.environ.get("GATED_ATTN_QUANT_GATE", "0")))
+    # Sparse Attention Gate (modded-nanogpt-style). Keeps dense SDPA and only
+    # swaps the output-gate input to the first GATE_WINDOW residual dims.
+    # W_g: (num_heads, gate_window) = (8, 12) = 96 params/layer (~44K total),
+    # vs dense GatedAttn's (8, 512) = 4K/layer (~44K diff). Name "attn_gate_w"
+    # is shared so quant routing and int8 gate passthrough Just Work. Gate
+    # passthrough int8 still applies via GATED_ATTN_QUANT_GATE=1.
+    # Mutually exclusive with ATTN_OUT_GATE_ENABLED and GATED_ATTN_ENABLED.
+    sparse_attn_gate_enabled = bool(
+        int(os.environ.get("SPARSE_ATTN_GATE_ENABLED", "0"))
+    )
+    sparse_attn_gate_init_std = float(os.environ.get("SPARSE_ATTN_GATE_INIT_STD", 0.0))
+    sparse_attn_gate_scale = float(os.environ.get("SPARSE_ATTN_GATE_SCALE", 1.0))
+    # LQER asymmetric rank-k correction on top-K quant-error tensors (PR #1530 v2 port).
+    # Computes SVD of E = W_fp - W_quant, packs top-r A,B as INT2/INT4 (asym) or INTk (sym).
+    lqer_enabled = bool(int(os.environ.get("LQER_ENABLED", "1")))
+    lqer_rank = int(os.environ.get("LQER_RANK", 4))
+    lqer_top_k = int(os.environ.get("LQER_TOP_K", 3))
+    lqer_factor_bits = int(os.environ.get("LQER_FACTOR_BITS", 4))
+    lqer_asym_enabled = bool(int(os.environ.get("LQER_ASYM_ENABLED", "1")))
+    lqer_asym_group = int(os.environ.get("LQER_ASYM_GROUP", "64"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = 8 // world_size
+    # CaseOps integration: optional override of dataset root + tokenizer path.
+    # When CASEOPS_ENABLED=1, the wrapper loads a per-token byte sidecar
+    # (fineweb_val_bytes_*.bin, identical shard layout to val_*.bin) and uses
+    # it as the canonical raw-byte budget for BPB accounting. The sidecar
+    # REPLACES the build_sentencepiece_luts byte-counting path entirely.
+    caseops_enabled = bool(int(os.environ.get("CASEOPS_ENABLED", "1")))
+    _default_caseops_data = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "datasets",
+        "fineweb10B_sp8192_lossless_caps_caseops_v1_reserved",
+    )
+    _default_caseops_tok = os.path.join(
+        data_dir,
+        "datasets",
+        "fineweb10B_sp8192_caseops",
+        "datasets",
+        "tokenizers",
+        "fineweb_8192_bpe_lossless_caps_caseops_v1_reserved.model",
+    )
+    if caseops_enabled:
+        datasets_dir = os.environ.get("DATA_PATH", _default_caseops_data)
+        tokenizer_path = os.environ.get("TOKENIZER_PATH", _default_caseops_tok)
+    else:
+        datasets_dir = os.environ.get(
+            "DATA_PATH",
+            os.path.join(data_dir, "datasets", f"fineweb10B_sp{vocab_size}"),
+        )
+        tokenizer_path = os.environ.get(
+            "TOKENIZER_PATH",
+            os.path.join(data_dir, "tokenizers", f"fineweb_{vocab_size}_bpe.model"),
+        )
+    train_files = os.path.join(datasets_dir, "fineweb_train_*.bin")
+    val_files = os.path.join(datasets_dir, "fineweb_val_*.bin")
+    val_bytes_files = os.path.join(datasets_dir, "fineweb_val_bytes_*.bin")
+    artifact_dir = os.environ.get("ARTIFACT_DIR", "")
+    logfile = (
+        os.path.join(artifact_dir, f"{run_id}.txt")
+        if artifact_dir
+        else f"logs/{run_id}.txt"
+    )
+    model_path = (
+        os.path.join(artifact_dir, "final_model.pt")
+        if artifact_dir
+        else "final_model.pt"
+    )
+    quantized_model_path = (
+        os.path.join(artifact_dir, "final_model.int6.ptz")
+        if artifact_dir
+        else "final_model.int6.ptz"
+    )
+
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.caseops_enabled = bool(getattr(h, "caseops_enabled", False))
+        if self.caseops_enabled:
+            self.base_bytes_lut = None
+            self.has_leading_space_lut = None
+            self.is_boundary_token_lut = None
+        else:
+            (
+                self.base_bytes_lut,
+                self.has_leading_space_lut,
+                self.is_boundary_token_lut,
+            ) = build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        self.val_bytes = None
+        if self.caseops_enabled:
+            self.val_bytes = load_validation_byte_sidecar(
+                h.val_bytes_files, h.eval_seq_len, self.val_tokens.numel()
+            )
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert sp.piece_to_id("▁") != sp.unk_id(), (
+        "Tokenizer must have '▁' (space) as its own token for correct BPB byte counting"
+    )
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern, seq_len):
+    # Filter out CaseOps byte sidecar shards which share the val_*.bin glob.
+    files = [
+        Path(p) for p in sorted(glob.glob(pattern)) if "_bytes_" not in Path(p).name
+    ]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def load_validation_byte_sidecar(pattern, seq_len, expected_len):
+    """Load CaseOps per-token byte sidecar(s). Same shard layout as token shards
+    (256 int32 header + uint16 array). Each entry = canonical raw-text byte
+    budget for that token in the corresponding val shard. Returns a CPU
+    int16 tensor sliced to match expected_len (i.e. val_tokens length)."""
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No byte sidecar files for pattern: {pattern}")
+    shards = [load_data_shard(file) for file in files]
+    # load_data_shard returns uint16 — that's exactly what the sidecar stores.
+    bytes_full = torch.cat(shards).contiguous()
+    if bytes_full.numel() < expected_len:
+        raise ValueError(
+            f"Byte sidecar too short: {bytes_full.numel()} < val_tokens {expected_len}"
+        )
+    return bytes_full[:expected_len].to(torch.int32)
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+BOS_ID = None
+
+
+def get_next_multiple_of_n(v, n):
+    return ((v + n - 1) // n) * n
+
+
+def _build_cu_seqlens(bos_pos, total_len, device, max_doc_len=0, bucket_size=64):
+    if not bos_pos or bos_pos[0] != 0:
+        bos_pos = [0] + bos_pos
+    seg_starts = []
+    starts_with_end = bos_pos + [total_len]
+    for i in range(len(starts_with_end) - 1):
+        start = starts_with_end[i]
+        end = starts_with_end[i + 1]
+        if max_doc_len > 0:
+            pos = start
+            while pos < end:
+                seg_starts.append(pos)
+                pos += max_doc_len
+        else:
+            seg_starts.append(start)
+    boundaries = seg_starts + [total_len]
+    padded_len = get_next_multiple_of_n(len(boundaries), bucket_size)
+    cu = torch.full((padded_len,), total_len, dtype=torch.int32, device=device)
+    cu[: len(boundaries)] = torch.tensor(boundaries, dtype=torch.int32, device=device)
+    seg_ends = seg_starts[1:] + [total_len]
+    max_seqlen = max(end - start for start, end in zip(seg_starts, seg_ends))
+    return cu, max_seqlen
+
+
+class DocumentPackingLoader:
+    _shard_pool = ThreadPoolExecutor(1)
+
+    def __init__(self, h, device, cu_bucket_size=64):
+        self.rank = h.rank
+        self.world_size = h.world_size
+        self.device = device
+        self.cu_bucket_size = cu_bucket_size
+        self.max_seq_len = h.train_seq_len
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files
+        self.file_iter = iter(self.files)
+        self._init_shard(load_data_shard(next(self.file_iter)))
+        self._next_shard = self._submit_next_shard()
+        self._batch_pool = ThreadPoolExecutor(1)
+        self._prefetch_queue = []
+
+    def _init_shard(self, tokens):
+        global BOS_ID
+        self.tokens = tokens
+        self.shard_size = tokens.numel()
+        if BOS_ID is None:
+            BOS_ID = 1
+        self.bos_idx = (
+            (tokens == BOS_ID).nonzero(as_tuple=True)[0].to(torch.int64).cpu().numpy()
+        )
+        self.cursor = int(self.bos_idx[0])
+
+    def _submit_next_shard(self):
+        try:
+            path = next(self.file_iter)
+            return self._shard_pool.submit(load_data_shard, path)
+        except StopIteration:
+            return None
+
+    def _advance_shard(self):
+        if self._next_shard is None:
+            self.file_iter = iter(self.files)
+            self._next_shard = self._shard_pool.submit(
+                load_data_shard, next(self.file_iter)
+            )
+        self._init_shard(self._next_shard.result())
+        self._next_shard = self._submit_next_shard()
+
+    def _local_doc_starts(self, local_start, total_len):
+        lo = np.searchsorted(self.bos_idx, local_start, side="left")
+        hi = np.searchsorted(self.bos_idx, local_start + total_len, side="left")
+        return (self.bos_idx[lo:hi] - local_start).tolist()
+
+    def _prepare_batch(self, num_tokens_local, max_seq_len):
+        per_rank_span = num_tokens_local + 1
+        global_span = per_rank_span * self.world_size
+        while self.cursor + global_span > self.shard_size:
+            self._advance_shard()
+        local_start = self.cursor + self.rank * per_rank_span
+        buf = self.tokens[local_start : local_start + per_rank_span]
+        inputs = torch.empty(per_rank_span - 1, dtype=torch.int64, pin_memory=True)
+        targets = torch.empty(per_rank_span - 1, dtype=torch.int64, pin_memory=True)
+        inputs.copy_(buf[:-1])
+        targets.copy_(buf[1:])
+        starts = self._local_doc_starts(local_start, inputs.numel())
+        cu_seqlens, max_seqlen = _build_cu_seqlens(
+            starts, inputs.numel(), inputs.device, max_seq_len, self.cu_bucket_size
+        )
+        cu_seqlens = cu_seqlens.pin_memory()
+        self.cursor += global_span
+        return inputs, targets, cu_seqlens, max_seqlen
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        num_tokens_local = global_tokens // (self.world_size * grad_accum_steps)
+        while len(self._prefetch_queue) < 2:
+            self._prefetch_queue.append(
+                self._batch_pool.submit(
+                    self._prepare_batch, num_tokens_local, self.max_seq_len
+                )
+            )
+        inputs, targets, cu_seqlens, max_seqlen = self._prefetch_queue.pop(0).result()
+        self._prefetch_queue.append(
+            self._batch_pool.submit(
+                self._prepare_batch, num_tokens_local, self.max_seq_len
+            )
+        )
+        return (
+            inputs[None].to(self.device, non_blocking=True),
+            targets[None].to(self.device, non_blocking=True),
+            cu_seqlens.to(self.device, non_blocking=True),
+            max_seqlen,
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        phase = int(self.rng.integers(max_phase + 1)) if max_phase > 0 else 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            total = remaining.sum()
+            if total <= 0:
+                for si in range(len(self.files)):
+                    self._reset_shard(si)
+                remaining = np.array(
+                    [len(s) for s in self.start_inds], dtype=np.float64
+                )
+                total = remaining.sum()
+            probs = remaining / total
+            si = int(self.rng.choice(len(self.files), p=probs))
+            start_ind = self.start_inds[si].pop()
+            remaining[si] -= 1
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+@triton.jit
+def linear_leaky_relu_square_kernel(
+    a_desc,
+    b_desc,
+    c_desc,
+    aux_desc,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_M: tl.constexpr,
+    BLOCK_SIZE_N: tl.constexpr,
+    BLOCK_SIZE_K: tl.constexpr,
+    NUM_SMS: tl.constexpr,
+    FORWARD: tl.constexpr,
+):
+    dtype = tl.bfloat16
+    start_pid = tl.program_id(axis=0)
+    num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
+    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    k_tiles = tl.cdiv(K, BLOCK_SIZE_K)
+    num_tiles = num_pid_m * num_pid_n
+    tile_id_c = start_pid - NUM_SMS
+    for tile_id in tl.range(start_pid, num_tiles, NUM_SMS, flatten=True):
+        pid_m = tile_id // num_pid_n
+        pid_n = tile_id % num_pid_n
+        offs_am = pid_m * BLOCK_SIZE_M
+        offs_bn = pid_n * BLOCK_SIZE_N
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        for ki in range(k_tiles):
+            offs_k = ki * BLOCK_SIZE_K
+            a = a_desc.load([offs_am, offs_k])
+            b = b_desc.load([offs_bn, offs_k])
+            accumulator = tl.dot(a, b.T, accumulator)
+        tile_id_c += NUM_SMS
+        offs_am_c = offs_am
+        offs_bn_c = offs_bn
+        acc = tl.reshape(accumulator, (BLOCK_SIZE_M, 2, BLOCK_SIZE_N // 2))
+        acc = tl.permute(acc, (0, 2, 1))
+        acc0, acc1 = tl.split(acc)
+        c0 = acc0.to(dtype)
+        c1 = acc1.to(dtype)
+        if not FORWARD:
+            pre0 = aux_desc.load([offs_am_c, offs_bn_c])
+            pre1 = aux_desc.load([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2])
+            c0 = c0 * tl.where(pre0 > 0, 2.0 * pre0, 0.5 * pre0)
+            c1 = c1 * tl.where(pre1 > 0, 2.0 * pre1, 0.5 * pre1)
+        c_desc.store([offs_am_c, offs_bn_c], c0)
+        c_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], c1)
+        if FORWARD:
+            aux0 = tl.where(c0 > 0, c0, 0.5 * c0)
+            aux1 = tl.where(c1 > 0, c1, 0.5 * c1)
+            aux_desc.store([offs_am_c, offs_bn_c], aux0 * aux0)
+            aux_desc.store([offs_am_c, offs_bn_c + BLOCK_SIZE_N // 2], aux1 * aux1)
+
+
+def linear_leaky_relu_square(a, b, aux=None):
+    M, K = a.shape
+    N, K2 = b.shape
+    assert K == K2
+    c = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    forward = aux is None
+    if aux is None:
+        aux = torch.empty((M, N), device=a.device, dtype=a.dtype)
+    num_sms = torch.cuda.get_device_properties(a.device).multi_processor_count
+    BLOCK_SIZE_M, BLOCK_SIZE_N, BLOCK_SIZE_K = 256, 128, 64
+    num_stages = 4 if forward else 3
+    a_desc = TensorDescriptor.from_tensor(a, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    b_desc = TensorDescriptor.from_tensor(b, [BLOCK_SIZE_N, BLOCK_SIZE_K])
+    c_desc = TensorDescriptor.from_tensor(c, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    aux_desc = TensorDescriptor.from_tensor(aux, [BLOCK_SIZE_M, BLOCK_SIZE_N // 2])
+    grid = lambda _meta: (
+        min(num_sms, triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N)),
+    )
+    linear_leaky_relu_square_kernel[grid](
+        a_desc,
+        b_desc,
+        c_desc,
+        aux_desc,
+        M,
+        N,
+        K,
+        BLOCK_SIZE_M=BLOCK_SIZE_M,
+        BLOCK_SIZE_N=BLOCK_SIZE_N,
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        NUM_SMS=num_sms,
+        FORWARD=forward,
+        num_stages=num_stages,
+        num_warps=8,
+    )
+    if forward:
+        return c, aux
+    return c
+
+
+class FusedLinearLeakyReLUSquareFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, w1, w2):
+        x_flat = x.reshape(-1, x.shape[-1])
+        pre, post = linear_leaky_relu_square(x_flat, w1)
+        out = F.linear(post, w2)
+        ctx.save_for_backward(x, w1, w2, pre, post)
+        return out.view(*x.shape[:-1], out.shape[-1])
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        x, w1, w2, pre, post = ctx.saved_tensors
+        x_flat = x.reshape(-1, x.shape[-1])
+        grad_output_flat = grad_output.reshape(-1, grad_output.shape[-1])
+        dw2 = grad_output_flat.T @ post
+        dpre = linear_leaky_relu_square(grad_output_flat, w2.T.contiguous(), aux=pre)
+        dw1 = dpre.T @ x_flat
+        dx = dpre @ w1
+        return dx.view_as(x), dw1, dw2
+
+
+FusedLeakyReLUSquareMLP = FusedLinearLeakyReLUSquareFunction.apply
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0, yarn=True):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.yarn = yarn
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached < seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            if self.yarn and seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                new_base = self.base * scale ** (rd / (rd - 2))
+                inv_freq = 1.0 / new_base ** (
+                    torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+                )
+            else:
+                inv_freq = self.inv_freq.float().to(device)
+            t = torch.arange(seq_len, device=device, dtype=torch.float32)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached[:, :seq_len].to(dtype=dtype), self._sin_cached[
+            :, :seq_len
+        ].to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        if int(attn_out_gate) + int(gated_attn) + int(sparse_attn_gate) > 1:
+            raise ValueError(
+                "attn_out_gate, gated_attn, and sparse_attn_gate are mutually exclusive"
+            )
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads,), qk_gain_init, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(
+            self.head_dim, base=rope_base, train_seq_len=train_seq_len, yarn=yarn
+        )
+        self.use_xsa = False
+        # AttnOutGate (PR #1667 MarioPaerle): per-head multiplicative gate on attention
+        # output. CastedLinear so restore_fp32_params casts back to fp32 for GPTQ.
+        # _zero_init -> 2*sigmoid(0)=1 -> transparent at init.
+        self.attn_out_gate = attn_out_gate
+        self.attn_out_gate_src = attn_out_gate_src
+        self.gate_window = gate_window
+        if attn_out_gate:
+            self.attn_gate_proj = CastedLinear(gate_window, num_heads, bias=False)
+            self.attn_gate_proj._zero_init = True
+        # Gated Attention (arXiv:2505.06708, Qwen, NeurIPS 2025). Per-head sigmoid
+        # gate on SDPA output, BEFORE out_proj. Gate projection W_g: (num_heads, dim).
+        # Name "attn_gate_w" contains "attn_gate" substring so it matches
+        # CONTROL_TENSOR_NAME_PATTERNS and routes to the scalar AdamW group.
+        # fp32 Parameter -> restore_fp32_params path covers it via the ndim<2 OR
+        # name-pattern check (name matches "attn_gate"). Cast to x.dtype on use.
+        self.gated_attn = gated_attn
+        if gated_attn:
+            W = torch.empty(num_heads, dim, dtype=torch.float32)
+            nn.init.normal_(W, mean=0.0, std=gated_attn_init_std)
+            self.attn_gate_w = nn.Parameter(W)
+        # Sparse attention head-output gate (modded-nanogpt style). Keeps dense SDPA
+        # and only narrows the gate input to the first gate_window residual dims.
+        # W_g: (num_heads, gate_window). y_{t,h} <- sigmoid(scale * W_g_h @ x_t[:gate_window]) * y_{t,h}.
+        # Shares attn_gate_w name with dense GatedAttn so the quant routing
+        # (CONTROL_TENSOR_NAME_PATTERNS / attn_gate_w int8 passthrough) is unchanged.
+        self.sparse_attn_gate = sparse_attn_gate
+        self.sparse_attn_gate_scale = sparse_attn_gate_scale
+        if sparse_attn_gate:
+            W = torch.empty(num_heads, gate_window, dtype=torch.float32)
+            if sparse_attn_gate_init_std > 0:
+                nn.init.normal_(W, mean=0.0, std=sparse_attn_gate_init_std)
+            else:
+                nn.init.zeros_(W)
+            self.attn_gate_w = nn.Parameter(W)
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x, q_w, k_w, v_w, out_w, cu_seqlens=None, max_seqlen=0):
+        bsz, seqlen, dim = x.shape
+        # q_raw kept around as a tap point for attn_out_gate_src='q' (post-projection,
+        # pre-reshape, pre-RoPE).
+        q_raw = F.linear(x, q_w.to(x.dtype))
+        q = q_raw.reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = F.linear(x, k_w.to(x.dtype)).reshape(
+            bsz, seqlen, self.num_kv_heads, self.head_dim
+        )
+        v = F.linear(x, v_w.to(x.dtype)).reshape(
+            bsz, seqlen, self.num_kv_heads, self.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        q = q * self.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        if cu_seqlens is not None:
+            y = flash_attn_varlen_func(
+                q[0],
+                k[0],
+                v[0],
+                cu_seqlens_q=cu_seqlens,
+                cu_seqlens_k=cu_seqlens,
+                max_seqlen_q=max_seqlen,
+                max_seqlen_k=max_seqlen,
+                causal=True,
+                window_size=(-1, -1),
+            )[None]
+        else:
+            y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        # AttnOutGate inlined (PR #1667). Inline + .contiguous() barrier so torch.compile
+        # fullgraph=True is happy (this avoids the @torch.compiler.disable trap that
+        # crashed gates v3). Per-head gate on (B,T,H,D) tensor: g shape [B,T,H], broadcast
+        # over D via [..., None]. zero-init weight -> 2*sigmoid(0)=1 -> transparent.
+        if self.attn_out_gate:
+            gate_src = q_raw if self.attn_out_gate_src == "q" else x
+            gate_in = gate_src[..., : self.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(self.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (arXiv:2505.06708 G1). Inline + .contiguous() barrier so
+        # torch.compile fullgraph=True is happy. Per-head gate on (B,T,H,D): g shape
+        # [B,T,H], broadcast over D via [..., None]. Paper: g = sigmoid(x @ W_g.T)
+        # where W_g: (H, dim). .to(x.dtype) on fp32 param before broadcast with bf16.
+        if self.gated_attn:
+            x_c = x.contiguous()
+            g = torch.sigmoid(F.linear(x_c, self.attn_gate_w.to(x.dtype)))
+            y = y * g[..., None]
+        # Sparse head-output gate: narrower (gate_window) input, same shape g as GatedAttn.
+        if self.sparse_attn_gate:
+            gate_in = x[..., : self.gate_window].contiguous()
+            g = torch.sigmoid(
+                self.sparse_attn_gate_scale
+                * F.linear(gate_in, self.attn_gate_w.to(x.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        self._last_proj_input = y.detach() if getattr(self, "_calib", False) else None
+        return F.linear(y, out_w.to(x.dtype))
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        self.use_fused = True
+
+    def forward(self, x, up_w, down_w):
+        if self.training and self.use_fused:
+            return FusedLeakyReLUSquareMLP(x, up_w.to(x.dtype), down_w.to(x.dtype))
+        hidden = F.leaky_relu(
+            F.linear(x, up_w.to(x.dtype)), negative_slope=0.5
+        ).square()
+        self._last_down_input = (
+            hidden.detach() if getattr(self, "_calib", False) else None
+        )
+        return F.linear(hidden, down_w.to(x.dtype))
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+        yarn=True,
+        attn_out_gate=False,
+        attn_out_gate_src="proj",
+        gate_window=12,
+        gated_attn=False,
+        gated_attn_init_std=0.01,
+        sparse_attn_gate=False,
+        sparse_attn_gate_init_std=0.0,
+        sparse_attn_gate_scale=1.0,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim,
+            num_heads,
+            num_kv_heads,
+            rope_base,
+            qk_gain_init,
+            train_seq_len,
+            yarn=yarn,
+            attn_out_gate=attn_out_gate,
+            attn_out_gate_src=attn_out_gate_src,
+            gate_window=gate_window,
+            gated_attn=gated_attn,
+            gated_attn_init_std=gated_attn_init_std,
+            sparse_attn_gate=sparse_attn_gate,
+            sparse_attn_gate_init_std=sparse_attn_gate_init_std,
+            sparse_attn_gate_scale=sparse_attn_gate_scale,
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+
+    def forward(
+        self, x, x0, q_w, k_w, v_w, out_w, up_w, down_w, cu_seqlens=None, max_seqlen=0
+    ):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(
+            self.attn_norm(x_in) * self.ln_scale_factor,
+            q_w,
+            k_w,
+            v_w,
+            out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        x_out = x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * self.mlp(
+            self.mlp_norm(x_out) * self.ln_scale_factor, up_w, down_w
+        )
+        return x_out
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.fused_ce_enabled = bool(h.fused_ce_enabled)
+        self.tok_emb = nn.Embedding(h.vocab_size, h.model_dim)
+        self.num_layers = h.num_layers
+        head_dim = h.model_dim // h.num_heads
+        kv_dim = h.num_kv_heads * head_dim
+        hidden_dim = int(h.mlp_mult * h.model_dim)
+        self.qo_bank = nn.Parameter(
+            torch.empty(2 * h.num_layers, h.model_dim, h.model_dim)
+        )
+        self.kv_bank = nn.Parameter(torch.empty(2 * h.num_layers, kv_dim, h.model_dim))
+        self.mlp_up_bank = nn.Parameter(
+            torch.empty(h.num_layers, hidden_dim, h.model_dim)
+        )
+        self.mlp_down_bank = nn.Parameter(
+            torch.empty(h.num_layers, h.model_dim, hidden_dim)
+        )
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                    yarn=h.rope_yarn,
+                    attn_out_gate=h.attn_out_gate_enabled,
+                    attn_out_gate_src=h.attn_out_gate_src,
+                    gate_window=h.gate_window,
+                    gated_attn=h.gated_attn_enabled,
+                    gated_attn_init_std=h.gated_attn_init_std,
+                    sparse_attn_gate=h.sparse_attn_gate_enabled,
+                    sparse_attn_gate_init_std=h.sparse_attn_gate_init_std,
+                    sparse_attn_gate_scale=h.sparse_attn_gate_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.train_seq_len,
+                    rope_dims=h.rope_dims,
+                    yarn=h.rope_yarn,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.model_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self.parallel_start_layer = h.parallel_start_layer
+        self.parallel_final_lane = h.parallel_final_lane.lower()
+        self.parallel_post_lambdas = nn.Parameter(
+            torch.ones(h.num_layers, 2, 2, dtype=torch.float32)
+        )
+        self.parallel_resid_lambdas = nn.Parameter(
+            torch.full((h.num_layers, 2), 1.1, dtype=torch.float32)
+        )
+        # SmearGate (PR #1667 / modded-nanogpt @classiclarryd):
+        #   x_t <- x_t + lam * sigmoid(W * x_t[:gate_window]) * x_{t-1}.
+        # Per-token forward-1 smear of the embedding lane. W zero-init + lam=0 ->
+        # transparent at init. Uses CastedLinear so restore_fp32_params handles dtype.
+        self.smear_gate_enabled = h.smear_gate_enabled
+        if self.smear_gate_enabled:
+            self.smear_window = h.gate_window
+            self.smear_gate = CastedLinear(self.smear_window, 1, bias=False)
+            self.smear_gate._zero_init = True
+            self.smear_lambda = nn.Parameter(torch.zeros(1, dtype=torch.float32))
+        self.art_delta_gate_enabled = bool(h.art_delta_gate_enabled)
+        self.art_delta_loop_start = h.loop_start
+        self.art_delta_loop_end = h.loop_end
+        self.art_delta_repeated_only = bool(h.art_delta_repeated_only)
+        self.art_delta_site_gates = bool(h.art_delta_site_gates)
+        self.art_delta_max_scale = float(h.art_delta_max_scale)
+        self.art_delta_init_alpha = float(h.art_delta_init_alpha)
+        self.art_delta_tanh_range = float(h.art_delta_tanh_range)
+        self.art_delta_gate_scale = h.art_delta_gate_scale
+        if self.art_delta_gate_enabled:
+            if self.art_delta_tanh_range <= 0.0:
+                raise ValueError(
+                    f"ART_DELTA_TANH_RANGE must be positive, got {self.art_delta_tanh_range}"
+                )
+            self.art_delta_gate_window = min(h.art_delta_gate_window, h.model_dim)
+            self.art_delta_site_count = (
+                (self.art_delta_loop_end - self.art_delta_loop_start + 1) * 2
+                if self.art_delta_site_gates
+                else 1
+            )
+            self.art_delta_gate = CastedLinear(
+                self.art_delta_gate_window, self.art_delta_site_count, bias=False
+            )
+            self.art_delta_gate._zero_init = True
+            self.art_delta_site_bias = nn.Parameter(
+                torch.zeros((self.art_delta_site_count,), dtype=torch.float32)
+            )
+        self._art_delta_stats = None
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        n = self.num_layers
+        proj_scale = 1.0 / math.sqrt(2 * n)
+        for i in range(n):
+            nn.init.orthogonal_(self.qo_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.qo_bank.data[n + i])
+            self.qo_bank.data[n + i].mul_(proj_scale)
+            nn.init.orthogonal_(self.kv_bank.data[i], gain=1.0)
+            nn.init.orthogonal_(self.kv_bank.data[n + i], gain=1.0)
+        for i in range(n):
+            nn.init.orthogonal_(self.mlp_up_bank.data[i], gain=1.0)
+            nn.init.zeros_(self.mlp_down_bank.data[i])
+            self.mlp_down_bank.data[i].mul_(proj_scale)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _bank_weights(self, i):
+        n = self.num_layers
+        return (
+            self.qo_bank[i],
+            self.kv_bank[i],
+            self.kv_bank[n + i],
+            self.qo_bank[n + i],
+            self.mlp_up_bank[i],
+            self.mlp_down_bank[i],
+        )
+
+    def _parallel_block(
+        self,
+        block_idx,
+        lane0,
+        lane1,
+        x0,
+        q_w,
+        k_w,
+        v_w,
+        out_w,
+        up_w,
+        down_w,
+        cu_seqlens=None,
+        max_seqlen=0,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        attn_out = block.attn(
+            block.attn_norm(attn_read) * block.ln_scale_factor,
+            q_w,
+            k_w,
+            v_w,
+            out_w,
+            cu_seqlens=cu_seqlens,
+            max_seqlen=max_seqlen,
+        )
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * block.mlp(
+            block.mlp_norm(mlp_read) * block.ln_scale_factor, up_w, down_w
+        )
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+    def _final_parallel_hidden(self, lane0, lane1):
+        if self.parallel_final_lane == "mlp":
+            return lane1
+        if self.parallel_final_lane == "attn":
+            return lane0
+        return 0.5 * (lane0 + lane1)
+
+    def _apply_art_delta_gate(self, block_idx, occurrence_idx, x_before, x_after):
+        if not self.art_delta_gate_enabled:
+            return x_after
+        if block_idx < self.art_delta_loop_start or block_idx > self.art_delta_loop_end:
+            return x_after
+        if self.art_delta_repeated_only and occurrence_idx <= 1:
+            return x_after
+        gate_in = x_before[..., : self.art_delta_gate_window].contiguous()
+        if self.art_delta_site_gates:
+            if occurrence_idx < 2 or occurrence_idx > 3:
+                raise ValueError(
+                    "site-gated ART delta expects only occurrence 2/3 for loop blocks"
+                )
+            site_idx = (block_idx - self.art_delta_loop_start) * 2 + (
+                occurrence_idx - 2
+            )
+            gate_logits = self.art_delta_gate(gate_in)[..., site_idx : site_idx + 1]
+            gate_bias = self.art_delta_site_bias[site_idx].to(dtype=x_before.dtype)
+        else:
+            site_idx = 0
+            gate_logits = self.art_delta_gate(gate_in)
+            gate_bias = self.art_delta_site_bias[0].to(dtype=x_before.dtype)
+        gate_logits = gate_bias + self.art_delta_gate_scale * gate_logits
+        alpha = 1.0 + self.art_delta_tanh_range * torch.tanh(gate_logits)
+        delta = x_after - x_before
+        if self._art_delta_stats is not None:
+            with torch.no_grad():
+                alpha_f = alpha.detach().float()
+                logits_f = gate_logits.detach().float()
+                delta_f = delta.detach().float()
+                gated_delta_f = alpha_f * delta_f
+                self._art_delta_stats.append(
+                    (
+                        block_idx,
+                        occurrence_idx,
+                        site_idx,
+                        alpha_f.mean(),
+                        alpha_f.std(unbiased=False),
+                        alpha_f.amin(),
+                        alpha_f.amax(),
+                        logits_f.mean(),
+                        logits_f.std(unbiased=False),
+                        torch.linalg.vector_norm(delta_f)
+                        / math.sqrt(max(delta_f.numel(), 1)),
+                        torch.linalg.vector_norm(gated_delta_f)
+                        / math.sqrt(max(gated_delta_f.numel(), 1)),
+                    )
+                )
+        return x_before + alpha * delta
+
+    def _forward_hidden(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        """Run the encoder/decoder stack to the final RMSNorm; returns pre-projection hidden.
+        Shared by eval (softcap+projection via forward_logits) and train (fused CE path)."""
+        x = self.tok_emb(input_ids)
+        # SmearGate (PR #1667). lam=0 + W=0 -> identity at init.
+        # Cross-doc leak fix: zero the prev-token smear at any position whose current token
+        # is BOS, so the BOS embedding starting doc N+1 in a packed stream is not
+        # contaminated by doc N's last token (audited issue on PR#1797 base).
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            not_bos = (input_ids[:, 1:] != BOS_ID).to(x.dtype).unsqueeze(-1)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1] * not_bos], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else range(self.num_encoder_layers)
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else range(
+                self.num_encoder_layers,
+                self.num_encoder_layers + self.num_decoder_layers,
+            )
+        )
+        loop_counts = [0] * self.num_layers
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x_before = x
+            x_after = self.blocks[i](
+                x,
+                x0,
+                q_w,
+                k_w,
+                v_w,
+                out_w,
+                up_w,
+                down_w,
+                cu_seqlens=cu_seqlens,
+                max_seqlen=max_seqlen,
+            )
+            loop_counts[i] += 1
+            x = self._apply_art_delta_gate(i, loop_counts[i], x_before, x_after)
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(
+                            self.skip_gates[skip_idx].to(dtype=lane0.dtype)
+                        )[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block(
+                    i,
+                    lane0,
+                    lane1,
+                    x0,
+                    q_w,
+                    k_w,
+                    v_w,
+                    out_w,
+                    up_w,
+                    down_w,
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                            None, None, :
+                        ]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x_before = x
+                x_after = self.blocks[i](
+                    x,
+                    x0,
+                    q_w,
+                    k_w,
+                    v_w,
+                    out_w,
+                    up_w,
+                    down_w,
+                    cu_seqlens=cu_seqlens,
+                    max_seqlen=max_seqlen,
+                )
+                loop_counts[i] += 1
+                x = self._apply_art_delta_gate(i, loop_counts[i], x_before, x_after)
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        return x
+
+    def _project_logits(self, hidden):
+        if self.tie_embeddings:
+            return F.linear(hidden, self.tok_emb.weight)
+        return self.lm_head(hidden)
+
+    def forward_logits(self, input_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(self, input_ids, target_ids, cu_seqlens=None, max_seqlen=0):
+        hidden = self._forward_hidden(
+            input_ids, cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+        )
+        logits_proj = self._project_logits(hidden)
+        flat_targets = target_ids.reshape(-1)
+        # Fused softcapped-CE kernel (training path only). Applies softcap inside the
+        # Triton kernel; takes pre-softcap logits_proj. Non-fused path matches stock
+        # PR-1736 numerics exactly (softcap in fp32, then F.cross_entropy on fp32).
+        if self.fused_ce_enabled:
+            return softcapped_cross_entropy(
+                logits_proj.reshape(-1, logits_proj.size(-1)),
+                flat_targets,
+                self.logit_softcap,
+                reduction="mean",
+            )
+        logits = self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+        return F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            flat_targets,
+            reduction="mean",
+        )
+
+    def forward_ttt(self, input_ids, target_ids, lora):
+        x = self.tok_emb(input_ids)
+        # SmearGate on the TTT path — same inline compute as forward_logits.
+        # Cross-doc leak fix: see _forward_hidden comment.
+        if self.smear_gate_enabled:
+            sl = self.smear_lambda.to(dtype=x.dtype)
+            gate_in = x[:, 1:, : self.smear_window].contiguous()
+            g = sl * torch.sigmoid(self.smear_gate(gate_in))
+            not_bos = (input_ids[:, 1:] != BOS_ID).to(x.dtype).unsqueeze(-1)
+            x = torch.cat([x[:, :1], x[:, 1:] + g * x[:, :-1] * not_bos], dim=1)
+        x = F.rms_norm(x, (x.size(-1),))
+        x0 = x
+        skips = []
+        enc_iter = (
+            self.encoder_indices
+            if self.looping_active
+            else list(range(self.num_encoder_layers))
+        )
+        dec_iter = (
+            self.decoder_indices
+            if self.looping_active
+            else list(
+                range(
+                    self.num_encoder_layers,
+                    self.num_encoder_layers + self.num_decoder_layers,
+                )
+            )
+        )
+        slot = 0
+        loop_counts = [0] * self.num_layers
+        for i in enc_iter:
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            x_before = x
+            x_after = self._block_with_lora(
+                self.blocks[i], x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w
+            )
+            loop_counts[i] += 1
+            x = self._apply_art_delta_gate(i, loop_counts[i], x_before, x_after)
+            slot += 1
+            skips.append(x)
+        psl = self.parallel_start_layer
+        lane0 = None
+        lane1 = None
+        for skip_idx, i in enumerate(dec_iter):
+            q_w, k_w, v_w, out_w, up_w, down_w = self._bank_weights(i)
+            if i >= psl and psl > 0:
+                if lane0 is None:
+                    lane0 = x
+                    lane1 = x
+                if skip_idx < self.num_skip_weights and skips:
+                    skip = skips.pop()
+                    w = self.skip_weights[skip_idx].to(dtype=lane0.dtype)[None, None, :]
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(
+                            self.skip_gates[skip_idx].to(dtype=lane0.dtype)
+                        )[None, None, :]
+                        lane0 = torch.lerp(w * skip, lane0, g)
+                    else:
+                        lane0 = lane0 + w * skip
+                lane0, lane1 = self._parallel_block_with_lora(
+                    i,
+                    lane0,
+                    lane1,
+                    x0,
+                    lora,
+                    slot,
+                    q_w,
+                    k_w,
+                    v_w,
+                    out_w,
+                    up_w,
+                    down_w,
+                )
+            else:
+                if skip_idx < self.num_skip_weights and skips:
+                    scaled_skip = (
+                        self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                        * skips.pop()
+                    )
+                    if self.skip_gates is not None:
+                        g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                            None, None, :
+                        ]
+                        x = torch.lerp(scaled_skip, x, g)
+                    else:
+                        x = x + scaled_skip
+                x_before = x
+                x_after = self._block_with_lora(
+                    self.blocks[i],
+                    x,
+                    x0,
+                    lora,
+                    slot,
+                    q_w,
+                    k_w,
+                    v_w,
+                    out_w,
+                    up_w,
+                    down_w,
+                )
+                loop_counts[i] += 1
+                x = self._apply_art_delta_gate(i, loop_counts[i], x_before, x_after)
+            slot += 1
+        if lane0 is not None:
+            x = self._final_parallel_hidden(lane0, lane1)
+        x = self.final_norm(x)
+        if self.tie_embeddings:
+            logits = F.linear(x, self.tok_emb.weight)
+        else:
+            logits = self.lm_head(x)
+        logits = logits + lora.lm_head_lora(x)
+        logits = self.logit_softcap * torch.tanh(logits / self.logit_softcap)
+        bsz, sl, V = logits.shape
+        return F.cross_entropy(
+            logits.float().reshape(-1, V), target_ids.reshape(-1), reduction="none"
+        ).reshape(bsz, sl)
+
+    def _block_with_lora(
+        self, block, x, x0, lora, slot, q_w, k_w, v_w, out_w, up_w, down_w
+    ):
+        mix = block.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        n = block.attn_norm(x_in) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        # Keep raw Q for AttnOutGate src='q' (matches forward path semantics).
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT path) — inline + .contiguous() barrier, same as the eval path.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT path). Gate input is n (post-norm block input), same
+        # as eval path. .to(n.dtype) on fp32 param before bf16 broadcast.
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT path) — must match the eval path in
+        # forward() exactly, else training (which applied the gate) and TTT eval (which
+        # skipped it) produce mismatched representations and catastrophic BPB regression.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        x_out = x_in + block.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+        mlp_n = block.mlp_norm(x_out) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        x_out = x_out + block.mlp_scale.to(dtype=x_out.dtype)[None, None, :] * mlp_out
+        return x_out
+
+    def _parallel_block_with_lora(
+        self,
+        block_idx,
+        lane0,
+        lane1,
+        x0,
+        lora,
+        slot,
+        q_w,
+        k_w,
+        v_w,
+        out_w,
+        up_w,
+        down_w,
+    ):
+        block = self.blocks[block_idx]
+        mix = block.resid_mix.to(dtype=lane0.dtype)
+        attn_read = mix[0][None, None, :] * lane0 + mix[1][None, None, :] * x0
+        n = block.attn_norm(attn_read) * block.ln_scale_factor
+        attn = block.attn
+        bsz, seqlen, dim = n.shape
+        q_raw = F.linear(n, q_w.to(n.dtype)) + lora.q_loras[slot](n)
+        q = q_raw.reshape(bsz, seqlen, attn.num_heads, attn.head_dim)
+        k = F.linear(n, k_w.to(n.dtype))
+        if lora.k_loras is not None:
+            k = k + lora.k_loras[slot](n)
+        k = k.reshape(bsz, seqlen, attn.num_kv_heads, attn.head_dim)
+        v = (F.linear(n, v_w.to(n.dtype)) + lora.v_loras[slot](n)).reshape(
+            bsz, seqlen, attn.num_kv_heads, attn.head_dim
+        )
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = attn.rotary(seqlen, n.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, attn.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, attn.rope_dims)
+        q = q * attn.q_gain.to(dtype=q.dtype)[None, None, :, None]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if attn.use_xsa:
+            y = attn._xsa_efficient(y, v)
+        # AttnOutGate (TTT parallel path) — inline + .contiguous() barrier.
+        if attn.attn_out_gate:
+            gate_src = q_raw if attn.attn_out_gate_src == "q" else n
+            gate_in = gate_src[..., : attn.gate_window].contiguous()
+            g = 2.0 * torch.sigmoid(attn.attn_gate_proj(gate_in))
+            y = y * g[..., None]
+        # Gated Attention (TTT parallel path). Gate input is n (post-norm block input).
+        if attn.gated_attn:
+            n_c = n.contiguous()
+            g = torch.sigmoid(F.linear(n_c, attn.attn_gate_w.to(n.dtype)))
+            y = y * g[..., None]
+        # Sparse attention head-output gate (TTT parallel path) — must match the
+        # eval path in forward() to keep train/eval semantics in sync.
+        if attn.sparse_attn_gate:
+            gate_in = n[..., : attn.gate_window].contiguous()
+            g = torch.sigmoid(
+                attn.sparse_attn_gate_scale
+                * F.linear(gate_in, attn.attn_gate_w.to(n.dtype))
+            )
+            y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        attn_out = F.linear(y, out_w.to(n.dtype))
+        if lora.o_loras is not None:
+            attn_out = attn_out + lora.o_loras[slot](n)
+        attn_out = block.attn_scale.to(dtype=attn_out.dtype)[None, None, :] * attn_out
+        mlp_read = lane1
+        mlp_n = block.mlp_norm(mlp_read) * block.ln_scale_factor
+        mlp_out = block.mlp(mlp_n, up_w, down_w)
+        if lora.mlp_loras is not None:
+            mlp_out = mlp_out + lora.mlp_loras[slot](mlp_n)
+        mlp_out = block.mlp_scale.to(dtype=lane1.dtype)[None, None, :] * mlp_out
+        attn_resid = self.parallel_resid_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        attn_post = self.parallel_post_lambdas[block_idx, 0].to(dtype=lane0.dtype)
+        mlp_resid = self.parallel_resid_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        mlp_post = self.parallel_post_lambdas[block_idx, 1].to(dtype=lane0.dtype)
+        lane0 = attn_resid * lane0 + attn_post[0] * attn_out + mlp_post[0] * mlp_out
+        lane1 = mlp_resid * lane1 + attn_post[1] * attn_out + mlp_post[1] * mlp_out
+        return lane0, lane1
+
+
+class BatchedLinearLoRA(nn.Module):
+    # PR-1767: rank-scaled output (alpha/rank), like standard LoRA. Decouples
+    # effective magnitude from rank so changing rank does not change LR scale.
+    _ALPHA = float(os.environ.get("TTT_LORA_ALPHA", "144"))
+    # PR-1767: optionally keep A warm across per-doc resets (only B is zeroed).
+    # Accumulates useful feature directions across documents within a TTT phase.
+    _WARM_START_A = bool(int(os.environ.get("TTT_WARM_START_A", "1")))
+
+    def __init__(self, bsz, in_features, out_features, rank):
+        super().__init__()
+        self._bound = 1.0 / math.sqrt(in_features)
+        self._scale = self._ALPHA / rank
+        self.A = nn.Parameter(
+            torch.empty(bsz, rank, in_features).uniform_(-self._bound, self._bound)
+        )
+        self.B = nn.Parameter(torch.zeros(bsz, out_features, rank))
+
+    def reset(self):
+        with torch.no_grad():
+            if not self._WARM_START_A:
+                self.A.uniform_(-self._bound, self._bound)
+            self.B.zero_()
+
+    def forward(self, x):
+        return ((x @ self.A.transpose(1, 2)) @ self.B.transpose(1, 2)) * self._scale
+
+
+class BatchedTTTLoRA(nn.Module):
+    def __init__(self, bsz, model, rank, k_lora=True, mlp_lora=True, o_lora=True):
+        super().__init__()
+        self.bsz = bsz
+        dim = model.qo_bank.shape[-1]
+        vocab = model.tok_emb.num_embeddings
+        if getattr(model, "looping_active", False):
+            num_slots = len(model.encoder_indices) + len(model.decoder_indices)
+        else:
+            num_slots = len(model.blocks)
+        kv_dim = model.blocks[0].attn.num_kv_heads * (
+            dim // model.blocks[0].attn.num_heads
+        )
+        embed_dim = model.tok_emb.embedding_dim
+        self.lm_head_lora = BatchedLinearLoRA(bsz, embed_dim, vocab, rank)
+        self.q_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+        )
+        self.v_loras = nn.ModuleList(
+            [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+        )
+        self.k_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, kv_dim, rank) for _ in range(num_slots)]
+            )
+            if k_lora
+            else None
+        )
+        self.mlp_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if mlp_lora
+            else None
+        )
+        self.o_loras = (
+            nn.ModuleList(
+                [BatchedLinearLoRA(bsz, dim, dim, rank) for _ in range(num_slots)]
+            )
+            if o_lora
+            else None
+        )
+
+    def reset(self):
+        with torch.no_grad():
+            self.lm_head_lora.reset()
+            for loras in [
+                self.q_loras,
+                self.v_loras,
+                self.k_loras,
+                self.mlp_loras,
+                self.o_loras,
+            ]:
+                if loras is not None:
+                    for lora in loras:
+                        lora.reset()
+
+
+# Polar Express per-iteration minimax Newton-Schulz coefficients (PR #1344).
+# Replaces the fixed (3.4445, -4.775, 2.0315) coefficients of stock Muon.
+# Applied at backend_steps=5 — taking more than 5 iterations from this list
+# falls back to the final (converged) tuple via the slice guard below.
+_PE_COEFFS = (
+    (8.156554524902461, -22.48329292557795, 15.878769915207462),
+    (4.042929935166739, -2.808917465908714, 0.5000178451051316),
+    (3.8916678022926607, -2.772484153217685, 0.5060648178503393),
+    (3.285753657755655, -2.3681294933425376, 0.46449024233003106),
+    (2.3465413258596377, -1.7097828382687081, 0.42323551169305323),
+)
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    was_2d = G.ndim == 2
+    if was_2d:
+        G = G.unsqueeze(0)
+    X = G.bfloat16()
+    transposed = X.size(-2) > X.size(-1)
+    if transposed:
+        X = X.mT
+    X = X / (X.norm(dim=(-2, -1), keepdim=True) + eps)
+    coeffs = _PE_COEFFS[:steps] if steps <= len(_PE_COEFFS) else _PE_COEFFS
+    for a, b, c in coeffs:
+        A = X @ X.mT
+        B = b * A + c * (A @ A)
+        X = a * X + B @ X
+    if transposed:
+        X = X.mT
+    if was_2d:
+        X = X.squeeze(0)
+    return X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+        self._built = False
+
+    def _build(self):
+        self._distributed = dist.is_available() and dist.is_initialized()
+        self._world_size = dist.get_world_size() if self._distributed else 1
+        self._rank = dist.get_rank() if self._distributed else 0
+        ws = self._world_size
+        self._bank_meta = []
+        for group in self.param_groups:
+            for p in group["params"]:
+                B = p.shape[0]
+                padded_B = ((B + ws - 1) // ws) * ws
+                shard_B = padded_B // ws
+                tail = p.shape[1:]
+                dev = p.device
+                self._bank_meta.append(
+                    {
+                        "p": p,
+                        "B": B,
+                        "padded_grad": torch.zeros(
+                            padded_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "shard": torch.zeros(
+                            shard_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "shard_mom": torch.zeros(
+                            shard_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "full_update": torch.zeros(
+                            padded_B, *tail, device=dev, dtype=torch.bfloat16
+                        ),
+                        "scale": max(1, p.shape[-2] / p.shape[-1]) ** 0.5,
+                    }
+                )
+        self._bank_meta.sort(key=lambda m: -m["p"].numel())
+        self._built = True
+
+    def launch_reduce_scatters(self):
+        if not self._built:
+            self._build()
+        if not self._distributed:
+            return
+        self._rs_futures = []
+        for m in self._bank_meta:
+            p = m["p"]
+            if p.grad is None:
+                self._rs_futures.append(None)
+                continue
+            pg = m["padded_grad"]
+            pg[: m["B"]].copy_(p.grad)
+            fut = dist.reduce_scatter_tensor(
+                m["shard"], pg, op=dist.ReduceOp.AVG, async_op=True
+            )
+            self._rs_futures.append(fut)
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        if not self._built:
+            self._build()
+        for group in self.param_groups:
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            wd = group.get("weight_decay", 0.0)
+            row_normalize = group.get("row_normalize", False)
+            prev_ag_handle = None
+            prev_m = None
+            sharded = self._distributed and hasattr(self, "_rs_futures")
+            for idx, m in enumerate(self._bank_meta):
+                p = m["p"]
+                if p.grad is None:
+                    continue
+                if prev_ag_handle is not None:
+                    prev_ag_handle.wait()
+                    pp = prev_m["p"]
+                    upd = prev_m["full_update"][: prev_m["B"]]
+                    if wd > 0.0:
+                        pp.data.mul_(1.0 - lr * wd)
+                    pp.add_(upd, alpha=-lr * prev_m["scale"])
+                if sharded and self._rs_futures[idx] is not None:
+                    self._rs_futures[idx].wait()
+                    g = m["shard"]
+                    buf = m["shard_mom"]
+                else:
+                    g = p.grad.bfloat16()
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                buf.mul_(momentum).add_(g)
+                if nesterov:
+                    update = g.add(buf, alpha=momentum)
+                else:
+                    update = buf
+                if row_normalize:
+                    rn = update.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                    update = update / rn.to(update.dtype)
+                update = zeropower_via_newtonschulz5(update, steps=backend_steps)
+                if sharded:
+                    prev_ag_handle = dist.all_gather_into_tensor(
+                        m["full_update"], update, async_op=True
+                    )
+                    prev_m = m
+                else:
+                    if wd > 0.0:
+                        p.data.mul_(1.0 - lr * wd)
+                    p.add_(update, alpha=-lr * m["scale"])
+            if prev_ag_handle is not None:
+                prev_ag_handle.wait()
+                pp = prev_m["p"]
+                upd = prev_m["full_update"][: prev_m["B"]]
+                if wd > 0.0:
+                    pp.data.mul_(1.0 - lr * wd)
+                pp.add_(upd, alpha=-lr * prev_m["scale"])
+            if hasattr(self, "_rs_futures"):
+                del self._rs_futures
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,parallel_post_lambdas,parallel_resid_lambdas,attn_gate_proj,attn_gate_w,smear_gate,smear_lambda,art_delta_gate,art_delta_site_bias",
+    ).split(",")
+    if pattern
+)
+
+
+PACKED_REPLICATED_GRAD_MAX_NUMEL = 1 << 15
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        matrix_params = [
+            base_model.qo_bank,
+            base_model.kv_bank,
+            base_model.mlp_up_bank,
+            base_model.mlp_down_bank,
+        ]
+        block_named_params = list(base_model.blocks.named_parameters())
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if base_model.parallel_post_lambdas is not None:
+            scalar_params.append(base_model.parallel_post_lambdas)
+        if base_model.parallel_resid_lambdas is not None:
+            scalar_params.append(base_model.parallel_resid_lambdas)
+        # SmearGate params live on GPT root (not in .blocks), so add them by hand.
+        # Both are tiny (gate_window scalars + 1 lambda). Optimized via scalar Adam.
+        if getattr(base_model, "smear_gate_enabled", False):
+            scalar_params.append(base_model.smear_gate.weight)
+            scalar_params.append(base_model.smear_lambda)
+        if getattr(base_model, "art_delta_gate_enabled", False):
+            scalar_params.append(base_model.art_delta_gate.weight)
+            scalar_params.append(base_model.art_delta_site_bias)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            matrix_params,
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        self.replicated_params = list(tok_params[0]["params"])
+        self.replicated_params.extend(scalar_params)
+        self.replicated_large_params = []
+        self.replicated_packed_params = []
+        for p in self.replicated_params:
+            if p.numel() <= PACKED_REPLICATED_GRAD_MAX_NUMEL:
+                self.replicated_packed_params.append(p)
+            else:
+                self.replicated_large_params.append(p)
+        self._aux_stream = torch.cuda.Stream()
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def _all_reduce_packed_grads(self):
+        grads_by_key = collections.defaultdict(list)
+        for p in self.replicated_packed_params:
+            if p.grad is not None:
+                grads_by_key[(p.grad.device, p.grad.dtype)].append(p.grad)
+        for grads in grads_by_key.values():
+            flat = torch.empty(
+                sum(g.numel() for g in grads),
+                device=grads[0].device,
+                dtype=grads[0].dtype,
+            )
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                flat[offset : offset + n].copy_(g.contiguous().view(-1))
+                offset += n
+            dist.all_reduce(flat, op=dist.ReduceOp.AVG)
+            offset = 0
+            for g in grads:
+                n = g.numel()
+                g.copy_(flat[offset : offset + n].view_as(g))
+                offset += n
+
+    def step(self, distributed=False):
+        self.optimizer_muon.launch_reduce_scatters()
+        if distributed:
+            reduce_handles = [
+                dist.all_reduce(p.grad, op=dist.ReduceOp.AVG, async_op=True)
+                for p in self.replicated_large_params
+                if p.grad is not None
+            ]
+            self._all_reduce_packed_grads()
+            for handle in reduce_handles:
+                handle.wait()
+        self._aux_stream.wait_stream(torch.cuda.current_stream())
+        with torch.cuda.stream(self._aux_stream):
+            self.optimizer_tok.step()
+            self.optimizer_scalar.step()
+        self.optimizer_muon.step()
+        torch.cuda.current_stream().wait_stream(self._aux_stream)
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, CastedLinear):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+    if hasattr(model, "qo_bank") and model.qo_bank is not None:
+        model.qo_bank.data = model.qo_bank.data.float()
+        model.kv_bank.data = model.kv_bank.data.float()
+    model.mlp_up_bank.data = model.mlp_up_bank.data.float()
+    model.mlp_down_bank.data = model.mlp_down_bank.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hooks = []
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = True
+        block.mlp._calib = True
+        block.mlp.use_fused = False
+
+    def make_attn_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            for suffix in ["c_q", "c_k", "c_v"]:
+                name = f"blocks.{layer_idx}.attn.{suffix}.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+            y = module._last_proj_input
+            if y is not None:
+                y = y.float()
+                if y.ndim == 3:
+                    y = y.reshape(-1, y.shape[-1])
+                name = f"blocks.{layer_idx}.attn.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        y.shape[1], y.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(y.T, y)
+
+        return hook_fn
+
+    def make_mlp_hook(layer_idx):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            name = f"blocks.{layer_idx}.mlp.fc.weight"
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[name].addmm_(x.T, x)
+            h_act = module._last_down_input
+            if h_act is not None:
+                h_act = h_act.float()
+                if h_act.ndim == 3:
+                    h_act = h_act.reshape(-1, h_act.shape[-1])
+                name = f"blocks.{layer_idx}.mlp.proj.weight"
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        h_act.shape[1],
+                        h_act.shape[1],
+                        dtype=torch.float32,
+                        device=device,
+                    )
+                hessians[name].addmm_(h_act.T, h_act)
+
+        return hook_fn
+
+    for i, block in enumerate(model.blocks):
+        hooks.append(block.attn.register_forward_hook(make_attn_hook(i)))
+        hooks.append(block.mlp.register_forward_hook(make_mlp_hook(i)))
+
+    # Hessian hooks for embedding factorization projection layers
+    def make_linear_input_hook(weight_name):
+        def hook_fn(module, inp, out):
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if weight_name not in hessians:
+                hessians[weight_name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+            hessians[weight_name].addmm_(x.T, x)
+
+        return hook_fn
+
+    if model.tie_embeddings:
+        hook_module = model.final_norm
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                hessians[name].addmm_(x.T, x)
+
+            return hook_fn
+
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+    model.eval()
+    with torch.no_grad():
+        for _ in range(n_calibration_batches):
+            x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            model.forward_logits(x)
+    for hook in hooks:
+        hook.remove()
+    for i, block in enumerate(model.blocks):
+        block.attn._calib = False
+        block.mlp._calib = False
+        block.mlp.use_fused = True
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / n_calibration_batches
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=128):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    damp = 0.01 * H.diag().mean()
+    H.diagonal().add_(damp)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _quantize_gate_int8_row(w):
+    # Symmetric int8-per-row quantization for small gate tensors. w shape
+    # (R, C) -> (R,) scales in fp16, int8 values in [-127, 127]. Single scale
+    # per row keeps accuracy high while halving storage vs fp16.
+    W = w.float().contiguous()
+    row_max = W.abs().amax(dim=1).clamp_min(1e-10)
+    s = (row_max / 127.0).to(torch.float16)
+    sf = s.float().view(-1, 1)
+    q = torch.clamp(torch.round(W / sf), -127, 127).to(torch.int8)
+    return q, s
+
+
+def _lqer_pack(A, B, bits):
+    rng = 2 ** (bits - 1) - 1
+    sA = (A.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    sB = (B.abs().amax(dim=1).clamp_min(1e-10) / rng).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    qB = torch.clamp(torch.round(B / sB.float().view(-1, 1)), -rng, rng).to(torch.int8)
+    return qA, sA, qB, sB
+
+
+def _lqer_pack_asym(A, B, g=64):
+    # A: INT2 per-matrix scalar (signed [-2,1], scale = |A|max/1.5).
+    sA = (A.abs().amax().clamp_min(1e-10) / 1.5).to(torch.float16)
+    qA = torch.clamp(torch.round(A / sA.float()), -2, 1).to(torch.int8)
+    # B: INT4 groupwise g over flattened B (signed [-8,7], per-group scale).
+    Bf = B.reshape(-1, g)
+    Bmax = Bf.abs().amax(dim=-1, keepdim=True).clamp_min(1e-10)
+    sB = (Bmax / 7.5).to(torch.float16).reshape(-1)
+    qB = (
+        torch.clamp(torch.round(Bf / sB.float().reshape(-1, 1)), -8, 7)
+        .to(torch.int8)
+        .reshape(B.shape)
+    )
+    return qA, sA, qB, sB
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    result = {}
+    meta = {}
+    quant_gate = bool(getattr(h, "gated_attn_quant_gate", False))
+    lqer_on = bool(getattr(h, "lqer_enabled", False))
+    lqer_cands = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        # Dedicated int8-per-row path for attn_gate_w (bypasses both GPTQ and
+        # fp16 passthrough). Applied BEFORE the numel<=65536 passthrough check
+        # so the gate tensor is routed here instead of to fp16.
+        if (
+            quant_gate
+            and t.is_floating_point()
+            and t.ndim == 2
+            and name.endswith(".attn_gate_w")
+            # Dense GatedAttn: (num_heads, dim) = (8, 512) = 4096.
+            # Sparse gate: (num_heads, gate_window) = (8, 12) = 96.
+            # Both need int8-per-row routing; the 1024 lower bound in stock
+            # PR-1736 presumed dense-only. Widen to catch both.
+            and 32 <= t.numel() <= 8192
+        ):
+            gq, gs = _quantize_gate_int8_row(t)
+            result[name + ".gq"] = gq
+            result[name + ".gs"] = gs
+            meta[name] = "gate_int8_row"
+            continue
+        if not t.is_floating_point() or t.numel() <= 65536:
+            result[name] = t.to(torch.float16) if t.is_floating_point() else t
+            meta[name] = "passthrough (float16)"
+            continue
+        if "tok_emb" in name:
+            cs = h.embed_clip_sigmas
+        elif ".mlp." in name:
+            cs = h.mlp_clip_sigmas
+        elif ".attn." in name:
+            cs = h.attn_clip_sigmas
+        else:
+            cs = h.matrix_clip_sigmas
+        bits = h.embed_bits if "tok_emb" in name else h.matrix_bits
+        clip_range = 2 ** (bits - 1) - 1
+        ret = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=clip_range
+        )
+        q, s = ret
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+        if lqer_on:
+            W_q = q.float() * s.float().view(-1, 1)
+            E = t.float() - W_q
+            lqer_cands[name] = (E, float(E.norm()))
+    if lqer_on and lqer_cands:
+        top = sorted(lqer_cands.items(), key=lambda kv: -kv[1][1])[: h.lqer_top_k]
+        asym_on = bool(getattr(h, "lqer_asym_enabled", False))
+        asym_g = int(getattr(h, "lqer_asym_group", 64))
+        for name, (E, _) in top:
+            U, S, Vh = torch.linalg.svd(E, full_matrices=False)
+            r = min(h.lqer_rank, S.numel())
+            A = (U[:, :r] * S[:r]).contiguous()
+            B = Vh[:r, :].contiguous()
+            if asym_on and B.numel() % asym_g == 0:
+                qA, sA, qB, sB = _lqer_pack_asym(A, B, asym_g)
+                result[name + ".lqA_a"] = qA
+                result[name + ".lqAs_a"] = sA
+                result[name + ".lqB_a"] = qB
+                result[name + ".lqBs_a"] = sB
+                meta[name] = meta[name] + "+lqer_asym"
+            else:
+                qA, sA, qB, sB = _lqer_pack(A, B, h.lqer_factor_bits)
+                result[name + ".lqA"] = qA
+                result[name + ".lqAs"] = sA
+                result[name + ".lqB"] = qB
+                result[name + ".lqBs"] = sB
+                meta[name] = meta[name] + "+lqer"
+    categories = collections.defaultdict(set)
+    for name, cat in meta.items():
+        short = re.sub("\\.\\d+$", "", re.sub("blocks\\.\\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        if info == "gate_int8_row":
+            gq = result[name + ".gq"]
+            gs = result[name + ".gs"]
+            out[name] = (gq.float() * gs.float().view(-1, 1)).to(orig_dtype)
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            W = q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+        else:
+            W = q.float() * float(s.item())
+        if "lqer_asym" in info:
+            qA_t = result[name + ".lqA_a"]
+            sA_t = result[name + ".lqAs_a"]
+            qB_t = result[name + ".lqB_a"]
+            sB_t = result[name + ".lqBs_a"]
+            qA = qA_t.float() * float(sA_t)
+            g_sz = qB_t.numel() // sB_t.numel()
+            qB = (qB_t.reshape(-1, g_sz).float() * sB_t.float().view(-1, 1)).reshape(
+                qB_t.shape
+            )
+            W = W + qA @ qB
+        elif "lqer" in info:
+            qA = result[name + ".lqA"].float() * result[name + ".lqAs"].float().view(
+                -1, 1
+            )
+            qB = result[name + ".lqB"].float() * result[name + ".lqBs"].float().view(
+                -1, 1
+            )
+            W = W + qA @ qB
+        out[name] = W.to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+# ── Per-group lrzip compression (ported from PR#1586 via PR#1667/1729) ────────
+
+_GROUP_ORDER = [
+    "_tok_emb.weight.q",
+    "attn.c_k.weight.q",
+    "attn.c_q.weight.q",
+    "attn.c_v.weight.q",
+    "attn.proj.weight.q",
+    "mlp.fc.weight.q",
+    "mlp.proj.weight.q",
+]
+_SIMSORT_KEYS = {"_tok_emb.weight.q", "attn.c_q.weight.q", "mlp.fc.weight.q"}
+_PACK_MAGIC = b"PGRP"
+
+
+def _similarity_sort_l1(matrix):
+    import numpy as _np
+
+    n = matrix.shape[0]
+    used = _np.zeros(n, dtype=bool)
+    order = [0]
+    used[0] = True
+    cur = matrix[0].astype(_np.float32)
+    for _ in range(n - 1):
+        dists = _np.sum(_np.abs(matrix[~used].astype(_np.float32) - cur), axis=1)
+        unused = _np.where(~used)[0]
+        best = unused[_np.argmin(dists)]
+        order.append(best)
+        used[best] = True
+        cur = matrix[best].astype(_np.float32)
+    return _np.array(order, dtype=_np.uint16)
+
+
+def _lrzip_compress(data, tmpdir, label):
+    inp = os.path.join(tmpdir, f"{label}.bin")
+    out = f"{inp}.lrz"
+    with open(inp, "wb") as f:
+        f.write(data)
+    subprocess.run(
+        ["lrzip", "-z", "-L", "9", "-o", out, inp], capture_output=True, check=True
+    )
+    with open(out, "rb") as f:
+        result = f.read()
+    os.remove(inp)
+    os.remove(out)
+    return result
+
+
+def _lrzip_decompress(data, tmpdir, label):
+    inp = os.path.join(tmpdir, f"{label}.lrz")
+    out = os.path.join(tmpdir, f"{label}.bin")
+    with open(inp, "wb") as f:
+        f.write(data)
+    subprocess.run(
+        ["lrzip", "-d", "-f", "-o", out, inp], capture_output=True, check=True
+    )
+    with open(out, "rb") as f:
+        result = f.read()
+    os.remove(inp)
+    os.remove(out)
+    return result
+
+
+def _pack_streams(streams):
+    import struct
+
+    n = len(streams)
+    hdr = _PACK_MAGIC + struct.pack("<I", n)
+    for s in streams:
+        hdr += struct.pack("<I", len(s))
+    return hdr + b"".join(streams)
+
+
+def _unpack_streams(blob):
+    import struct
+
+    assert blob[:4] == _PACK_MAGIC
+    n = struct.unpack("<I", blob[4:8])[0]
+    off = 8
+    lengths = [
+        struct.unpack("<I", blob[off + i * 4 : off + i * 4 + 4])[0] for i in range(n)
+    ]
+    off += n * 4
+    streams = []
+    for length in lengths:
+        streams.append(blob[off : off + length])
+        off += length
+    return streams
+
+
+def _compress(raw, compressor):
+    if compressor == "brotli":
+        import brotli
+
+        return brotli.compress(raw, quality=11)
+    if compressor == "lzma":
+        import lzma
+
+        return lzma.compress(raw, preset=9)
+    raise ValueError(f"unknown compressor {compressor!r}")
+
+
+def _decompress(blob, compressor):
+    if compressor == "brotli":
+        import brotli
+
+        return brotli.decompress(blob)
+    if compressor == "lzma":
+        import lzma
+
+        return lzma.decompress(blob)
+    raise ValueError(f"unknown compressor {compressor!r}")
+
+
+def _serialize_pergroup(quant_result, quant_meta, num_layers, tmpdir):
+    import brotli
+    import numpy as _np
+
+    groups = collections.defaultdict(list)
+    remainder = {}
+    for name, t in sorted(quant_result.items()):
+        if t.dtype != torch.int8:
+            remainder[name] = t
+            continue
+        parts = name.split(".")
+        routed = False
+        if parts[0] == "blocks" and parts[1].isdigit():
+            key = ".".join(parts[2:])
+            if key in _GROUP_ORDER:
+                groups[key].append((int(parts[1]), t))
+                routed = True
+        else:
+            group_key = "_" + name
+            if group_key in _GROUP_ORDER:
+                groups[group_key] = [(0, t)]
+                routed = True
+        if not routed:
+            # int8 tensor that doesn't fit a known group (e.g. gate_int8_row
+            # tensors like attn.attn_gate_w.gq from GATED_ATTN). Stash in
+            # the brotli-compressed remainder blob so it round-trips.
+            remainder[name] = t
+
+    streams = []
+    all_perms = b""
+    shape_manifest = {}
+
+    for group_key in _GROUP_ORDER:
+        if group_key not in groups:
+            streams.append(b"")
+            continue
+        tensors = sorted(groups[group_key], key=lambda x: x[0])
+        blob = b""
+        grp_shapes = []
+        for idx, t in tensors:
+            arr = t.numpy()
+            orig_shape = arr.shape
+            if arr.ndim == 2:
+                if group_key in _SIMSORT_KEYS:
+                    order = _similarity_sort_l1(arr)
+                    all_perms += order.tobytes()
+                    arr = arr[order]
+                arr = _np.ascontiguousarray(arr.T)
+            blob += arr.tobytes()
+            grp_shapes.append(orig_shape)
+        shape_manifest[group_key] = grp_shapes
+        compressed = _lrzip_compress(blob, tmpdir, group_key.replace(".", "_"))
+        streams.append(compressed)
+
+    remainder_buf = io.BytesIO()
+    torch.save({"r": remainder, "m": quant_meta, "s": shape_manifest}, remainder_buf)
+    streams.append(brotli.compress(remainder_buf.getvalue(), quality=11, lgwin=24))
+    streams.append(brotli.compress(all_perms, quality=11) if all_perms else b"")
+
+    return _pack_streams(streams)
+
+
+def _deserialize_pergroup(blob, num_layers, tmpdir):
+    import brotli
+    import numpy as _np
+
+    streams = _unpack_streams(blob)
+    n_groups = len(_GROUP_ORDER)
+
+    remainder_state = torch.load(
+        io.BytesIO(brotli.decompress(streams[n_groups])), map_location="cpu"
+    )
+    quant_meta = remainder_state["m"]
+    quant_result = dict(remainder_state["r"])
+    shape_manifest = remainder_state["s"]
+    all_perms = (
+        brotli.decompress(streams[n_groups + 1]) if streams[n_groups + 1] else b""
+    )
+
+    def _decompress_one(args):
+        i, gk, data = args
+        if not data:
+            return gk, b""
+        return gk, _lrzip_decompress(data, tmpdir, f"d_{gk.replace('.', '_')}")
+
+    from concurrent.futures import ThreadPoolExecutor as _TPool
+
+    with _TPool(max_workers=n_groups) as pool:
+        futs = [
+            pool.submit(_decompress_one, (i, gk, streams[i]))
+            for i, gk in enumerate(_GROUP_ORDER)
+        ]
+        raw_groups = {f.result()[0]: f.result()[1] for f in futs}
+
+    perm_off = 0
+    for group_key in _GROUP_ORDER:
+        raw = raw_groups.get(group_key, b"")
+        if not raw:
+            continue
+        grp_shapes = shape_manifest[group_key]
+        data_arr = _np.frombuffer(raw, dtype=_np.int8)
+
+        if group_key.startswith("_"):
+            tensor_names = [group_key[1:]]
+        else:
+            tensor_names = [f"blocks.{i}.{group_key}" for i in range(num_layers)]
+
+        offset = 0
+        for tname, orig_shape in zip(tensor_names, grp_shapes):
+            n_elem = 1
+            for d in orig_shape:
+                n_elem *= d
+            chunk = data_arr[offset : offset + n_elem].copy()
+            offset += n_elem
+
+            if len(orig_shape) == 2:
+                rows, cols = orig_shape
+                chunk = chunk.reshape(cols, rows).T
+
+                if group_key in _SIMSORT_KEYS:
+                    perm = _np.frombuffer(
+                        all_perms[perm_off : perm_off + rows * 2], dtype=_np.uint16
+                    )
+                    perm_off += rows * 2
+                    inv_perm = _np.empty_like(perm)
+                    inv_perm[perm] = _np.arange(rows, dtype=_np.uint16)
+                    chunk = chunk[inv_perm]
+
+                chunk = chunk.reshape(orig_shape)
+
+            quant_result[tname] = torch.from_numpy(_np.ascontiguousarray(chunk))
+
+    return quant_result, quant_meta
+
+
+def _unbank_state_dict(state_dict, num_layers):
+    sd = {}
+    n = num_layers
+    for k, v in state_dict.items():
+        t = v.detach().cpu() if v is not None else None
+        if k == "qo_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_q.weight"] = t[i]
+                sd[f"blocks.{i}.attn.proj.weight"] = t[n + i]
+        elif k == "kv_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.attn.c_k.weight"] = t[i]
+                sd[f"blocks.{i}.attn.c_v.weight"] = t[n + i]
+        elif k == "mlp_up_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.fc.weight"] = t[i]
+        elif k == "mlp_down_bank":
+            for i in range(n):
+                sd[f"blocks.{i}.mlp.proj.weight"] = t[i]
+        else:
+            if t is not None:
+                sd[k] = t
+    return sd
+
+
+def _rebank_state_dict(flat_sd, num_layers, model_dim, kv_dim, hidden_dim):
+    sd = {}
+    n = num_layers
+    sd["qo_bank"] = torch.zeros(2 * n, model_dim, model_dim)
+    sd["kv_bank"] = torch.zeros(2 * n, kv_dim, model_dim)
+    for i in range(n):
+        sd["qo_bank"][i] = flat_sd[f"blocks.{i}.attn.c_q.weight"]
+        sd["qo_bank"][n + i] = flat_sd[f"blocks.{i}.attn.proj.weight"]
+        sd["kv_bank"][i] = flat_sd[f"blocks.{i}.attn.c_k.weight"]
+        sd["kv_bank"][n + i] = flat_sd[f"blocks.{i}.attn.c_v.weight"]
+    sd["mlp_up_bank"] = torch.zeros(n, hidden_dim, model_dim)
+    sd["mlp_down_bank"] = torch.zeros(n, model_dim, hidden_dim)
+    for i in range(n):
+        sd["mlp_up_bank"][i] = flat_sd[f"blocks.{i}.mlp.fc.weight"]
+        sd["mlp_down_bank"][i] = flat_sd[f"blocks.{i}.mlp.proj.weight"]
+    for k, v in flat_sd.items():
+        if not (
+            k.startswith("blocks.")
+            and any(
+                p in k
+                for p in [
+                    ".attn.c_q.",
+                    ".attn.c_k.",
+                    ".attn.c_v.",
+                    ".attn.proj.",
+                    ".mlp.fc.",
+                    ".mlp.proj.",
+                ]
+            )
+        ):
+            sd[k] = v
+    return sd
+
+
+def _compressed_code_size(code):
+    import brotli
+
+    code_raw = code.encode("utf-8")
+    try:
+        minified = subprocess.run(
+            [
+                "pyminify",
+                "--no-rename-locals",
+                "--no-hoist-literals",
+                "--remove-literal-statements",
+                "--remove-asserts",
+                "--prefer-single-line",
+                "-",
+            ],
+            input=code_raw,
+            capture_output=True,
+            check=True,
+        ).stdout
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        minified = code_raw
+    compressed = brotli.compress(minified, quality=11)
+    encoded = base64.b85encode(compressed)
+    wrapper = (
+        b'import brotli as B,base64 as b\nexec(B.decompress(b.b85decode("'
+        + encoded
+        + b'")))\n'
+    )
+    return len(code_raw), len(wrapper)
+
+
+def serialize(h, base_model, code):
+    code_bytes_uncompressed, code_bytes = _compressed_code_size(code)
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+        log(f"Code size (uncompressed): {code_bytes_uncompressed} bytes")
+        log(f"Code size (compressed): {code_bytes} bytes")
+    sd_cpu = _unbank_state_dict(base_model.state_dict(), h.num_layers)
+    device = torch.device("cuda", h.local_rank)
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    log("GPTQ:collecting Hessians from calibration data...")
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    if h.compressor == "pergroup":
+        import tempfile
+
+        tmpdir = tempfile.mkdtemp(prefix="pgrp_")
+        log("Serialize: per-group lrzip compression...")
+        t1 = time.perf_counter()
+        quant_blob = _serialize_pergroup(quant_result, quant_meta, h.num_layers, tmpdir)
+        log(f"Serialize: per-group compression done in {time.perf_counter() - t1:.1f}s")
+        try:
+            os.rmdir(tmpdir)
+        except OSError:
+            pass
+    else:
+        quant_buf = io.BytesIO()
+        torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+        quant_raw = quant_buf.getvalue()
+        quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    bytes_total = quant_file_bytes + code_bytes
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+        log(f"Total submission size quantized+{h.compressor}: {bytes_total} bytes")
+    return bytes_total, quant_file_bytes
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    flat_template = _unbank_state_dict(eval_model.state_dict(), h.num_layers)
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    if quant_blob_disk[:4] == _PACK_MAGIC:
+        import tempfile
+
+        tmpdir = tempfile.mkdtemp(prefix="pgrp_dec_")
+        log("Deserialize: per-group lrzip decompression...")
+        t0 = time.perf_counter()
+        quant_result, quant_meta = _deserialize_pergroup(
+            quant_blob_disk, h.num_layers, tmpdir
+        )
+        log(f"Deserialize: decompression done in {time.perf_counter() - t0:.1f}s")
+        try:
+            os.rmdir(tmpdir)
+        except OSError:
+            pass
+    else:
+        quant_state = torch.load(
+            io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+        )
+        quant_result, quant_meta = quant_state["w"], quant_state["m"]
+    deq_flat = dequantize_mixed(quant_result, quant_meta, flat_template)
+    head_dim = h.model_dim // h.num_heads
+    kv_dim = h.num_kv_heads * head_dim
+    hidden_dim = int(h.mlp_mult * h.model_dim)
+    deq_state = _rebank_state_dict(
+        deq_flat, h.num_layers, h.model_dim, kv_dim, hidden_dim
+    )
+    eval_model.load_state_dict(deq_state, strict=True)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def eval_val(h, device, val_data, model, forward_logits_fn=None):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_SIZE must provide at least one sequence per rank; got VAL_BATCH_SIZE={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+
+    # TODO: Don't truncate this.
+    seq_end = seq_start + ((seq_end - seq_start) // local_batch_seqs) * local_batch_seqs
+
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    run_forward_logits = (
+        (
+            model.module.forward_logits
+            if hasattr(model, "module")
+            else model.forward_logits
+        )
+        if forward_logits_fn is None
+        else forward_logits_fn
+    )
+    model.eval()
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    with torch.no_grad():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1]
+            y = local[1:]
+            bos_pos = (x == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                bos_pos, x.numel(), x.device, h.eval_seq_len, 64
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                logits = run_forward_logits(
+                    x[None], cu_seqlens=cu_seqlens, max_seqlen=max_seqlen
+                ).detach()
+            per_token_loss = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y.reshape(-1),
+                reduction="none",
+            )
+            val_loss_sum += per_token_loss.to(torch.float64).sum()
+            val_token_count += float(y.numel())
+            if val_data.val_bytes is not None:
+                sidecar_slice = val_data.val_bytes[raw_start + 1 : raw_end].to(
+                    device=device, dtype=torch.int32, non_blocking=True
+                )
+                val_byte_count += sidecar_slice.to(torch.float64).sum()
+            else:
+                tok_bytes = val_data.base_bytes_lut[y].to(torch.float64)
+                tok_bytes += (
+                    val_data.has_leading_space_lut[y]
+                    & ~val_data.is_boundary_token_lut[x]
+                ).to(torch.float64)
+                val_byte_count += tok_bytes.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def _find_docs(all_tokens):
+    bos_positions = (all_tokens == BOS_ID).nonzero(as_tuple=True)[0].numpy()
+    docs = []
+    for i in range(len(bos_positions)):
+        start = int(bos_positions[i])
+        end = (
+            int(bos_positions[i + 1])
+            if i + 1 < len(bos_positions)
+            else all_tokens.numel()
+        )
+        if i + 1 < len(bos_positions):
+            end += 1
+        assert end - start >= 2
+        docs.append((start, end - start))
+    return docs
+
+
+def _build_ttt_global_batches(doc_entries, h, ascending=False):
+    batch_size = h.ttt_batch_size
+    global_doc_entries = sorted(doc_entries, key=lambda x: x[1][1])
+    global_batches = [
+        global_doc_entries[i : i + batch_size]
+        for i in range(0, len(global_doc_entries), batch_size)
+    ]
+    indexed = list(enumerate(global_batches))
+    if not ascending:
+        indexed.sort(key=lambda ib: -max(dl for _, (_, dl) in ib[1]))
+    return indexed
+
+
+def _init_batch_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(4, "little"))
+
+
+def _claim_next_batch(counter_path, queue_len):
+    try:
+        with open(counter_path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            idx = int.from_bytes(f.read(4), "little")
+            f.seek(0)
+            f.write((idx + 1).to_bytes(4, "little"))
+            f.flush()
+    except FileNotFoundError:
+        return queue_len
+    return idx
+
+
+def _compute_chunk_window(ci, pred_len, num_chunks, chunk_size, eval_seq_len):
+    chunk_end = pred_len if ci == num_chunks - 1 else (ci + 1) * chunk_size
+    win_start = max(0, chunk_end - eval_seq_len)
+    win_len = chunk_end - win_start
+    chunk_start = ci * chunk_size
+    chunk_offset = chunk_start - win_start
+    chunk_len = chunk_end - chunk_start
+    return win_start, win_len, chunk_offset, chunk_len
+
+
+def _accumulate_bpb(
+    ptl,
+    x,
+    y,
+    chunk_offsets,
+    chunk_lens,
+    pos_idx,
+    base_bytes_lut,
+    has_leading_space_lut,
+    is_boundary_token_lut,
+    loss_sum,
+    byte_sum,
+    token_count,
+    y_bytes=None,
+):
+    pos = pos_idx[: x.size(1)].unsqueeze(0)
+    mask = (
+        (chunk_lens.unsqueeze(1) > 0)
+        & (pos >= chunk_offsets.unsqueeze(1))
+        & (pos < (chunk_offsets + chunk_lens).unsqueeze(1))
+    )
+    mask_f64 = mask.to(torch.float64)
+    if y_bytes is not None:
+        tok_bytes = y_bytes.to(torch.float64)
+    else:
+        tok_bytes = base_bytes_lut[y].to(torch.float64)
+        tok_bytes += (has_leading_space_lut[y] & ~is_boundary_token_lut[x]).to(
+            torch.float64
+        )
+    loss_sum += (ptl.to(torch.float64) * mask_f64).sum()
+    byte_sum += (tok_bytes * mask_f64).sum()
+    token_count += chunk_lens.to(torch.float64).sum()
+
+
+def _loss_bpb_from_sums(loss_sum, token_count, byte_sum):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_sum.item())
+    return val_loss, val_bpb
+
+
+def _add_to_counter(path, delta):
+    try:
+        with open(path, "r+b") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            cur = int.from_bytes(f.read(8), "little", signed=True)
+            cur += int(delta)
+            f.seek(0)
+            f.write(int(cur).to_bytes(8, "little", signed=True))
+            f.flush()
+            return cur
+    except FileNotFoundError:
+        return int(delta)
+
+
+def _init_int64_counter(path):
+    with open(path, "wb") as f:
+        f.write((0).to_bytes(8, "little", signed=True))
+
+
+def _select_ttt_doc_entries(docs, h):
+    doc_entries = list(enumerate(docs))
+    if h.val_doc_fraction < 1.0:
+        sample_n = max(1, int(round(len(docs) * h.val_doc_fraction)))
+        sampled_indices = sorted(
+            random.Random(h.seed).sample(range(len(docs)), sample_n)
+        )
+        return [(i, docs[i]) for i in sampled_indices]
+    return doc_entries
+
+
+@torch.no_grad()
+def format_art_delta_probe(model, h, device, val_data, step):
+    if not getattr(model, "art_delta_gate_enabled", False):
+        return None
+    if not getattr(model, "looping_active", False):
+        return None
+    probe_tokens = min(
+        max(int(getattr(h, "art_delta_probe_tokens", 0)), 1),
+        int(val_data.val_tokens.numel()),
+    )
+    if probe_tokens <= 1:
+        return None
+    was_training = model.training
+    previous_stats = model._art_delta_stats
+    model.eval()
+    model._art_delta_stats = []
+    try:
+        input_ids = val_data.val_tokens[:probe_tokens].to(
+            device=device, dtype=torch.int64, non_blocking=True
+        )[None]
+        with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+            model.forward_logits(input_ids)
+        stats = list(model._art_delta_stats)
+    finally:
+        model._art_delta_stats = previous_stats
+        model.train(was_training)
+    if not stats:
+        return None
+
+    alpha_mean = torch.stack([s[3] for s in stats]).mean().item()
+    alpha_std = torch.stack([s[4] for s in stats]).mean().item()
+    alpha_min = torch.stack([s[5] for s in stats]).amin().item()
+    alpha_max = torch.stack([s[6] for s in stats]).amax().item()
+    logit_mean = torch.stack([s[7] for s in stats]).mean().item()
+    logit_std = torch.stack([s[8] for s in stats]).mean().item()
+    delta_rms = torch.stack([s[9] for s in stats]).mean().item()
+    gated_delta_rms = torch.stack([s[10] for s in stats]).mean().item()
+    gate_weight = model.art_delta_gate.weight.detach().float()
+    gate_bias = model.art_delta_site_bias.detach().float()
+    site_parts = []
+    for block_idx, occurrence_idx, site_idx, a_mean, _, _, _, _, _, d_rms, gd_rms in stats:
+        ratio = (gd_rms / d_rms.clamp_min(1e-12)).item()
+        site_parts.append(
+            f"s{site_idx}:b{block_idx}o{occurrence_idx}:a{a_mean.item():.3f}/r{ratio:.3f}"
+        )
+    return (
+        f"art_delta_probe step:{step} sites:{len(stats)} "
+        f"alpha_mean:{alpha_mean:.4f} alpha_std:{alpha_std:.4f} "
+        f"alpha_min:{alpha_min:.4f} alpha_max:{alpha_max:.4f} "
+        f"logit_mean:{logit_mean:.4f} logit_std:{logit_std:.4f} "
+        f"delta_rms:{delta_rms:.5f} gated_delta_rms:{gated_delta_rms:.5f} "
+        f"gate_w_rms:{gate_weight.pow(2).mean().sqrt().item():.6f} "
+        f"gate_w_max:{gate_weight.abs().amax().item():.6f} "
+        f"gate_b_mean:{gate_bias.mean().item():.6f} "
+        f"gate_b_min:{gate_bias.amin().item():.6f} "
+        f"gate_b_max:{gate_bias.amax().item():.6f} "
+        f"sites:{','.join(site_parts)}"
+    )
+
+
+def train_val_ttt_global_sgd_distributed(
+    h, device, val_data, base_model, val_tokens, batch_seqs=None
+):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    seq_len = h.eval_seq_len
+    total_tokens = val_tokens.numel() - 1
+    ttt_chunk = h.global_ttt_chunk_tokens
+    batch_seqs = h.global_ttt_batch_seqs if batch_seqs is None else batch_seqs
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    ttt_params = [p for p in base_model.parameters()]
+    for p in ttt_params:
+        p.requires_grad_(True)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.global_ttt_lr, momentum=h.global_ttt_momentum
+    )
+    t_start = time.perf_counter()
+    for ci in range(num_chunks):
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        is_last_chunk = ci == num_chunks - 1
+        if is_last_chunk or h.global_ttt_epochs <= 0:
+            continue
+        base_model.train()
+        chunk_seqs = (chunk_end - chunk_start) // seq_len
+        if chunk_seqs <= 0:
+            continue
+        warmup_chunks = max(0, min(h.global_ttt_warmup_chunks, num_chunks - 1))
+        if warmup_chunks > 0 and ci < warmup_chunks:
+            warmup_denom = max(warmup_chunks - 1, 1)
+            warmup_t = ci / warmup_denom
+            lr_now = (
+                h.global_ttt_warmup_start_lr
+                + (h.global_ttt_lr - h.global_ttt_warmup_start_lr) * warmup_t
+            )
+        else:
+            decay_steps = max(num_chunks - 1 - warmup_chunks, 1)
+            decay_ci = max(ci - warmup_chunks, 0)
+            lr_now = (
+                h.global_ttt_lr
+                * 0.5
+                * (1.0 + math.cos(math.pi * decay_ci / decay_steps))
+            )
+        for pg in optimizer.param_groups:
+            pg["lr"] = lr_now
+        my_seq_s = chunk_seqs * h.rank // h.world_size
+        my_seq_e = chunk_seqs * (h.rank + 1) // h.world_size
+        my_chunk_seqs = my_seq_e - my_seq_s
+        for _ in range(h.global_ttt_epochs):
+            for bs in range(0, my_chunk_seqs, batch_seqs):
+                be = min(bs + batch_seqs, my_chunk_seqs)
+                actual_bs = my_seq_s + bs
+                start_tok = chunk_start + actual_bs * seq_len
+                end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                if end_tok > val_tokens.numel():
+                    continue
+                local = val_tokens[start_tok:end_tok].to(
+                    device=device, dtype=torch.int64
+                )
+                x_flat = local[:-1]
+                y_flat = local[1:]
+                optimizer.zero_grad(set_to_none=True)
+                with torch.enable_grad():
+                    with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                        if h.global_ttt_respect_doc_boundaries:
+                            bos_pos = (
+                                (x_flat == BOS_ID).nonzero(as_tuple=True)[0].tolist()
+                            )
+                            cu_seqlens, max_seqlen = _build_cu_seqlens(
+                                bos_pos,
+                                x_flat.numel(),
+                                x_flat.device,
+                                h.eval_seq_len,
+                                64,
+                            )
+                            loss = base_model(
+                                x_flat[None],
+                                y_flat[None],
+                                cu_seqlens=cu_seqlens,
+                                max_seqlen=max_seqlen,
+                            )
+                        else:
+                            x = x_flat.reshape(-1, seq_len)
+                            y = y_flat.reshape(-1, seq_len)
+                            loss = base_model(x, y)
+                loss.backward()
+                if dist.is_available() and dist.is_initialized():
+                    for p in ttt_params:
+                        if p.grad is not None:
+                            dist.all_reduce(p.grad, op=dist.ReduceOp.SUM)
+                            p.grad.mul_(1.0 / h.world_size)
+                if h.global_ttt_grad_clip > 0:
+                    torch.nn.utils.clip_grad_norm_(ttt_params, h.global_ttt_grad_clip)
+                optimizer.step()
+        base_model.eval()
+        if h.rank == 0:
+            elapsed = time.perf_counter() - t_start
+            log(f"tttg: c{ci + 1}/{num_chunks} lr:{lr_now:.6f} t:{elapsed:.1f}s")
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+
+
+def eval_val_ttt_phased(h, base_model, device, val_data, forward_ttt_train):
+    global BOS_ID
+    if BOS_ID is None:
+        BOS_ID = 1
+    base_model.eval()
+    for p in base_model.parameters():
+        p.requires_grad_(False)
+    all_tokens = val_data.val_tokens
+    all_tokens_idx = all_tokens.to(torch.int32)
+    docs = _find_docs(all_tokens)
+    doc_entries = _select_ttt_doc_entries(docs, h)
+    prefix_doc_limit = max(0, min(len(doc_entries), int(h.phased_ttt_prefix_docs)))
+    num_phases = max(1, int(h.phased_ttt_num_phases))
+    phase_boundaries = []
+    for pi in range(num_phases):
+        boundary = prefix_doc_limit * (pi + 1) // num_phases
+        phase_boundaries.append(boundary)
+    current_phase = 0
+    current_phase_boundary = phase_boundaries[0]
+    log(
+        "ttt_phased:"
+        f" total_docs:{len(doc_entries)} prefix_docs:{prefix_doc_limit} "
+        f"suffix_docs:{len(doc_entries) - prefix_doc_limit}"
+        f" num_phases:{num_phases} boundaries:{phase_boundaries}"
+    )
+    chunk_size, eval_seq_len = h.ttt_chunk_size, h.ttt_eval_seq_len
+    eval_batch_set = None
+    if h.ttt_eval_batches:
+        eval_batch_set = set(int(x) for x in h.ttt_eval_batches.split(",") if x.strip())
+    use_ascending = eval_batch_set is not None
+    global_batches_sorted = _build_ttt_global_batches(
+        doc_entries, h, ascending=use_ascending
+    )
+    queue_len = len(global_batches_sorted)
+    counter_path = f"/tmp/ttt_counter_{h.run_id}"
+    prefix_counter_path = f"/tmp/ttt_prefix_counter_{h.run_id}"
+    pause_flag_path = f"/tmp/ttt_pause_flag_{h.run_id}"
+    if h.rank == 0:
+        _init_batch_counter(counter_path)
+        _init_int64_counter(prefix_counter_path)
+        try:
+            os.remove(pause_flag_path)
+        except FileNotFoundError:
+            pass
+    if dist.is_available() and dist.is_initialized():
+        path_list = [counter_path, prefix_counter_path, pause_flag_path]
+        dist.broadcast_object_list(path_list, src=0)
+        counter_path, prefix_counter_path, pause_flag_path = path_list
+        dist.barrier()
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    byte_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    t_start = time.perf_counter()
+    reusable_lora = BatchedTTTLoRA(
+        h.ttt_batch_size,
+        base_model,
+        h.ttt_lora_rank,
+        k_lora=h.ttt_k_lora,
+        mlp_lora=h.ttt_mlp_lora,
+        o_lora=h.ttt_o_lora,
+    ).to(device)
+
+    def _build_opt(lora):
+        if h.ttt_optimizer == "sgd":
+            return torch.optim.SGD(
+                lora.parameters(),
+                lr=h.ttt_lora_lr,
+                momentum=h.ttt_beta1,
+                weight_decay=h.ttt_weight_decay,
+            )
+        return torch.optim.AdamW(
+            lora.parameters(),
+            lr=h.ttt_lora_lr,
+            betas=(h.ttt_beta1, h.ttt_beta2),
+            eps=1e-10,
+            weight_decay=h.ttt_weight_decay,
+            fused=True,
+        )
+
+    reusable_opt = _build_opt(reusable_lora)
+    local_scored_docs = []
+    global_ttt_done = prefix_doc_limit == 0
+    try:
+        while True:
+            queue_idx = _claim_next_batch(counter_path, queue_len)
+            if queue_idx >= queue_len:
+                break
+            orig_batch_idx, batch_entries = global_batches_sorted[queue_idx]
+            batch = [doc for _, doc in batch_entries]
+            bsz = len(batch)
+            prev_loss = loss_sum.item()
+            prev_bytes = byte_sum.item()
+            prev_tokens = token_count.item()
+            if bsz == reusable_lora.bsz:
+                reusable_lora.reset()
+                for s in reusable_opt.state.values():
+                    for k, v in s.items():
+                        if isinstance(v, torch.Tensor):
+                            v.zero_()
+                        elif k == "step":
+                            s[k] = 0
+                cur_lora = reusable_lora
+                cur_opt = reusable_opt
+            else:
+                cur_lora = BatchedTTTLoRA(
+                    bsz,
+                    base_model,
+                    h.ttt_lora_rank,
+                    k_lora=h.ttt_k_lora,
+                    mlp_lora=h.ttt_mlp_lora,
+                    o_lora=h.ttt_o_lora,
+                ).to(device)
+                cur_opt = _build_opt(cur_lora)
+            pred_lens = [doc_len - 1 for _, doc_len in batch]
+            num_chunks = [(pl + chunk_size - 1) // chunk_size for pl in pred_lens]
+            max_nc = max(num_chunks)
+            num_chunks_t = torch.tensor(num_chunks, dtype=torch.int64, device=device)
+            for ci in range(max_nc):
+                active = [ci < nc for nc in num_chunks]
+                needs_train = any(ci < nc - 1 for nc in num_chunks)
+                tok_starts = torch.zeros(bsz, dtype=torch.int64)
+                tok_wls = torch.zeros(bsz, dtype=torch.int64)
+                chunk_offsets_cpu = torch.zeros(bsz, dtype=torch.int64)
+                chunk_lens_cpu = torch.zeros(bsz, dtype=torch.int64)
+                for b in range(bsz):
+                    if not active[b]:
+                        continue
+                    doc_start, doc_len = batch[b]
+                    win_start, win_len, chunk_offset, chunk_len = _compute_chunk_window(
+                        ci, pred_lens[b], num_chunks[b], chunk_size, eval_seq_len
+                    )
+                    tok_starts[b] = doc_start + win_start
+                    tok_wls[b] = win_len
+                    chunk_offsets_cpu[b] = chunk_offset
+                    chunk_lens_cpu[b] = chunk_len
+                _, context_size, chunk_offset, _ = _compute_chunk_window(
+                    ci, (ci + 1) * chunk_size, ci + 1, chunk_size, eval_seq_len
+                )
+                col_idx = torch.arange(context_size + 1)
+                idx = tok_starts.unsqueeze(1) + col_idx.unsqueeze(0)
+                idx.clamp_(max=all_tokens.numel() - 1)
+                gathered_gpu = all_tokens_idx[idx].to(
+                    device=device, dtype=torch.int64, non_blocking=True
+                )
+                valid = (col_idx[:context_size].unsqueeze(0) < tok_wls.unsqueeze(1)).to(
+                    device, non_blocking=True
+                )
+                chunk_offsets = chunk_offsets_cpu.to(device, non_blocking=True)
+                chunk_lens = chunk_lens_cpu.to(device, non_blocking=True)
+                x = torch.where(valid, gathered_gpu[:, :context_size], 0)
+                y = torch.where(valid, gathered_gpu[:, 1 : context_size + 1], 0)
+                ctx_pos = torch.arange(context_size, device=device, dtype=torch.int64)
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                # CaseOps sidecar-driven byte budget. Mirror the index pattern
+                # used to build y from all_tokens: y[b, j] corresponds to the
+                # token at global position tok_starts[b] + 1 + j (when valid).
+                y_bytes_arg = None
+                if val_data.caseops_enabled and val_data.val_bytes is not None:
+                    y_idx = (
+                        tok_starts.unsqueeze(1)
+                        + 1
+                        + col_idx[:context_size].unsqueeze(0)
+                    )
+                    y_idx = y_idx.clamp_(max=val_data.val_bytes.numel() - 1)
+                    y_bytes_arg = val_data.val_bytes[y_idx].to(
+                        device=device, dtype=torch.int32, non_blocking=True
+                    )
+                    # Mirror the `valid` masking used for y so out-of-range tokens
+                    # contribute zero bytes (matches y=0 substitution above).
+                    y_bytes_arg = torch.where(
+                        valid, y_bytes_arg, torch.zeros_like(y_bytes_arg)
+                    )
+                with torch.no_grad():
+                    _accumulate_bpb(
+                        per_tok_loss,
+                        x,
+                        y,
+                        chunk_offsets,
+                        chunk_lens,
+                        ctx_pos,
+                        val_data.base_bytes_lut,
+                        val_data.has_leading_space_lut,
+                        val_data.is_boundary_token_lut,
+                        loss_sum,
+                        byte_sum,
+                        token_count,
+                        y_bytes=y_bytes_arg,
+                    )
+                if needs_train:
+                    activate_chunk_mask = (num_chunks_t - 1 > ci).float()
+                    for gi in range(h.ttt_grad_steps):
+                        if gi > 0:
+                            with torch.autocast(
+                                device_type="cuda", dtype=torch.bfloat16
+                            ):
+                                per_tok_loss = forward_ttt_train(x, y, lora=cur_lora)
+                        per_doc = per_tok_loss[
+                            :, chunk_offset : chunk_offset + chunk_size
+                        ].mean(dim=-1)
+                        cur_opt.zero_grad(set_to_none=True)
+                        (per_doc * activate_chunk_mask).sum().backward()
+                        cur_opt.step()
+                else:
+                    del per_tok_loss
+            batch_num = orig_batch_idx + 1
+            doc_lens = [dl for _, dl in batch]
+            should_report = (
+                batch_num in eval_batch_set if eval_batch_set is not None else True
+            )
+            if should_report:
+                cur_tokens = token_count.item()
+                cur_loss_val = loss_sum.item()
+                cur_bytes_val = byte_sum.item()
+                dt = cur_tokens - prev_tokens
+                db = cur_bytes_val - prev_bytes
+                if dt > 0 and db > 0:
+                    b_loss = (cur_loss_val - prev_loss) / dt
+                    b_bpb = b_loss / math.log(2.0) * (dt / db)
+                else:
+                    b_loss = b_bpb = 0.0
+                r_loss = cur_loss_val / max(cur_tokens, 1)
+                r_bpb = r_loss / math.log(2.0) * (cur_tokens / max(cur_bytes_val, 1))
+                elapsed = time.perf_counter() - t_start
+                log(
+                    f"ttp: b{batch_num}/{queue_len} bl:{b_loss:.4f} bb:{b_bpb:.4f} "
+                    f"rl:{r_loss:.4f} rb:{r_bpb:.4f} dl:{min(doc_lens)}-{max(doc_lens)} "
+                    f"gd:{int(global_ttt_done)}"
+                )
+            if not global_ttt_done:
+                local_scored_docs.extend(
+                    (orig_batch_idx, pos, doc_start, doc_len)
+                    for pos, (doc_start, doc_len) in enumerate(batch)
+                )
+                prefix_done = _add_to_counter(prefix_counter_path, len(batch_entries))
+                if prefix_done >= current_phase_boundary:
+                    try:
+                        with open(pause_flag_path, "x"):
+                            pass
+                    except FileExistsError:
+                        pass
+                should_pause = os.path.exists(pause_flag_path)
+                if should_pause:
+                    if dist.is_available() and dist.is_initialized():
+                        dist.barrier()
+                    gathered_scored_docs = [None] * h.world_size
+                    if dist.is_available() and dist.is_initialized():
+                        dist.all_gather_object(gathered_scored_docs, local_scored_docs)
+                    else:
+                        gathered_scored_docs = [local_scored_docs]
+                    scored_docs_for_global = []
+                    for rank_docs in gathered_scored_docs:
+                        if rank_docs:
+                            scored_docs_for_global.extend(rank_docs)
+                    scored_docs_for_global.sort(key=lambda x: (x[0], x[1]))
+                    scored_docs_for_global = scored_docs_for_global[
+                        :current_phase_boundary
+                    ]
+                    scored_token_chunks = [
+                        val_data.val_tokens[doc_start : doc_start + doc_len]
+                        for _, _, doc_start, doc_len in scored_docs_for_global
+                    ]
+                    if scored_token_chunks:
+                        global_ttt_tokens = torch.cat(scored_token_chunks)
+                    else:
+                        global_ttt_tokens = val_data.val_tokens[:0]
+                    if h.rank == 0:
+                        prefix_done = 0
+                        try:
+                            with open(prefix_counter_path, "rb") as f:
+                                prefix_done = int.from_bytes(
+                                    f.read(8), "little", signed=True
+                                )
+                        except FileNotFoundError:
+                            pass
+                        log(
+                            f"ttpp: phase:{current_phase + 1}/{num_phases} pd:{prefix_done} "
+                            f"gd:{len(scored_docs_for_global)} "
+                            f"t:{time.perf_counter() - t_start:.1f}s"
+                        )
+                    train_val_ttt_global_sgd_distributed(
+                        h, device, val_data, base_model, global_ttt_tokens
+                    )
+                    for p in base_model.parameters():
+                        p.requires_grad_(False)
+                    reusable_lora = BatchedTTTLoRA(
+                        h.ttt_batch_size,
+                        base_model,
+                        h.ttt_lora_rank,
+                        k_lora=h.ttt_k_lora,
+                        mlp_lora=h.ttt_mlp_lora,
+                        o_lora=h.ttt_o_lora,
+                    ).to(device)
+                    reusable_opt = _build_opt(reusable_lora)
+                    current_phase += 1
+                    if current_phase >= num_phases:
+                        global_ttt_done = True
+                    else:
+                        current_phase_boundary = phase_boundaries[current_phase]
+                        if h.rank == 0:
+                            try:
+                                os.remove(pause_flag_path)
+                            except FileNotFoundError:
+                                pass
+                    if dist.is_available() and dist.is_initialized():
+                        dist.barrier()
+                    if h.rank == 0:
+                        log(
+                            f"ttpr: phase:{current_phase}/{num_phases} t:{time.perf_counter() - t_start:.1f}s"
+                        )
+            del cur_lora, cur_opt
+    finally:
+        pass
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.train()
+    return _loss_bpb_from_sums(loss_sum, token_count, byte_sum)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    return val_loss, val_bpb
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True)
+    compiled_forward_logits = torch.compile(
+        base_model.forward_logits, dynamic=False, fullgraph=True
+    )
+    model = compiled_model
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+    log(
+        "art_delta_gate:"
+        f"enabled:{int(base_model.art_delta_gate_enabled)} "
+        "mode:tanh_sitegain "
+        f"window:{getattr(base_model, 'art_delta_gate_window', 0)} "
+        f"scale:{base_model.art_delta_gate_scale:g} "
+        f"site_gates:{int(getattr(base_model, 'art_delta_site_gates', False))} "
+        f"tanh_range:{getattr(base_model, 'art_delta_tanh_range', 1.0):g} "
+        "init_alpha:1 "
+        f"repeated_only:{int(base_model.art_delta_repeated_only)} "
+        f"probe_every:{h.art_delta_probe_every} "
+        f"probe_tokens:{h.art_delta_probe_tokens}"
+    )
+    optimizers = Optimizers(h, base_model)
+    train_loader = DocumentPackingLoader(h, device)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+    if max_wallclock_ms is not None:
+        max_wallclock_ms -= h.gptq_reserve_seconds * 1e3
+        log(
+            f"gptq:reserving {h.gptq_reserve_seconds:.0f}s, effective={max_wallclock_ms:.0f}ms"
+        )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    _clip_params = [p for p in base_model.parameters() if p.requires_grad]
+
+    def step_fn(step, lr_scale):
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(h.grad_accum_steps):
+            x, y, cu_seqlens, _max_seqlen = train_loader.next_batch(
+                h.train_batch_tokens, h.grad_accum_steps
+            )
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y, cu_seqlens=cu_seqlens, max_seqlen=h.train_seq_len)
+            train_loss += loss.detach()
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        if step <= h.muon_momentum_warmup_steps:
+            frac = (
+                min(step / h.muon_momentum_warmup_steps, 1.0)
+                if h.muon_momentum_warmup_steps > 0
+                else 1.0
+            )
+
+            muon_momentum = (
+                1 - frac
+            ) * h.muon_momentum_warmup_start + frac * h.muon_momentum
+
+            for group in optimizers.optimizer_muon.param_groups:
+                group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(_clip_params, h.grad_clip_norm)
+        optimizers.step(distributed=h.distributed)
+        return train_loss
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: tensor.detach().cpu().clone()
+            for (name, tensor) in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        num_tokens_local = h.train_batch_tokens // h.world_size
+        for blk in base_model.blocks:
+            blk.attn.rotary(num_tokens_local, device, torch.bfloat16)
+        cu_bucket_size = train_loader.cu_bucket_size
+        warmup_cu_buckets = tuple(cu_bucket_size * i for i in range(1, 5))
+        warmup_cu_iters = 3
+        x, y, cu_seqlens, _ = train_loader.next_batch(
+            h.train_batch_tokens, h.grad_accum_steps
+        )
+        log(
+            f"warmup_cu_buckets:{','.join(str(b) for b in warmup_cu_buckets)} iters_each:{warmup_cu_iters}"
+        )
+
+        def _run_cu_bucket_warmup():
+            for bucket_len in warmup_cu_buckets:
+                boundaries = list(range(0, x.size(1), max(h.train_seq_len, 1)))
+                if boundaries[-1] != x.size(1):
+                    boundaries.append(x.size(1))
+                cu = torch.full(
+                    (bucket_len,), x.size(1), dtype=torch.int32, device=device
+                )
+                cu[: len(boundaries)] = torch.tensor(
+                    boundaries, dtype=torch.int32, device=device
+                )
+                for _ in range(warmup_cu_iters):
+                    optimizers.zero_grad_all()
+                    with torch.autocast(
+                        device_type="cuda", dtype=torch.bfloat16, enabled=True
+                    ):
+                        wloss = model(x, y, cu_seqlens=cu, max_seqlen=h.train_seq_len)
+                    (wloss / h.grad_accum_steps).backward()
+            optimizers.zero_grad_all()
+
+        _run_cu_bucket_warmup()
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            _run_cu_bucket_warmup()
+            base_model.looping_active = False
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        train_loader = DocumentPackingLoader(h, device)
+    _live_state = base_model.state_dict(keep_vars=True)
+    ema_decay = h.ema_decay
+    ema_activate_at = h.ema_activate_at
+    ema_state = None
+    _ema_pairs = None
+    ema_active = False
+
+    def _activate_ema(step, frac):
+        nonlocal ema_state, _ema_pairs, ema_active
+        ema_state = {
+            name: t.detach().float().clone() for (name, t) in _live_state.items()
+        }
+        _ema_pairs = [(ema_state[name], t) for (name, t) in _live_state.items()]
+        ema_active = True
+        log(f"ema:activated step:{step} frac:{frac:.3f} decay:{ema_decay:g}")
+
+    if ema_activate_at <= 0.0:
+        _activate_ema(0, 0.0)
+    else:
+        log(f"ema:delayed activate_at:{ema_activate_at:g} decay:{ema_decay:g}")
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = (
+            step == h.iterations
+            or stop_after_step is not None
+            and step >= stop_after_step
+        )
+        should_validate = (
+            last_step or h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                h, device, val_data, model, compiled_forward_logits
+            )
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            enable_loop_now = True
+        else:
+            enable_loop_now = False
+        if h.distributed and h.num_loops > 0 and not base_model.looping_active:
+            flag = torch.tensor(int(enable_loop_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_loop_now = bool(flag.item())
+        if enable_loop_now:
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            if h.distributed:
+                dist.barrier()
+                log("layer_loop:sync_done")
+        train_loss = step_fn(step, scale)
+        enable_ema_now = (not ema_active) and frac >= ema_activate_at
+        if h.distributed and not ema_active:
+            flag = torch.tensor(int(enable_ema_now), device=device)
+            dist.all_reduce(flag, op=dist.ReduceOp.MAX)
+            enable_ema_now = bool(flag.item())
+        if enable_ema_now:
+            _activate_ema(step + 1, frac)
+            if h.distributed:
+                dist.barrier()
+                log("ema:sync_done")
+        if ema_active:
+            with torch.no_grad():
+                for ema_t, t in _ema_pairs:
+                    ema_t.mul_(ema_decay).add_(t.detach(), alpha=1.0 - ema_decay)
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        if should_log_train:
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} train_time: {approx_training_time_ms / 60000:.1f}m tok/s: {tok_per_sec:.0f}"
+            )
+            if (
+                h.art_delta_probe_every > 0
+                and step % h.art_delta_probe_every == 0
+                and getattr(base_model, "art_delta_gate_enabled", False)
+            ):
+                probe_msg = format_art_delta_probe(
+                    base_model, h, device, val_data, step
+                )
+                if probe_msg is not None:
+                    log(probe_msg)
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    if ema_state is not None:
+        log("ema:applying EMA weights")
+        current_state = base_model.state_dict()
+        avg_state = {
+            name: t.to(dtype=current_state[name].dtype)
+            for (name, t) in ema_state.items()
+        }
+        base_model.load_state_dict(avg_state, strict=True)
+    else:
+        log("ema:inactive using final live weights")
+    return base_model, compiled_model, compiled_forward_logits
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    if h.artifact_dir and h.is_main_process:
+        os.makedirs(h.artifact_dir, exist_ok=True)
+    val_data = ValidationData(h, device)
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+    # TTT_EVAL_ONLY: skip training + GPTQ, jump straight to TTT eval on a
+    # pre-existing quantized artifact. Used to test TTT-only improvements
+    # (e.g., PR-1767's alpha/warm-start/WD) without retraining.
+    ttt_eval_only = os.environ.get("TTT_EVAL_ONLY", "0") == "1"
+    if ttt_eval_only:
+        log(
+            "TTT_EVAL_ONLY=1 — skipping training + GPTQ, loading saved artifact for TTT eval"
+        )
+        log(f"ttt_lora_alpha: {BatchedLinearLoRA._ALPHA}")
+        log(f"ttt_warm_start_a: {BatchedLinearLoRA._WARM_START_A}")
+        log(f"ttt_weight_decay: {h.ttt_weight_decay}")
+    else:
+        base_model, compiled_model, compiled_forward_logits = train_model(
+            h, device, val_data
+        )
+        torch._dynamo.reset()
+        timed_eval(
+            "diagnostic pre-quantization post-ema",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        probe_msg = format_art_delta_probe(base_model, h, device, val_data, "prequant")
+        if probe_msg is not None:
+            log(probe_msg)
+        if os.environ.get("PREQUANT_ONLY", "0") == "1":
+            log("PREQUANT_ONLY=1 — skipping serialize/GPTQ/post-quant eval/TTT")
+            return
+        serialize(h, base_model, Path(__file__).read_text(encoding="utf-8"))
+        if h.distributed:
+            dist.barrier()
+    eval_model = deserialize(h, device)
+    if h.num_loops > 0:
+        eval_model.looping_active = True
+    if not ttt_eval_only:
+        compiled_model = torch.compile(eval_model, dynamic=False, fullgraph=True)
+        compiled_forward_logits = torch.compile(
+            eval_model.forward_logits, dynamic=False, fullgraph=True
+        )
+        timed_eval(
+            "diagnostic quantized",
+            eval_val,
+            h,
+            device,
+            val_data,
+            compiled_model,
+            compiled_forward_logits,
+        )
+        probe_msg = format_art_delta_probe(eval_model, h, device, val_data, "quantized")
+        if probe_msg is not None:
+            log(probe_msg)
+        del eval_model
+    if h.ttt_enabled:
+        if not ttt_eval_only:
+            del compiled_model
+        if ttt_eval_only:
+            del eval_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        if h.num_loops > 0:
+            ttt_model.looping_active = True
+        for p in ttt_model.parameters():
+            p.requires_grad_(False)
+
+        if h.rope_yarn:
+            _yarn_seqlen = h.train_batch_tokens // h.grad_accum_steps
+            for block in ttt_model.blocks:
+                block.attn.rotary(_yarn_seqlen, device, torch.bfloat16)
+        else:
+            for block in ttt_model.blocks:
+                block.attn.rotary._cos_cached = None
+                block.attn.rotary._sin_cached = None
+                block.attn.rotary._seq_len_cached = 0
+                block.attn.rotary(h.ttt_eval_seq_len, device, torch.bfloat16)
+
+        def _fwd_ttt_inner(input_ids, target_ids, lora):
+            return ttt_model.forward_ttt(input_ids, target_ids, lora=lora)
+
+        _fwd_ttt_compiled_inner = None
+
+        def _fwd_ttt(input_ids, target_ids, lora):
+            nonlocal _fwd_ttt_compiled_inner
+            if _fwd_ttt_compiled_inner is None:
+                _fwd_ttt_compiled_inner = torch.compile(_fwd_ttt_inner, dynamic=True)
+            return _fwd_ttt_compiled_inner(input_ids, target_ids, lora=lora)
+
+        fwd_ttt_compiled = _fwd_ttt
+        log(f"ttt_lora:warming up compile (random tokens, no val data)")
+        global BOS_ID
+        if BOS_ID is None:
+            BOS_ID = 1
+        t_warmup = time.perf_counter()
+        warmup_bszes = [h.ttt_batch_size]
+        for bsz in warmup_bszes:
+            wl = BatchedTTTLoRA(
+                bsz,
+                ttt_model,
+                h.ttt_lora_rank,
+                k_lora=h.ttt_k_lora,
+                mlp_lora=h.ttt_mlp_lora,
+                o_lora=h.ttt_o_lora,
+            ).to(device)
+            wo = torch.optim.AdamW(
+                wl.parameters(),
+                lr=h.ttt_lora_lr,
+                betas=(h.ttt_beta1, h.ttt_beta2),
+                eps=1e-10,
+                weight_decay=h.ttt_weight_decay,
+                fused=True,
+            )
+            for ctx_len in (h.ttt_chunk_size, h.ttt_eval_seq_len):
+                xw = torch.randint(
+                    0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64
+                )
+                yw = torch.randint(
+                    0, h.vocab_size, (bsz, ctx_len), device=device, dtype=torch.int64
+                )
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    ptl = fwd_ttt_compiled(xw, yw, lora=wl)
+                ptl[:, : min(h.ttt_chunk_size, ctx_len)].mean(dim=-1).sum().backward()
+                wo.step()
+                wo.zero_grad(set_to_none=True)
+            del wl, wo
+        torch.cuda.empty_cache()
+        compile_elapsed = time.perf_counter() - t_warmup
+        log(f"ttt_lora:compile warmup done ({compile_elapsed:.1f}s)")
+        log("\nbeginning TTT eval timer")
+        torch.cuda.synchronize()
+        t_ttt = time.perf_counter()
+        ttt_val_loss, ttt_val_bpb = eval_val_ttt_phased(
+            h, ttt_model, device, val_data, forward_ttt_train=fwd_ttt_compiled
+        )
+        torch.cuda.synchronize()
+        ttt_eval_elapsed = time.perf_counter() - t_ttt
+        log(
+            "quantized_ttt_phased "
+            f"val_loss:{ttt_val_loss:.8f} val_bpb:{ttt_val_bpb:.8f} "
+            f"eval_time:{1e3 * ttt_eval_elapsed:.0f}ms"
+        )
+        log(f"total_eval_time:{ttt_eval_elapsed:.1f}s")
+        del ttt_model
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    torch._dynamo.config.cache_size_limit = 64
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs(h.artifact_dir if h.artifact_dir else "logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log("Source code:", console=False)
+        log("=" * 100, console=False)
+        with open(__file__, "r", encoding="utf-8") as _src:
+            log(_src.read(), console=False)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        log("=" * 100, console=False)
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/run_variant.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/run_variant.py
@@ -1,0 +1,135 @@
+from __future__ import annotations
+
+import datetime
+import os
+import runpy
+import sys
+import uuid
+from pathlib import Path
+
+COMMON_DEFAULTS = {
+    "TTT_ENABLED": "0",
+    "SLIDING_WINDOW_ENABLED": "0",
+    "ART_QUANT_DIAG_ENABLED": "0",
+    "RAW_ROUNDTRIP_CHECK_ENABLED": "0",
+    "ART_EVAL_ROUTE_STATS": "1",
+    "RECURRENCE_PROBE_EVERY": "10",
+    "TRAIN_LOG_EVERY": "100",
+}
+
+
+VARIANTS = {
+    "baseline_prettt": {
+        "notes": "Exact RoPE-fix triple ART score path through quantized eval, with TTT disabled.",
+        "env": {},
+    },
+    "seed2_prettt": {
+        "notes": "Same as baseline with a second seed to estimate 1x variance before paying for 8x.",
+        "env": {"SEED": "7331"},
+    },
+    "eval_argmax_prettt": {
+        "notes": "Train with sampled ART, evaluate with deterministic argmax routes to estimate route-sampling dependence.",
+        "env": {"ART_EVAL_SAMPLE_ROUTES": "0"},
+    },
+    "eval_threshold055_prettt": {
+        "notes": "Deterministic eval with a stricter continue threshold, testing whether marginal routes are hurting quantized score.",
+        "env": {
+            "ART_EVAL_SAMPLE_ROUTES": "0",
+            "ART_EVAL_ROUTE_THRESHOLD": "0.6",
+        },
+    },
+    "penalty_low_prettt": {
+        "notes": "Lower cycle penalty; tests whether 8x compute should spend more recurrence for bpb.",
+        "env": {"ART_CYCLE_PENALTY": "0.0001"},
+    },
+    "penalty_high_prettt": {
+        "notes": "Higher cycle penalty; tests whether current avg_cycles can be reduced without losing pre-TTT score.",
+        "env": {"ART_CYCLE_PENALTY": "0.003"},
+    },
+    "entropy_low_prettt": {
+        "notes": "Lower router entropy reward; targets the observed high/noisy route entropy late in training.",
+        "env": {
+            "ART_ROUTER_ENTROPY_START": "0.02",
+            "ART_ROUTER_ENTROPY_END": "0.0",
+        },
+    },
+    "entropy_high_prettt": {
+        "notes": "Higher router entropy reward; tests whether the late entropy rebound is beneficial exploration rather than noise.",
+        "env": {
+            "ART_ROUTER_ENTROPY_START": "0.10",
+            "ART_ROUTER_ENTROPY_END": "0.01",
+        },
+    },
+    "art_early_prettt": {
+        "notes": "Enable ART earlier so routers train longer under the wallclock schedule.",
+        "env": {"ART_HALT_ENABLE_AT": "0.45"},
+    },
+    "art_late_prettt": {
+        "notes": "Enable ART later so the fixed recurrent backbone stabilizes longer before routing.",
+        "env": {"ART_HALT_ENABLE_AT": "0.65"},
+    },
+    "batch_small_prettt": {
+        "notes": "Smaller global train batch; probes whether the 1x result depends on high update frequency/noisier gradients.",
+        "env": {"TRAIN_BATCH_TOKENS": "524288"},
+    },
+    "batch_large_prettt": {
+        "notes": "Larger global train batch; proxy for whether 8x should spend extra throughput on batch size rather than steps.",
+        "env": {"TRAIN_BATCH_TOKENS": "1048576"},
+    },
+    "ema_low_prettt": {
+        "notes": "Lower EMA decay; tests whether post-reset EMA is lagging too much for short 1x runs.",
+        "env": {"EMA_DECAY": "0.995"},
+    },
+    "ema_high_prettt": {
+        "notes": "Higher EMA decay; proxy for 8x where more optimizer steps occur inside the same wallclock.",
+        "env": {"EMA_DECAY": "0.9985"},
+    },
+    "routed_gptq_prettt": {
+        "notes": "Use routed ART during GPTQ calibration; tests whether calibration should follow adaptive eval routes.",
+        "env": {"ART_GPTQ_CALIBRATE_ROUTED": "1"},
+    },
+    "full_ttt_baseline": {
+        "notes": "Baseline plus post-quant TTT, for final confirmation only; expensive.",
+        "env": {"TTT_ENABLED": "1"},
+    },
+}
+
+
+def _usage() -> None:
+    print("Usage: python run_variant.py <variant>")
+    print("")
+    print("Variants:")
+    for name, spec in VARIANTS.items():
+        print(f"  {name:24s} {spec['notes']}")
+
+
+def run_variant(name: str) -> None:
+    if name not in VARIANTS:
+        _usage()
+        raise SystemExit(f"Unknown variant: {name}")
+
+    spec = VARIANTS[name]
+    defaults = dict(COMMON_DEFAULTS)
+    defaults.update(spec["env"])
+    for key, value in defaults.items():
+        os.environ.setdefault(key, str(value))
+
+    os.environ.setdefault("EXPERIMENT_VARIANT", name)
+    os.environ.setdefault("EXPERIMENT_NOTES", spec["notes"])
+    ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    os.environ.setdefault("RUN_ID", f"{ts}_{name}_{uuid.uuid4().hex[:8]}")
+
+    base = Path(__file__).with_name("train_gpt_base_prettt.py")
+    sys.argv = [str(base), *sys.argv[2:]]
+    runpy.run_path(str(base), run_name="__main__")
+
+
+def main() -> None:
+    if len(sys.argv) < 2 or sys.argv[1] in {"-h", "--help", "list", "--list"}:
+        _usage()
+        return
+    run_variant(sys.argv[1])
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/train_gpt_base_prettt.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/train_gpt_base_prettt.py
@@ -1,0 +1,3645 @@
+"""Triple ART RoPE-fix pre-TTT test base.
+
+Use run_variant.py for targeted pre-TTT scale-up experiments.
+"""
+
+from __future__ import annotations
+
+import collections
+import copy
+import datetime
+import glob
+import io
+import math
+import os
+import random
+import re
+import subprocess
+import sys
+import time
+import uuid
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+import torch.nn.functional as F
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+_SMOKE_TEST: bool = bool(int(os.environ.get("SMOKE_TEST", "0")))
+try:
+    if _SMOKE_TEST:
+        raise ImportError("SMOKE_TEST: forcing SDPA fallback")
+    from flash_attn_interface import flash_attn_func as _fa3_impl
+
+    _USE_FA3 = True
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        return _fa3_impl(q, k, v, causal=causal)
+
+except ImportError:
+    _USE_FA3 = False
+
+    def flash_attn_3_func(q, k, v, causal: bool = True):
+        B, T, Hq, D = q.shape
+        Hkv = k.shape[2]
+        q_ = q.permute(0, 2, 1, 3).contiguous()
+        k_ = k.permute(0, 2, 1, 3).contiguous()
+        v_ = v.permute(0, 2, 1, 3).contiguous()
+        if Hkv != Hq:
+            repeat = Hq // Hkv
+            k_ = k_.repeat_interleave(repeat, dim=1)
+            v_ = v_.repeat_interleave(repeat, dim=1)
+        out = F.scaled_dot_product_attention(q_, k_, v_, is_causal=causal)
+        return out.permute(0, 2, 1, 3).contiguous()
+
+
+_SCRIPT_PATH = Path(__file__).resolve()
+
+
+def _find_repo_root(start: Path) -> Path:
+    for candidate in (start.parent, *start.parents):
+        if (candidate / "experiments").exists() and (candidate / "data").exists():
+            return candidate
+    return start.parent
+
+
+_REPO_ROOT = _find_repo_root(_SCRIPT_PATH)
+
+
+def _unique_paths(paths) -> list[Path]:
+    seen = set()
+    unique = []
+    for path in paths:
+        key = str(path)
+        if key in seen:
+            continue
+        seen.add(key)
+        unique.append(path)
+    return unique
+
+
+def _is_safe_recursive_search_root(path: Path) -> bool:
+    if not path.exists() or not path.is_dir():
+        return False
+    try:
+        resolved = path.resolve()
+    except OSError:
+        return False
+    if resolved == resolved.parent:
+        return False
+    return str(resolved) not in {"/proc", "/sys", "/dev"}
+
+
+def _with_vocab_substitution(raw_path: str, vocab_size: int | None) -> list[str]:
+    paths = [raw_path]
+    if vocab_size is not None:
+        replaced = re.sub(r"fineweb10B_sp\d+", f"fineweb10B_sp{vocab_size}", raw_path)
+        replaced = re.sub(
+            r"fineweb_\d+_bpe\.model", f"fineweb_{vocab_size}_bpe.model", replaced
+        )
+        paths.insert(0, replaced)
+    return list(dict.fromkeys(paths))
+
+
+def _expand_path_candidates(raw_path: str, vocab_size: int | None = None) -> list[Path]:
+    candidates = []
+    for candidate_path in _with_vocab_substitution(raw_path, vocab_size):
+        path = Path(candidate_path).expanduser()
+        if path.is_absolute():
+            candidates.append(path)
+        else:
+            candidates.append((Path.cwd() / path).resolve())
+            candidates.append((_REPO_ROOT / path).resolve())
+    return _unique_paths(candidates)
+
+
+def _data_root_candidates_from_path(path: Path) -> list[Path]:
+    text = str(path)
+    base = path.parent if any(ch in text for ch in "*?[") else path
+    candidates = []
+    if base.name.startswith("fineweb10B_sp") and base.parent.name == "datasets":
+        candidates.append(base.parent.parent)
+    if base.name == "datasets":
+        candidates.append(base.parent)
+    if base.name == "tokenizers":
+        candidates.append(base.parent)
+    if base.parent.name == "tokenizers":
+        candidates.append(base.parent.parent)
+    candidates.append(base)
+    return _unique_paths(candidates)
+
+
+def _path_mentions_other_vocab(path: Path, vocab_size: int) -> bool:
+    text = str(path)
+    for pattern in (r"fineweb10B_sp(\d+)", r"fineweb_(\d+)_bpe\.model"):
+        for match in re.finditer(pattern, text):
+            if int(match.group(1)) != vocab_size:
+                return True
+    return False
+
+
+def _tokenizer_matches_vocab(path: Path, vocab_size: int) -> bool:
+    if not path.exists():
+        return False
+    try:
+        sp = spm.SentencePieceProcessor(model_file=str(path))
+    except Exception:
+        return False
+    return int(sp.vocab_size()) == vocab_size
+
+
+def _candidate_search_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend([path, *path.parents])
+    candidates.extend([_SCRIPT_PATH.parent, *_SCRIPT_PATH.parents])
+    cwd = Path.cwd().resolve()
+    candidates.extend([cwd, *cwd.parents])
+    candidates.extend(
+        [
+            _REPO_ROOT,
+            Path("/workspace"),
+            Path("/workspace/parameter-golf"),
+            Path("/workspace/caseops_data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(
+        [path for path in candidates if _is_safe_recursive_search_root(path)]
+    )
+
+
+def _candidate_data_roots(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> list[Path]:
+    candidates = []
+    if explicit_data_dir:
+        for path in _expand_path_candidates(explicit_data_dir, vocab_size=vocab_size):
+            candidates.extend(_data_root_candidates_from_path(path))
+    candidates.extend(
+        [
+            _REPO_ROOT / "data",
+            Path.cwd() / "data",
+            Path("/workspace/parameter-golf/data"),
+            Path("/workspace/caseops_data/datasets"),
+        ]
+    )
+    return _unique_paths(candidates)
+
+
+def _resolve_existing_path(candidates: list[Path]) -> Path | None:
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _resolve_data_dir(
+    explicit_data_dir: str | None, vocab_size: int | None = None
+) -> str:
+    candidates = _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _resolve_existing_path(candidates)
+    return str(resolved if resolved is not None else candidates[0])
+
+
+def _resolve_glob_candidates(
+    patterns: list[Path], vocab_size: int | None = None
+) -> Path | None:
+    for pattern in patterns:
+        matches = [Path(path) for path in glob.glob(str(pattern))]
+        if vocab_size is not None:
+            matches = [
+                path
+                for path in matches
+                if not _path_mentions_other_vocab(path, vocab_size)
+            ]
+        if matches:
+            return pattern
+    return None
+
+
+def _search_dataset_pattern(
+    split: str, vocab_size: int, roots: list[Path]
+) -> Path | None:
+    target_dir = f"fineweb10B_sp{vocab_size}"
+    filename = f"fineweb_{split}_*.bin"
+    direct_patterns = []
+    for root in roots:
+        direct_patterns.extend(
+            [
+                root / "data" / "datasets" / target_dir / filename,
+                root / "datasets" / target_dir / filename,
+                root / "dashboard_data" / "smoke_data" / target_dir / filename,
+                root / filename,
+            ]
+        )
+    resolved = _resolve_glob_candidates(
+        _unique_paths(direct_patterns), vocab_size=vocab_size
+    )
+    if resolved is not None:
+        return resolved
+
+    for root in roots:
+        try:
+            recursive = sorted(root.glob(f"**/{target_dir}/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        usable = [path for path in recursive if "_bytes_" not in path.name]
+        if usable:
+            return usable[0].parent / filename
+    return None
+
+
+def _resolve_data_pattern(
+    split: str,
+    vocab_size: int,
+    explicit_pattern: str | None,
+    explicit_data_dir: str | None,
+) -> str:
+    if explicit_pattern:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(explicit_pattern, vocab_size=vocab_size)
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        resolved = _resolve_glob_candidates(explicit_candidates, vocab_size=vocab_size)
+        if resolved is not None:
+            return str(resolved)
+        if explicit_candidates:
+            return str(explicit_candidates[0])
+
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    resolved = _search_dataset_pattern(split, vocab_size, search_roots)
+    if resolved is not None:
+        return str(resolved)
+
+    candidates = [
+        root / "datasets" / f"fineweb10B_sp{vocab_size}" / f"fineweb_{split}_*.bin"
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if glob.glob(str(candidate)):
+            return str(candidate)
+    return str(candidates[0])
+
+
+def _resolve_tokenizer_path(
+    vocab_size: int, explicit_tokenizer_path: str | None, explicit_data_dir: str | None
+) -> str:
+    if explicit_tokenizer_path:
+        explicit_candidates = [
+            path
+            for path in _expand_path_candidates(
+                explicit_tokenizer_path, vocab_size=vocab_size
+            )
+            if not _path_mentions_other_vocab(path, vocab_size)
+        ]
+        for candidate in explicit_candidates:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+    filename = f"fineweb_{vocab_size}_bpe.model"
+    search_roots = _candidate_search_roots(explicit_data_dir, vocab_size=vocab_size)
+    candidates = []
+    for root in search_roots:
+        candidates.extend(
+            [
+                root / "data" / "tokenizers" / filename,
+                root / "tokenizers" / filename,
+            ]
+        )
+    for candidate in _unique_paths(candidates):
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+
+    for root in search_roots:
+        try:
+            recursive = sorted(root.glob(f"**/{filename}"))
+        except (PermissionError, OSError):
+            continue
+        for candidate in recursive:
+            if _tokenizer_matches_vocab(candidate, vocab_size):
+                return str(candidate)
+
+    candidates = [
+        root / "tokenizers" / filename
+        for root in _candidate_data_roots(explicit_data_dir, vocab_size=vocab_size)
+    ]
+    for candidate in candidates:
+        if _tokenizer_matches_vocab(candidate, vocab_size):
+            return str(candidate)
+    return str(_unique_paths(candidates)[0])
+
+
+class Hyperparameters:
+    _ts = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
+    _short = uuid.uuid4().hex[:8]
+    run_id = os.environ.get("RUN_ID", f"{_ts}_{_short}")
+    experiment_variant = os.environ.get("EXPERIMENT_VARIANT", "base_prettt")
+    experiment_notes = os.environ.get("EXPERIMENT_NOTES", "")
+    seed = int(os.environ.get("SEED", 1337))
+
+    requested_vocab_size = int(os.environ.get("VOCAB_SIZE", 8192))
+    vocab_size = 8192
+    data_root_hint = os.environ.get("DATA_DIR") or os.environ.get("DATA_PATH")
+    data_dir = _resolve_data_dir(data_root_hint, vocab_size=vocab_size)
+    datasets_dir = os.path.dirname(
+        _resolve_data_pattern(
+            "train",
+            vocab_size,
+            os.environ.get("TRAIN_FILES"),
+            data_root_hint,
+        )
+    )
+    train_files = _resolve_data_pattern(
+        "train",
+        vocab_size,
+        os.environ.get("TRAIN_FILES"),
+        data_root_hint,
+    )
+    val_files = _resolve_data_pattern(
+        "val",
+        vocab_size,
+        os.environ.get("VAL_FILES"),
+        data_root_hint,
+    )
+    tokenizer_path = _resolve_tokenizer_path(
+        vocab_size,
+        os.environ.get("TOKENIZER_PATH"),
+        data_root_hint,
+    )
+
+    iterations = int(os.environ.get("ITERATIONS", 50000))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", 0.72))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 786_432))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 2048))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 500))
+    recurrence_probe_every = int(os.environ.get("RECURRENCE_PROBE_EVERY", 10))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 4000))
+    val_batch_tokens = int(os.environ.get("VAL_BATCH_TOKENS", 524_288))
+    eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", 2048))
+    sliding_window_enabled = bool(int(os.environ.get("SLIDING_WINDOW_ENABLED", "0")))
+
+    num_layers = int(os.environ.get("NUM_LAYERS", 11))
+    xsa_last_n = int(os.environ.get("XSA_LAST_N", 11))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    embedding_dim = int(os.environ.get("EMBEDDING_DIM", 512))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = float(os.environ.get("MLP_MULT", 4.0))
+    skip_gates_enabled = bool(int(os.environ.get("SKIP_GATES_ENABLED", "1")))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    rope_dims = int(os.environ.get("ROPE_DIMS", 16))
+    rope_train_seq_len = int(os.environ.get("ROPE_TRAIN_SEQ_LEN", 2048))
+    ln_scale = bool(int(os.environ.get("LN_SCALE", "1")))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 5.25))
+
+    num_loops = int(os.environ.get("NUM_LOOPS", 2))
+    loop_start = int(os.environ.get("LOOP_START", 3))
+    loop_end = int(os.environ.get("LOOP_END", 5))
+    enable_looping_at = float(os.environ.get("ENABLE_LOOPING_AT", 0.35))
+    art_halt_enabled = bool(int(os.environ.get("ART_HALT_ENABLED", "1")))
+    art_halt_enable_at = float(os.environ.get("ART_HALT_ENABLE_AT", 0.55))
+    art_router_hidden_dim = int(os.environ.get("ART_ROUTER_HIDDEN_DIM", 64))
+    art_router_lr = float(os.environ.get("ART_ROUTER_LR", 5e-4))
+    art_router_wd = float(os.environ.get("ART_ROUTER_WD", 0.01))
+    art_router_entropy_start = float(os.environ.get("ART_ROUTER_ENTROPY_START", 0.05))
+    art_router_entropy_end = float(os.environ.get("ART_ROUTER_ENTROPY_END", 0.0))
+    art_cycle_penalty = float(os.environ.get("ART_CYCLE_PENALTY", 0.001))
+    art_route_group_size = int(os.environ.get("ART_ROUTE_GROUP_SIZE", 1))
+    art_shard_coherent_batches = bool(
+        int(os.environ.get("ART_SHARD_COHERENT_BATCHES", "0"))
+    )
+    art_gptq_calibrate_routed = bool(
+        int(os.environ.get("ART_GPTQ_CALIBRATE_ROUTED", "0"))
+    )
+    art_quant_router_fp32 = bool(int(os.environ.get("ART_QUANT_ROUTER_FP32", "0")))
+    art_eval_route_stats = bool(int(os.environ.get("ART_EVAL_ROUTE_STATS", "1")))
+    art_eval_sample_routes = bool(int(os.environ.get("ART_EVAL_SAMPLE_ROUTES", "1")))
+    art_eval_route_threshold = float(os.environ.get("ART_EVAL_ROUTE_THRESHOLD", 0.5))
+    art_quant_diag_enabled = bool(int(os.environ.get("ART_QUANT_DIAG_ENABLED", "0")))
+    art_quant_diag_modes = os.environ.get(
+        "ART_QUANT_DIAG_MODES", "sample,argmax,force0,force1,force2,force3"
+    )
+    raw_roundtrip_check_enabled = bool(
+        int(os.environ.get("RAW_ROUNDTRIP_CHECK_ENABLED", "0"))
+    )
+    parallel_residual_start = int(os.environ.get("PARALLEL_RESIDUAL_START", 7))
+
+    min_lr = float(os.environ.get("MIN_LR", 0.0))
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.03))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.022))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.02))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.99))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.92)
+    )
+    muon_momentum_warmup_fraction = float(
+        os.environ.get("MUON_MOMENTUM_WARMUP_FRACTION", 0.22)
+    )
+    muon_row_normalize = bool(int(os.environ.get("MUON_ROW_NORMALIZE", "1")))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.3))
+    eval_stride = int(os.environ.get("EVAL_STRIDE", 64))
+    muon_beta2 = float(os.environ.get("MUON_BETA2", 0.95))
+    adam_wd = float(os.environ.get("ADAM_WD", 0.005))
+    muon_wd = float(os.environ.get("MUON_WD", 0.095))
+    muon_wd_mlp = float(os.environ.get("MUON_WD_MLP", 0.115))
+    embed_wd = float(os.environ.get("EMBED_WD", 0.085))
+    ema_decay = float(os.environ.get("EMA_DECAY", 0.9965))
+    ema_reset_on_looping = bool(int(os.environ.get("EMA_RESET_ON_LOOPING", "1")))
+    ema_reset_on_art = bool(int(os.environ.get("EMA_RESET_ON_ART", "1")))
+
+    ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    ttt_lr = float(os.environ.get("TTT_LR", 0.005))
+    ttt_epochs = int(os.environ.get("TTT_EPOCHS", 4))
+    ttt_momentum = float(os.environ.get("TTT_MOMENTUM", 0.9))
+    ttt_chunk_tokens = int(os.environ.get("TTT_CHUNK_TOKENS", 65536))
+    ttt_log_every_chunks = int(os.environ.get("TTT_LOG_EVERY_CHUNKS", 1))
+
+    compressor = os.environ.get("COMPRESSOR", "brotli")
+    gptq_calibration_batches = int(os.environ.get("GPTQ_CALIBRATION_BATCHES", 64))
+    matrix_bits = int(os.environ.get("MATRIX_BITS", 6))
+    embed_bits = int(os.environ.get("EMBED_BITS", 8))
+    matrix_clip_sigmas = float(os.environ.get("MATRIX_CLIP_SIGMAS", 12.85))
+    embed_clip_sigmas = float(os.environ.get("EMBED_CLIP_SIGMAS", 20.0))
+    lowbit_layers = os.environ.get("LOWBIT_LAYERS", "")
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    is_main_process = rank == 0
+    grad_accum_steps = max(1, 8 // world_size)
+
+    logfile = f"logs/{run_id}.txt"
+    os.makedirs("ckpt", exist_ok=True)
+    model_path = "ckpt/final_model.pt"
+    quantized_model_path = "ckpt/final_model.int6.ptz"
+
+
+if _SMOKE_TEST:
+    Hyperparameters.iterations = int(os.environ.get("ITERATIONS", "30"))
+    Hyperparameters.train_batch_tokens = int(
+        os.environ.get("TRAIN_BATCH_TOKENS", "32768")
+    )
+    Hyperparameters.train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", "512"))
+    Hyperparameters.eval_seq_len = int(os.environ.get("EVAL_SEQ_LEN", "512"))
+    Hyperparameters.max_wallclock_seconds = float(
+        os.environ.get("MAX_WALLCLOCK_SECONDS", "120.0")
+    )
+    Hyperparameters.val_batch_tokens = int(
+        os.environ.get("VAL_BATCH_TOKENS", "2097152")
+    )
+    Hyperparameters.warmdown_frac = float(os.environ.get("WARMDOWN_FRAC", "0.2"))
+    Hyperparameters.val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", "0"))
+    Hyperparameters.train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", "5"))
+    Hyperparameters.warmup_steps = int(os.environ.get("WARMUP_STEPS", "0"))
+    Hyperparameters.ttt_enabled = bool(int(os.environ.get("TTT_ENABLED", "0")))
+    Hyperparameters.gptq_calibration_batches = int(
+        os.environ.get("GPTQ_CALIBRATION_BATCHES", "2")
+    )
+
+_logger_hparams = None
+
+
+def set_logging_hparams(h):
+    global _logger_hparams
+    _logger_hparams = h
+
+
+def log(msg, console=True):
+    if _logger_hparams is None:
+        print(msg)
+        return
+    if _logger_hparams.is_main_process:
+        if console:
+            print(msg)
+        if _logger_hparams.logfile is not None:
+            with open(_logger_hparams.logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+
+_SHARD_HEADER_BYTES = 256 * np.dtype("<i4").itemsize
+_SHARD_NTOKENS_CACHE = {}
+_MMAP_CACHE = {}
+
+
+def _read_num_tokens(file):
+    key = str(file)
+    cached = _SHARD_NTOKENS_CACHE.get(key)
+    if cached is not None:
+        return cached
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    n = int(header[2])
+    _SHARD_NTOKENS_CACHE[key] = n
+    return n
+
+
+def _get_shard_memmap(file):
+    key = str(file)
+    mm = _MMAP_CACHE.get(key)
+    if mm is not None:
+        return mm
+    n = _read_num_tokens(file)
+    mm = np.memmap(file, mode="r", dtype="<u2", offset=_SHARD_HEADER_BYTES, shape=(n,))
+    _MMAP_CACHE[key] = mm
+    return mm
+
+
+def load_data_shard(file):
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(
+            f"Shard size mismatch for {file}: expected {expected_size} bytes"
+        )
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+def load_validation_tokens(pattern, seq_len):
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    tokens = torch.cat([load_data_shard(f) for f in files]).contiguous()
+    usable = (tokens.numel() - 1) // seq_len * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for seq_len={seq_len}")
+    return tokens[: usable + 1]
+
+
+def build_sentencepiece_luts(sp, vocab_size, device):
+    sp_vocab_size = int(sp.vocab_size())
+    assert sp.piece_to_id("▁") != sp.unk_id(), (
+        "Tokenizer must have '▁' as a token for BPB byte counting"
+    )
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+class ValidationData:
+    def __init__(self, h, device):
+        if not Path(h.tokenizer_path).exists():
+            raise FileNotFoundError(
+                f"Tokenizer model not found: {h.tokenizer_path}. "
+                "Set TOKENIZER_PATH or DATA_DIR/DATA_PATH to a location containing tokenizers/."
+            )
+        self.sp = spm.SentencePieceProcessor(model_file=h.tokenizer_path)
+        if int(self.sp.vocab_size()) != h.vocab_size:
+            raise ValueError(
+                f"VOCAB_SIZE={h.vocab_size} does not match tokenizer vocab_size={int(self.sp.vocab_size())}"
+            )
+        self.val_tokens = load_validation_tokens(h.val_files, h.eval_seq_len)
+        self.base_bytes_lut, self.has_leading_space_lut, self.is_boundary_token_lut = (
+            build_sentencepiece_luts(self.sp, h.vocab_size, device)
+        )
+
+
+class ShuffledSequenceLoader:
+    def __init__(self, h, device):
+        self.world_size = h.world_size
+        self.seq_len = h.train_seq_len
+        self.device = device
+        self.shard_coherent_batches = getattr(h, "art_shard_coherent_batches", False)
+        all_files = [Path(p) for p in sorted(glob.glob(h.train_files))]
+        if not all_files:
+            raise FileNotFoundError(f"No files found for pattern: {h.train_files}")
+        self.files = all_files[h.rank :: h.world_size]
+        self.rng = np.random.Generator(np.random.PCG64(h.rank))
+        self.num_tokens = [_read_num_tokens(f) for f in self.files]
+        self.start_inds = [[] for _ in self.files]
+        self._phase_epoch = [0] * len(self.files)
+        self._phase_order = [self.rng.permutation(8).tolist() for _ in self.files]
+        for si in range(len(self.files)):
+            self._reset_shard(si)
+
+    def _reset_shard(self, si):
+        max_phase = min(
+            self.seq_len - 1, max(0, self.num_tokens[si] - self.seq_len - 1)
+        )
+        if max_phase > 0:
+            k = self._phase_order[si][self._phase_epoch[si] % 8]
+            self._phase_epoch[si] += 1
+            phase = min(k * (max_phase + 1) // 8, max_phase)
+        else:
+            phase = 0
+        num_sequences = (self.num_tokens[si] - 1 - phase) // self.seq_len
+        sequence_order = self.rng.permutation(num_sequences)
+        self.start_inds[si] = (phase + sequence_order * self.seq_len).tolist()
+
+    def next_batch(self, global_tokens, grad_accum_steps):
+        device_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        device_batch_size = device_tokens // self.seq_len
+        num_shards = len(self.files)
+        remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+        total = remaining.sum()
+        if total <= 0:
+            for si in range(num_shards):
+                self._reset_shard(si)
+            remaining = np.array([len(s) for s in self.start_inds], dtype=np.float64)
+            total = remaining.sum()
+        target = device_batch_size * remaining / total
+        quotas = np.floor(target).astype(np.int64)
+        leftover = device_batch_size - int(quotas.sum())
+        if leftover > 0:
+            order = np.argsort(-(target - quotas))
+            for i in order[:leftover]:
+                quotas[int(i)] += 1
+        quotas = np.minimum(quotas, remaining.astype(np.int64))
+        shortfall = device_batch_size - int(quotas.sum())
+        if shortfall > 0:
+            extra = remaining.astype(np.int64) - quotas
+            order = np.argsort(-extra)
+            fill = 0
+            while shortfall > 0 and fill < num_shards:
+                j = int(order[fill])
+                if extra[j] > 0:
+                    quotas[j] += 1
+                    extra[j] -= 1
+                    shortfall -= 1
+                else:
+                    fill += 1
+        shard_plan = np.concatenate(
+            [np.full(int(q), s, dtype=np.int64) for s, q in enumerate(quotas)]
+        )
+        if self.shard_coherent_batches:
+            if shard_plan.size > 1:
+                shard_plan = np.roll(
+                    shard_plan, int(self.rng.integers(0, shard_plan.size))
+                )
+        else:
+            self.rng.shuffle(shard_plan)
+        x = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        y = torch.empty((device_batch_size, self.seq_len), dtype=torch.int64)
+        for bi in range(device_batch_size):
+            si = int(shard_plan[bi])
+            if not self.start_inds[si]:
+                for si2 in range(num_shards):
+                    self._reset_shard(si2)
+            start_ind = self.start_inds[si].pop()
+            mm = _get_shard_memmap(self.files[si])
+            window = torch.as_tensor(
+                np.array(mm[start_ind : start_ind + self.seq_len + 1], dtype=np.int64)
+            )
+            x[bi] = window[:-1]
+            y[bi] = window[1:]
+        return x.to(self.device, non_blocking=True), y.to(
+            self.device, non_blocking=True
+        )
+
+
+class RMSNorm(nn.Module):
+    def __init__(self, eps=None):
+        super().__init__()
+        self.eps = eps
+
+    def forward(self, x):
+        return F.rms_norm(x, (x.size(-1),), eps=self.eps)
+
+
+class CastedLinear(nn.Linear):
+    def forward(self, x):
+        w = self.weight.to(x.dtype)
+        bias = self.bias.to(x.dtype) if self.bias is not None else None
+        return F.linear(x, w, bias)
+
+
+class Rotary(nn.Module):
+    def __init__(self, dim, base=1e4, train_seq_len=1024, rope_dims=0):
+        super().__init__()
+        self.dim = dim
+        self.base = base
+        self.train_seq_len = train_seq_len
+        self.rope_dims = rope_dims if rope_dims > 0 else dim
+        inv_freq = 1.0 / base ** (
+            torch.arange(0, self.rope_dims, 2, dtype=torch.float32) / self.rope_dims
+        )
+        self.register_buffer("inv_freq", inv_freq, persistent=False)
+        self._seq_len_cached = 0
+        self._cos_cached = None
+        self._sin_cached = None
+
+    def forward(self, seq_len, device, dtype):
+        if (
+            self._cos_cached is None
+            or self._sin_cached is None
+            or self._seq_len_cached != seq_len
+            or self._cos_cached.device != device
+        ):
+            rd = self.rope_dims
+            base = self.base
+            if seq_len > self.train_seq_len:
+                scale = seq_len / self.train_seq_len
+                base = self.base * scale ** (rd / (rd - 2))
+            # Recompute in fp32. The non-persistent buffer is affected by
+            # module-wide bf16 conversion and made fresh reloads non-equivalent.
+            inv_freq = 1.0 / base ** (
+                torch.arange(0, rd, 2, dtype=torch.float32, device=device) / rd
+            )
+            t = torch.arange(seq_len, device=device, dtype=inv_freq.dtype)
+            freqs = torch.outer(t, inv_freq)
+            self._cos_cached = freqs.cos()[None, :, None, :]
+            self._sin_cached = freqs.sin()[None, :, None, :]
+            self._seq_len_cached = seq_len
+        return self._cos_cached.to(dtype=dtype), self._sin_cached.to(dtype=dtype)
+
+
+def apply_rotary_emb(x, cos, sin, rope_dims=0):
+    if rope_dims > 0 and rope_dims < x.size(-1):
+        x_rope, x_pass = x[..., :rope_dims], x[..., rope_dims:]
+        half = rope_dims // 2
+        x1, x2 = x_rope[..., :half], x_rope[..., half:]
+        x_rope = torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+        return torch.cat((x_rope, x_pass), dim=-1)
+    half = x.size(-1) // 2
+    x1, x2 = x[..., :half], x[..., half:]
+    return torch.cat((x1 * cos + x2 * sin, x1 * -sin + x2 * cos), dim=-1)
+
+
+class CausalSelfAttention(nn.Module):
+    def __init__(
+        self, dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+    ):
+        super().__init__()
+        if dim % num_heads != 0:
+            raise ValueError("model_dim must be divisible by num_heads")
+        if num_heads % num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads")
+        self.num_heads = num_heads
+        self.num_kv_heads = num_kv_heads
+        self.head_dim = dim // num_heads
+        if self.head_dim % 2 != 0:
+            raise ValueError("head_dim must be even for RoPE")
+        kv_dim = self.num_kv_heads * self.head_dim
+        self.c_q = CastedLinear(dim, dim, bias=False)
+        self.c_k = CastedLinear(dim, kv_dim, bias=False)
+        self.c_v = CastedLinear(dim, kv_dim, bias=False)
+        self.proj = CastedLinear(dim, dim, bias=False)
+        self.proj._zero_init = True
+        self.q_gain = nn.Parameter(
+            torch.full((num_heads, 2), qk_gain_init, dtype=torch.float32)
+        )
+        self.attn_out_gate_width = 12
+        self.attn_out_gate_w = nn.Parameter(
+            torch.zeros(num_heads, self.attn_out_gate_width, dtype=torch.float32)
+        )
+        self.rope_dims = 0
+        self.rotary = Rotary(self.head_dim, base=rope_base, train_seq_len=train_seq_len)
+        self.use_xsa = False
+
+    def _xsa_efficient(self, y, v):
+        B, T, H, D = y.shape
+        Hkv = v.size(-2)
+        group = H // Hkv
+        y_g = y.reshape(B, T, Hkv, group, D)
+        vn = F.normalize(v, dim=-1).unsqueeze(-2)
+        proj = (y_g * vn).sum(dim=-1, keepdim=True) * vn
+        return (y_g - proj).reshape(B, T, H, D)
+
+    def forward(self, x):
+        bsz, seqlen, dim = x.shape
+        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim)
+        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim)
+        q = F.rms_norm(q, (q.size(-1),))
+        k = F.rms_norm(k, (k.size(-1),))
+        cos, sin = self.rotary(seqlen, x.device, q.dtype)
+        q = apply_rotary_emb(q, cos, sin, self.rope_dims)
+        k = apply_rotary_emb(k, cos, sin, self.rope_dims)
+        rd = self.rope_dims
+        gain = self.q_gain.to(dtype=q.dtype)
+        if 0 < rd < q.size(-1):
+            q_rope = q[..., :rd] * gain[None, None, :, 0:1]
+            q_nope = q[..., rd:] * gain[None, None, :, 1:2]
+            q = torch.cat((q_rope, q_nope), dim=-1)
+        else:
+            q = q * gain[None, None, :, 0:1]
+        y = flash_attn_3_func(q, k, v, causal=True)
+        if self.use_xsa:
+            y = self._xsa_efficient(y, v)
+        gate_w = self.attn_out_gate_w.to(dtype=x.dtype)
+        g = 2.0 * torch.sigmoid(F.linear(x[..., : self.attn_out_gate_width], gate_w))
+        y = y * g[..., None]
+        y = y.reshape(bsz, seqlen, dim)
+        return self.proj(y)
+
+
+class MLP(nn.Module):
+    def __init__(self, dim, mlp_mult):
+        super().__init__()
+        hidden = int(mlp_mult * dim)
+        self.fc = CastedLinear(dim, hidden, bias=False)
+        self.proj = CastedLinear(hidden, dim, bias=False)
+        self.proj._zero_init = True
+
+    def forward(self, x):
+        return self.proj(F.silu(self.fc(x)).square())
+
+
+class Block(nn.Module):
+    def __init__(
+        self,
+        dim,
+        num_heads,
+        num_kv_heads,
+        mlp_mult,
+        rope_base,
+        qk_gain_init,
+        train_seq_len,
+        layer_idx=0,
+        ln_scale=False,
+    ):
+        super().__init__()
+        self.attn_norm = RMSNorm()
+        self.mlp_norm = RMSNorm()
+        self.attn = CausalSelfAttention(
+            dim, num_heads, num_kv_heads, rope_base, qk_gain_init, train_seq_len
+        )
+        self.mlp = MLP(dim, mlp_mult)
+        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))
+        self.resid_mix = nn.Parameter(
+            torch.stack((torch.ones(dim), torch.zeros(dim))).float()
+        )
+        self.ln_scale_factor = 1.0 / math.sqrt(layer_idx + 1) if ln_scale else 1.0
+        self.parallel = False
+
+    def forward(self, x, x0):
+        mix = self.resid_mix.to(dtype=x.dtype)
+        x_in = mix[0][None, None, :] * x + mix[1][None, None, :] * x0
+        attn_out = self.attn(self.attn_norm(x_in) * self.ln_scale_factor)
+        if self.parallel:
+            mlp_out = self.mlp(self.mlp_norm(x_in) * self.ln_scale_factor)
+            x_out = (
+                x_in
+                + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+                + self.mlp_scale.to(dtype=x_in.dtype)[None, None, :] * mlp_out
+            )
+        else:
+            x_out = (
+                x_in + self.attn_scale.to(dtype=x_in.dtype)[None, None, :] * attn_out
+            )
+            x_out = x_out + self.mlp_scale.to(dtype=x_out.dtype)[
+                None, None, :
+            ] * self.mlp(self.mlp_norm(x_out) * self.ln_scale_factor)
+        return x_out
+
+
+class ARTHaltRouter(nn.Module):
+    def __init__(self, input_dim: int, hidden_dim: int):
+        super().__init__()
+        self.fc = nn.Linear(input_dim, hidden_dim)
+        self.proj = nn.Linear(hidden_dim, 2)
+        nn.init.zeros_(self.proj.weight)
+        nn.init.zeros_(self.proj.bias)
+
+    def forward(self, features: Tensor) -> Tensor:
+        return self.proj(F.gelu(self.fc(features.float())))
+
+
+class GPT(nn.Module):
+    def __init__(self, h):
+        super().__init__()
+        if h.logit_softcap <= 0.0:
+            raise ValueError(f"logit_softcap must be positive, got {h.logit_softcap}")
+        self.tie_embeddings = h.tie_embeddings
+        self.tied_embed_init_std = h.tied_embed_init_std
+        self.logit_softcap = h.logit_softcap
+        self.tok_emb = nn.Embedding(h.vocab_size, h.embedding_dim)
+        self.embed_scale = nn.Parameter(
+            torch.ones(h.embedding_dim, dtype=torch.float32)
+        )
+        if h.embedding_dim != h.model_dim:
+            self.embed_proj = CastedLinear(h.embedding_dim, h.model_dim, bias=False)
+            self.head_proj = CastedLinear(h.model_dim, h.embedding_dim, bias=False)
+        else:
+            self.embed_proj = None
+            self.head_proj = None
+        self.num_encoder_layers = h.num_layers // 2
+        self.num_decoder_layers = h.num_layers - self.num_encoder_layers
+        self.blocks = nn.ModuleList(
+            [
+                Block(
+                    h.model_dim,
+                    h.num_heads,
+                    h.num_kv_heads,
+                    h.mlp_mult,
+                    h.rope_base,
+                    h.qk_gain_init,
+                    h.train_seq_len,
+                    layer_idx=i,
+                    ln_scale=h.ln_scale,
+                )
+                for i in range(h.num_layers)
+            ]
+        )
+        if h.rope_dims > 0:
+            head_dim = h.model_dim // h.num_heads
+            for block in self.blocks:
+                block.attn.rope_dims = h.rope_dims
+                block.attn.rotary = Rotary(
+                    head_dim,
+                    base=h.rope_base,
+                    train_seq_len=h.rope_train_seq_len,
+                    rope_dims=h.rope_dims,
+                )
+        self.final_norm = RMSNorm()
+        self.lm_head = (
+            None
+            if h.tie_embeddings
+            else CastedLinear(h.embedding_dim, h.vocab_size, bias=False)
+        )
+        if self.lm_head is not None:
+            self.lm_head._zero_init = True
+        if h.xsa_last_n > 0:
+            for i in range(max(0, h.num_layers - h.xsa_last_n), h.num_layers):
+                self.blocks[i].attn.use_xsa = True
+        if h.parallel_residual_start >= 0:
+            for i in range(h.parallel_residual_start, h.num_layers):
+                self.blocks[i].parallel = True
+        if h.num_loops > 0 and h.ln_scale:
+            loop_scale = 1.0 / math.sqrt(h.num_loops + 1)
+            for i in range(h.loop_start, h.loop_end + 1):
+                self.blocks[i].ln_scale_factor = (
+                    self.blocks[i].ln_scale_factor * loop_scale
+                )
+
+        self.looping_active = False
+        if h.num_loops > 0:
+            loop_seg = list(range(h.loop_start, h.loop_end + 1))
+            all_indices = list(range(h.loop_start))
+            for _ in range(h.num_loops + 1):
+                all_indices.extend(loop_seg)
+            all_indices.extend(range(h.loop_end + 1, h.num_layers))
+            num_enc = len(all_indices) // 2
+            self.encoder_indices = all_indices[:num_enc]
+            self.decoder_indices = all_indices[num_enc:]
+        else:
+            self.encoder_indices = list(range(self.num_encoder_layers))
+            self.decoder_indices = list(range(self.num_encoder_layers, h.num_layers))
+
+        self.art_halt_enabled = h.art_halt_enabled
+        self.art_halt_runtime_active = False
+        self.art_router_entropy_bonus = h.art_router_entropy_start
+        self.art_cycle_penalty = h.art_cycle_penalty
+        self.art_router_first = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_early = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router = ARTHaltRouter(2 * h.model_dim, h.art_router_hidden_dim)
+        self.art_router_continue_idx = 0
+        self.art_router_stop_idx = 1
+        self.art_route_group_size = h.art_route_group_size
+        self.art_eval_sample_routes = h.art_eval_sample_routes
+        self.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        self.art_eval_route_threshold = h.art_eval_route_threshold
+        self.art_eval_force_depth = -1
+        self._art_eval_gate_index = 0
+        self.use_routed_compiled_blocks = False
+        self._routed_compiled_blocks = None
+        self._compiled_art_prefix_dual = None
+        self._compiled_art_tail_dual = None
+        self.last_art_avg_cycles = 3.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_policy_loss = 0.0
+        self.art_gate_names = ("cycle1", "cycle2", "cycle3")
+        self._last_art_log_probs: Tensor | None = None
+        self._last_art_entropies: Tensor | None = None
+        self._last_art_cycles: Tensor | None = None
+        self._last_art_gate_continue_stats: Tensor | None = None
+        self._last_art_avg_cycles_stat: Tensor | None = None
+        self._last_art_continue_rate_stat: Tensor | None = None
+        self._last_art_router_entropy_stat: Tensor | None = None
+        self._last_art_router_loss_stat: Tensor | None = None
+        self._last_art_policy_loss_stat: Tensor | None = None
+        self._art_early_cycle_boundary_encoder_pos = 5
+        self._art_early_encoder_cycle_positions = (6, 7)
+        self._art_late_cycle_boundary_decoder_pos = 0
+        self._art_late_decoder_cycle_positions = (1, 2, 3)
+
+        if self.art_halt_enabled:
+            if (h.num_loops, h.loop_start, h.loop_end) != (2, 3, 5):
+                raise ValueError(
+                    "Triple ART halt requires NUM_LOOPS=2, LOOP_START=3, LOOP_END=5"
+                )
+            expected_encoder = [0, 1, 2, 3, 4, 5, 3, 4]
+            if self.encoder_indices != expected_encoder:
+                raise ValueError(
+                    f"Triple ART halt expects encoder {expected_encoder}, got {self.encoder_indices}"
+                )
+            expected_decoder = [5, 3, 4, 5]
+            if self.decoder_indices[:4] != expected_decoder:
+                raise ValueError(
+                    f"Triple ART halt expects decoder prefix {expected_decoder}, got {self.decoder_indices[:4]}"
+                )
+
+        self.num_skip_weights = min(
+            len(self.encoder_indices), len(self.decoder_indices)
+        )
+        self.skip_weights = nn.Parameter(
+            torch.ones(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+        )
+        self.skip_gates = (
+            nn.Parameter(
+                torch.zeros(self.num_skip_weights, h.model_dim, dtype=torch.float32)
+            )
+            if h.skip_gates_enabled
+            else None
+        )
+        self._init_weights()
+
+    def _init_weights(self):
+        if self.tie_embeddings:
+            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)
+        for name, module in self.named_modules():
+            if isinstance(module, nn.Linear):
+                if getattr(module, "_zero_init", False):
+                    nn.init.zeros_(module.weight)
+                elif (
+                    module.weight.ndim == 2
+                    and module.weight.shape[0] >= 64
+                    and module.weight.shape[1] >= 64
+                ):
+                    nn.init.orthogonal_(module.weight, gain=1.0)
+
+    def _art_router_features(self, x: Tensor) -> Tensor:
+        last_token = x[:, -1, :]
+        pooled = x.amax(dim=1)
+        return torch.cat((last_token, pooled), dim=-1)
+
+    def _next_art_eval_gate_index(self) -> int:
+        gate_idx = int(self._art_eval_gate_index)
+        self._art_eval_gate_index = gate_idx + 1
+        return gate_idx
+
+    def _art_eval_action_ids(self, probs: Tensor) -> Tensor:
+        mode = self.art_eval_route_mode
+        if mode == "sample":
+            return torch.multinomial(probs, num_samples=1).squeeze(1)
+        if mode == "threshold":
+            continue_probs = probs[:, self.art_router_continue_idx]
+            return torch.where(
+                continue_probs >= self.art_eval_route_threshold,
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_continue_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+                torch.full(
+                    (probs.size(0),),
+                    self.art_router_stop_idx,
+                    device=probs.device,
+                    dtype=torch.long,
+                ),
+            )
+        if mode == "force":
+            continue_gate = self._next_art_eval_gate_index() < self.art_eval_force_depth
+            action_id = (
+                self.art_router_continue_idx
+                if continue_gate
+                else self.art_router_stop_idx
+            )
+            return torch.full(
+                (probs.size(0),), action_id, device=probs.device, dtype=torch.long
+            )
+        return probs.argmax(dim=-1)
+
+    def _art_router_decision(
+        self, router: ARTHaltRouter, x: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        features = self._art_router_features(x)
+        if self.art_route_group_size != 1 and features.size(0) > 1:
+            return self._art_router_decision_grouped(router, features)
+        logits = router(features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            selected_log_probs = log_probs.gather(1, action_ids.unsqueeze(1)).squeeze(1)
+        else:
+            action_ids = self._art_eval_action_ids(probs)
+            selected_log_probs = None
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_decision_grouped(
+        self, router: ARTHaltRouter, features: Tensor
+    ) -> tuple[Tensor, Tensor | None, Tensor]:
+        batch_size = features.size(0)
+        group_size = (
+            batch_size
+            if self.art_route_group_size <= 0
+            else min(self.art_route_group_size, batch_size)
+        )
+        num_groups = (batch_size + group_size - 1) // group_size
+        group_ids = torch.arange(batch_size, device=features.device) // group_size
+        if batch_size % group_size == 0:
+            group_features = features.reshape(num_groups, group_size, -1).mean(dim=1)
+        else:
+            group_features = features.new_zeros(num_groups, features.size(-1))
+            group_features.index_add_(0, group_ids, features)
+            group_counts = torch.bincount(group_ids, minlength=num_groups).to(
+                dtype=features.dtype
+            )
+            group_features = group_features / group_counts.clamp_min(1.0).unsqueeze(1)
+
+        logits = router(group_features)
+        probs = torch.softmax(logits, dim=-1)
+        log_probs = torch.log(probs.clamp_min(1e-9))
+        group_entropies = -(probs * log_probs).sum(dim=1)
+        if self.training and torch.is_grad_enabled():
+            group_action_ids = torch.multinomial(probs, num_samples=1).squeeze(1)
+            group_selected_log_probs = log_probs.gather(
+                1, group_action_ids.unsqueeze(1)
+            ).squeeze(1)
+        else:
+            group_action_ids = self._art_eval_action_ids(probs)
+            group_selected_log_probs = None
+
+        action_ids = group_action_ids.index_select(0, group_ids)
+        selected_log_probs = (
+            group_selected_log_probs.index_select(0, group_ids)
+            if group_selected_log_probs is not None
+            else None
+        )
+        entropies = group_entropies.index_select(0, group_ids)
+        continue_mask = action_ids == self.art_router_continue_idx
+        return continue_mask, selected_log_probs, entropies
+
+    def _art_router_anchor(self, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in self.art_router_first.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router_early.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        for param in self.art_router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _art_single_router_anchor(self, router: ARTHaltRouter, ref: Tensor) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for param in router.parameters():
+            anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def _block_param_anchor(
+        self, block_indices: tuple[int, ...], ref: Tensor
+    ) -> Tensor:
+        anchor = torch.zeros((), device=ref.device, dtype=torch.float32)
+        for block_idx in block_indices:
+            for param in self.blocks[block_idx].parameters():
+                anchor = anchor + param.reshape(-1)[0].float() * 0.0
+        return anchor.to(dtype=ref.dtype)
+
+    def prepare_routed_compiled_blocks(self) -> None:
+        if _SMOKE_TEST:
+            return
+        if self._routed_compiled_blocks is None:
+            self._routed_compiled_blocks = [
+                torch.compile(block, dynamic=True, fullgraph=True)
+                for block in self.blocks
+            ]
+
+    def _run_block(self, x: Tensor, x0: Tensor, block_idx: int) -> Tensor:
+        if self.use_routed_compiled_blocks and self._routed_compiled_blocks is not None:
+            return self._routed_compiled_blocks[block_idx](x, x0)
+        return self.blocks[block_idx](x, x0)
+
+    def warm_routed_compiled_blocks(
+        self, batch_size: int, seq_len: int, device: torch.device, dtype: torch.dtype
+    ) -> None:
+        if _SMOKE_TEST:
+            return
+        self.prepare_routed_compiled_blocks()
+        previous_enabled = self.use_routed_compiled_blocks
+        previous_training = self.training
+        self.use_routed_compiled_blocks = True
+        self.train()
+        dim = int(self.skip_weights.size(1))
+        block_indices = sorted(set(self.encoder_indices + self.decoder_indices))
+        for block_idx in block_indices:
+            x = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            x0 = torch.zeros(
+                batch_size, seq_len, dim, device=device, dtype=dtype, requires_grad=True
+            )
+            loss = self._run_block(x, x0, block_idx).float().mean()
+            loss.backward()
+            self.zero_grad(set_to_none=True)
+        self.use_routed_compiled_blocks = previous_enabled
+        self.train(previous_training)
+
+    def _project_logits(self, x: Tensor) -> Tensor:
+        x = self.final_norm(x)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def _forward_art_prefix_triple(self, input_ids: Tensor):
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        for i in self.encoder_indices[:3]:
+            x = self._run_block(x, x0, i)
+            skips.append(x)
+        return x, x0, skips[0], skips[1], skips[2]
+
+    def _forward_art_tail_triple(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        s0: Tensor,
+        s1: Tensor,
+        s2: Tensor,
+        first_continue_idx: Tensor,
+        active_s3: Tensor | None,
+    ) -> Tensor:
+        if first_continue_idx.numel() > 0 and active_s3 is not None:
+            scaled_s3 = (
+                self.skip_weights[4].to(dtype=x.dtype)[None, None, :] * active_s3
+            )
+            if first_continue_idx.numel() == x.size(0):
+                x = self._apply_skip(x, scaled_s3, 4)
+            else:
+                full_scaled_s3 = torch.zeros_like(x)
+                full_scaled_s3.index_copy_(0, first_continue_idx, scaled_s3)
+                x = self._apply_skip_subset(x, full_scaled_s3, 4, first_continue_idx)
+        x = self._run_block(x, x0, self.decoder_indices[4])
+        for skip_idx, block_idx, skip in (
+            (5, self.decoder_indices[5], s2),
+            (6, self.decoder_indices[6], s1),
+            (7, self.decoder_indices[7], s0),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :] * skip
+            )
+            x = self._apply_skip(x, scaled_skip, skip_idx)
+            x = self._run_block(x, x0, block_idx)
+        x = self._run_block(x, x0, self.decoder_indices[8])
+        return self._project_logits(x)
+
+    def _forward_logits_trunk_only(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        empty_idx = torch.empty(0, device=x.device, dtype=torch.long)
+        if self.training and torch.is_grad_enabled():
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+            x = x + self._block_param_anchor((3, 4, 5), x).view(1, 1, 1)
+        return self._forward_art_tail_triple(x, x0, s0, s1, s2, empty_idx, None)
+
+    def _forward_logits_art_triple_segmented(self, input_ids: Tensor) -> Tensor:
+        x, x0, s0, s1, s2 = self._forward_art_prefix_triple(input_ids)
+        (
+            first_continue_mask,
+            first_log_probs,
+            first_entropies,
+        ) = self._art_router_decision(self.art_router_first, x)
+        first_continue_idx = first_continue_mask.nonzero(as_tuple=False).flatten()
+        art_cycles = first_continue_mask.to(dtype=torch.float32)
+        art_log_prob_accum = first_log_probs
+        art_entropy_accum = first_entropies
+        active_s3_for_tail = None
+        early_continue_rate = x.new_zeros((), dtype=torch.float32)
+        late_continue_rate = x.new_zeros((), dtype=torch.float32)
+
+        if first_continue_idx.numel() > 0:
+            if first_continue_idx.numel() == x.size(0):
+                active_x = x
+                active_x0 = x0
+            else:
+                active_x = x.index_select(0, first_continue_idx)
+                active_x0 = x0.index_select(0, first_continue_idx)
+
+            active_x, active_s3, active_s4, active_s5 = (
+                self._run_art_first_cycle_active(active_x, active_x0)
+            )
+            active_s3_for_tail = active_s3
+            (
+                early_continue_subset,
+                early_log_probs,
+                early_entropies,
+            ) = self._art_router_decision(self.art_router_early, active_x)
+            early_continue_mask = torch.zeros_like(first_continue_mask)
+            early_continue_mask.index_copy_(
+                0, first_continue_idx, early_continue_subset
+            )
+            early_continue_subset_idx = early_continue_subset.nonzero(
+                as_tuple=False
+            ).flatten()
+            early_continue_rate = early_continue_subset.to(dtype=torch.float32).mean()
+            art_cycles = art_cycles + early_continue_mask.to(dtype=torch.float32)
+            if early_log_probs is not None:
+                if art_log_prob_accum is None:
+                    art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                art_log_prob_accum = art_log_prob_accum.index_copy(
+                    0,
+                    first_continue_idx,
+                    art_log_prob_accum.index_select(0, first_continue_idx)
+                    + early_log_probs,
+                )
+            art_entropy_accum = art_entropy_accum.index_copy(
+                0,
+                first_continue_idx,
+                art_entropy_accum.index_select(0, first_continue_idx) + early_entropies,
+            )
+
+            if early_continue_subset_idx.numel() > 0:
+                second_x = active_x.index_select(0, early_continue_subset_idx)
+                second_x0 = active_x0.index_select(0, early_continue_subset_idx)
+                second_s5 = active_s5.index_select(0, early_continue_subset_idx)
+                second_s4 = active_s4.index_select(0, early_continue_subset_idx)
+                second_x, second_s6 = self._run_art_second_cycle_active(
+                    second_x, second_x0
+                )
+                (
+                    late_continue_subset,
+                    late_log_probs,
+                    late_entropies,
+                ) = self._art_router_decision(self.art_router, second_x)
+                second_continue_idx = first_continue_idx.index_select(
+                    0, early_continue_subset_idx
+                )
+                late_continue_mask = torch.zeros_like(first_continue_mask)
+                late_continue_mask.index_copy_(
+                    0, second_continue_idx, late_continue_subset
+                )
+                late_continue_subset_idx = late_continue_subset.nonzero(
+                    as_tuple=False
+                ).flatten()
+                late_continue_rate = late_continue_subset.to(dtype=torch.float32).mean()
+                art_cycles = art_cycles + late_continue_mask.to(dtype=torch.float32)
+                if late_log_probs is not None:
+                    if art_log_prob_accum is None:
+                        art_log_prob_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_log_prob_accum = art_log_prob_accum.index_copy(
+                        0,
+                        second_continue_idx,
+                        art_log_prob_accum.index_select(0, second_continue_idx)
+                        + late_log_probs,
+                    )
+                art_entropy_accum = art_entropy_accum.index_copy(
+                    0,
+                    second_continue_idx,
+                    art_entropy_accum.index_select(0, second_continue_idx)
+                    + late_entropies,
+                )
+
+                if late_continue_subset_idx.numel() > 0:
+                    if late_continue_subset_idx.numel() == second_x.size(0):
+                        second_x = self._run_art_third_cycle_active(
+                            second_x, second_x0, second_s6, second_s5, second_s4
+                        )
+                    else:
+                        late_x = second_x.index_select(0, late_continue_subset_idx)
+                        late_x0 = second_x0.index_select(0, late_continue_subset_idx)
+                        late_s6 = second_s6.index_select(0, late_continue_subset_idx)
+                        late_s5 = second_s5.index_select(0, late_continue_subset_idx)
+                        late_s4 = second_s4.index_select(0, late_continue_subset_idx)
+                        late_x = self._run_art_third_cycle_active(
+                            late_x, late_x0, late_s6, late_s5, late_s4
+                        )
+                        second_x = second_x.index_copy(
+                            0, late_continue_subset_idx, late_x
+                        )
+                active_x = active_x.index_copy(0, early_continue_subset_idx, second_x)
+            elif self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+            x = self._scatter_subset(x, first_continue_idx, active_x)
+        else:
+            if self.training and torch.is_grad_enabled():
+                x = x + self._art_single_router_anchor(self.art_router_early, x).view(
+                    1, 1, 1
+                )
+                x = x + self._art_single_router_anchor(self.art_router, x).view(1, 1, 1)
+
+        self._last_art_log_probs = art_log_prob_accum
+        self._last_art_entropies = art_entropy_accum
+        self._last_art_cycles = art_cycles
+        self._last_art_gate_continue_stats = torch.stack(
+            (
+                first_continue_mask.to(dtype=torch.float32).mean(),
+                early_continue_rate,
+                late_continue_rate,
+            )
+        ).detach()
+        self._last_art_continue_rate_stat = (art_cycles / 3.0).mean().detach()
+        self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+        self._last_art_router_entropy_stat = art_entropy_accum.mean().detach()
+
+        return self._forward_art_tail_triple(
+            x, x0, s0, s1, s2, first_continue_idx, active_s3_for_tail
+        )
+
+    def sync_art_logging_stats(self) -> None:
+        if self._last_art_avg_cycles_stat is not None:
+            self.last_art_avg_cycles = float(self._last_art_avg_cycles_stat.item())
+        if self._last_art_continue_rate_stat is not None:
+            self.last_art_continue_rate = float(
+                self._last_art_continue_rate_stat.item()
+            )
+        if self._last_art_router_entropy_stat is not None:
+            self.last_art_router_entropy = float(
+                self._last_art_router_entropy_stat.item()
+            )
+        if self._last_art_router_loss_stat is not None:
+            self.last_art_router_loss = float(self._last_art_router_loss_stat.item())
+        if self._last_art_policy_loss_stat is not None:
+            self.last_art_policy_loss = float(self._last_art_policy_loss_stat.item())
+
+    def _apply_skip(self, x: Tensor, scaled_skip: Tensor, skip_idx: int) -> Tensor:
+        if self.skip_gates is not None:
+            g = torch.sigmoid(self.skip_gates[skip_idx].to(dtype=x.dtype))[
+                None, None, :
+            ]
+            return torch.lerp(scaled_skip, x, g)
+        return x + scaled_skip
+
+    def _apply_skip_subset(
+        self,
+        x: Tensor,
+        scaled_skip: Tensor,
+        skip_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._apply_skip(x, scaled_skip, skip_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._apply_skip(
+                x.index_select(0, active_idx),
+                scaled_skip.index_select(0, active_idx),
+                skip_idx,
+            ),
+        )
+        return next_x
+
+    def _scatter_subset(
+        self, x: Tensor, active_idx: Tensor, active_x: Tensor
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return active_x
+        return x.index_copy(0, active_idx, active_x)
+
+    def _run_block_subset(
+        self,
+        x: Tensor,
+        x0: Tensor,
+        block_idx: int,
+        active_idx: Tensor,
+    ) -> Tensor:
+        if active_idx.numel() == 0:
+            return x
+        if active_idx.numel() == x.size(0):
+            return self._run_block(x, x0, block_idx)
+        next_x = x.clone()
+        next_x.index_copy_(
+            0,
+            active_idx,
+            self._run_block(
+                x.index_select(0, active_idx),
+                x0.index_select(0, active_idx),
+                block_idx,
+            ),
+        )
+        return next_x
+
+    def _run_art_first_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor, Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[3])
+        active_s3 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[4])
+        active_s4 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[5])
+        active_s5 = active_x
+        return active_x, active_s3, active_s4, active_s5
+
+    def _run_art_second_cycle_active(
+        self, active_x: Tensor, active_x0: Tensor
+    ) -> tuple[Tensor, Tensor]:
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[6])
+        active_s6 = active_x
+        active_x = self._run_block(active_x, active_x0, self.encoder_indices[7])
+        scaled_skip = (
+            self.skip_weights[0].to(dtype=active_x.dtype)[None, None, :] * active_x
+        )
+        active_x = self._apply_skip(active_x, scaled_skip, 0)
+        active_x = self._run_block(active_x, active_x0, self.decoder_indices[0])
+        return active_x, active_s6
+
+    def _run_art_third_cycle_active(
+        self,
+        active_x: Tensor,
+        active_x0: Tensor,
+        active_s6: Tensor,
+        active_s5: Tensor,
+        active_s4: Tensor,
+    ) -> Tensor:
+        for skip_idx, block_idx, skip in (
+            (1, self.decoder_indices[1], active_s6),
+            (2, self.decoder_indices[2], active_s5),
+            (3, self.decoder_indices[3], active_s4),
+        ):
+            scaled_skip = (
+                self.skip_weights[skip_idx].to(dtype=active_x.dtype)[None, None, :]
+                * skip
+            )
+            active_x = self._apply_skip(active_x, scaled_skip, skip_idx)
+            active_x = self._run_block(active_x, active_x0, block_idx)
+        return active_x
+
+    def forward_logits(
+        self, input_ids: Tensor, art_halt_active: bool | None = None
+    ) -> Tensor:
+        art_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+        )
+        art_early_continue_mask: Tensor | None = None
+        art_early_continue_idx: Tensor | None = None
+        art_late_continue_mask: Tensor | None = None
+        art_late_continue_idx: Tensor | None = None
+        art_cycles: Tensor | None = None
+        art_log_prob_accum: Tensor | None = None
+        art_entropy_accum: Tensor | None = None
+        art_early_decision_made = False
+        art_late_decision_made = False
+        self._last_art_log_probs = None
+        self._last_art_entropies = None
+        self._last_art_cycles = None
+        self._last_art_gate_continue_stats = None
+        self._last_art_avg_cycles_stat = None
+        self._last_art_continue_rate_stat = None
+        self._last_art_router_entropy_stat = None
+        self._last_art_router_loss_stat = None
+        self._last_art_policy_loss_stat = None
+        self.last_art_policy_loss = 0.0
+        self.last_art_router_loss = 0.0
+        self.last_art_router_entropy = 0.0
+        self.last_art_continue_rate = 1.0
+        self.last_art_avg_cycles = 3.0 if self.looping_active else 0.0
+        if not (self.training and torch.is_grad_enabled()):
+            self._art_eval_gate_index = 0
+        if art_active:
+            return self._forward_logits_art_triple_segmented(input_ids)
+        if not self.looping_active:
+            return self._forward_logits_trunk_only(input_ids)
+
+        x = self.tok_emb(input_ids)
+        x = F.rms_norm(x * self.embed_scale.to(x.dtype), (x.size(-1),))
+        if self.embed_proj is not None:
+            x = self.embed_proj(x)
+        x0 = x
+        skips = []
+        enc_iter = self.encoder_indices if self.looping_active else (0, 1, 2)
+        dec_iter = self.decoder_indices if self.looping_active else (6, 7, 8, 9, 10)
+        for enc_pos, i in enumerate(enc_iter):
+            in_early_cycle = (
+                art_active
+                and art_early_decision_made
+                and enc_pos in self._art_early_encoder_cycle_positions
+                and art_early_continue_idx is not None
+            )
+            if in_early_cycle:
+                x = self._run_block_subset(x, x0, i, art_early_continue_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            skips.append(x)
+            if (
+                art_active
+                and not art_early_decision_made
+                and enc_pos == self._art_early_cycle_boundary_encoder_pos
+            ):
+                (
+                    art_early_continue_mask,
+                    selected_log_probs,
+                    entropies,
+                ) = self._art_router_decision(self.art_router_early, x)
+                art_early_continue_idx = art_early_continue_mask.nonzero(
+                    as_tuple=False
+                ).flatten()
+                art_cycles = 1.0 + art_early_continue_mask.to(dtype=torch.float32)
+                if selected_log_probs is not None:
+                    art_log_prob_accum = selected_log_probs
+                art_entropy_accum = entropies
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                self._last_art_router_entropy_stat = entropies.mean().detach()
+                art_early_decision_made = True
+        for skip_idx, i in enumerate(dec_iter):
+            in_second_cycle = (
+                art_active
+                and art_early_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+            )
+            in_late_cycle = (
+                art_active
+                and art_late_decision_made
+                and skip_idx in self._art_late_decoder_cycle_positions
+                and art_late_continue_idx is not None
+            )
+            art_slot_idx = None
+            if in_second_cycle:
+                art_slot_idx = art_early_continue_idx
+            elif in_late_cycle:
+                art_slot_idx = art_late_continue_idx
+            if skip_idx < self.num_skip_weights and skips:
+                scaled_skip = (
+                    self.skip_weights[skip_idx].to(dtype=x.dtype)[None, None, :]
+                    * skips.pop()
+                )
+                if art_slot_idx is not None:
+                    x = self._apply_skip_subset(x, scaled_skip, skip_idx, art_slot_idx)
+                else:
+                    x = self._apply_skip(x, scaled_skip, skip_idx)
+            if art_slot_idx is not None:
+                x = self._run_block_subset(x, x0, i, art_slot_idx)
+            else:
+                x = self._run_block(x, x0, i)
+            if (
+                art_active
+                and art_early_decision_made
+                and not art_late_decision_made
+                and skip_idx == self._art_late_cycle_boundary_decoder_pos
+                and art_early_continue_idx is not None
+                and art_cycles is not None
+            ):
+                active_idx = art_early_continue_idx
+                art_late_continue_mask = torch.zeros_like(art_early_continue_mask)
+                if active_idx.numel() > 0:
+                    (
+                        late_continue_subset,
+                        selected_log_probs,
+                        entropies,
+                    ) = self._art_router_decision(
+                        self.art_router, x.index_select(0, active_idx)
+                    )
+                    art_late_continue_mask.index_copy_(
+                        0, active_idx, late_continue_subset
+                    )
+                    late_continue_subset_idx = late_continue_subset.nonzero(
+                        as_tuple=False
+                    ).flatten()
+                    art_late_continue_idx = active_idx.index_select(
+                        0, late_continue_subset_idx
+                    )
+                    art_cycles = art_cycles + art_late_continue_mask.to(
+                        dtype=torch.float32
+                    )
+                    if selected_log_probs is not None:
+                        if art_log_prob_accum is None:
+                            art_log_prob_accum = x.new_zeros(
+                                x.size(0), dtype=torch.float32
+                            )
+                        art_log_prob_accum = art_log_prob_accum.index_copy(
+                            0,
+                            active_idx,
+                            art_log_prob_accum.index_select(0, active_idx)
+                            + selected_log_probs,
+                        )
+                    if art_entropy_accum is None:
+                        art_entropy_accum = x.new_zeros(x.size(0), dtype=torch.float32)
+                    art_entropy_accum = art_entropy_accum.index_copy(
+                        0,
+                        active_idx,
+                        art_entropy_accum.index_select(0, active_idx) + entropies,
+                    )
+                self._last_art_log_probs = art_log_prob_accum
+                self._last_art_entropies = art_entropy_accum
+                self._last_art_cycles = art_cycles
+                self._last_art_continue_rate_stat = (
+                    ((art_cycles - 1.0) / 2.0).mean().detach()
+                )
+                self._last_art_avg_cycles_stat = art_cycles.mean().detach()
+                if art_entropy_accum is not None:
+                    self._last_art_router_entropy_stat = (
+                        art_entropy_accum.mean().detach()
+                    )
+                art_late_decision_made = True
+
+        x = self.final_norm(x)
+        if (
+            not art_early_decision_made
+            and not art_late_decision_made
+            and self.training
+            and torch.is_grad_enabled()
+        ):
+            x = x + self._art_router_anchor(x).view(1, 1, 1)
+        if self.head_proj is not None:
+            x = self.head_proj(x)
+        if self.tie_embeddings:
+            logits_proj = F.linear(x, self.tok_emb.weight)
+        else:
+            logits_proj = self.lm_head(x)
+        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)
+
+    def forward(
+        self,
+        input_ids: Tensor,
+        target_ids: Tensor,
+        art_halt_active: bool | None = None,
+    ) -> Tensor:
+        logits = self.forward_logits(input_ids, art_halt_active=art_halt_active)
+        art_loss_active = (
+            self.art_halt_enabled
+            and self.looping_active
+            and (
+                self.art_halt_runtime_active
+                if art_halt_active is None
+                else art_halt_active
+            )
+            and self.training
+            and torch.is_grad_enabled()
+        )
+        if not art_loss_active:
+            return F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                target_ids.reshape(-1),
+                reduction="mean",
+            )
+        token_losses = F.cross_entropy(
+            logits.reshape(-1, logits.size(-1)).float(),
+            target_ids.reshape(-1),
+            reduction="none",
+        ).reshape_as(target_ids)
+        seq_losses = token_losses.mean(dim=1)
+        main_loss = seq_losses.mean()
+        total_loss = main_loss
+        router_policy_loss = main_loss.new_zeros(())
+        router_loss = main_loss.new_zeros(())
+        if (
+            self.art_halt_enabled
+            and self.art_halt_runtime_active
+            and self.training
+            and torch.is_grad_enabled()
+            and self._last_art_log_probs is not None
+            and self._last_art_entropies is not None
+            and self._last_art_cycles is not None
+        ):
+            router_costs = (
+                seq_losses.detach() + self.art_cycle_penalty * self._last_art_cycles
+            )
+            advantages = router_costs - router_costs.mean()
+            router_policy_loss = (advantages * self._last_art_log_probs).mean()
+            router_mean_entropy = self._last_art_entropies.mean()
+            router_loss = (
+                router_policy_loss - self.art_router_entropy_bonus * router_mean_entropy
+            )
+            total_loss = total_loss + router_loss
+        self._last_art_policy_loss_stat = router_policy_loss.detach()
+        self._last_art_router_loss_stat = router_loss.detach()
+        if (
+            self._last_art_entropies is not None
+            and self._last_art_entropies.numel() > 0
+        ):
+            self._last_art_router_entropy_stat = (
+                self._last_art_entropies.mean().detach()
+            )
+        return total_loss
+
+
+def classify_param(name):
+    if "tok_emb" in name or "lm_head" in name:
+        return "embed"
+    if ".mlp." in name:
+        return "mlp"
+    if ".attn." in name or (".proj." in name and ".mlp." not in name):
+        return "attn"
+    return "other"
+
+
+@torch.compile
+def zeropower_via_newtonschulz5(G, steps=10, eps=1e-07):
+    a, b, c = 3.4445, -4.775, 2.0315
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr,
+        momentum,
+        backend_steps,
+        nesterov=True,
+        weight_decay=0.0,
+        row_normalize=False,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                weight_decay=weight_decay,
+                row_normalize=row_normalize,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+        distributed = dist.is_available() and dist.is_initialized()
+        world_size = dist.get_world_size() if distributed else 1
+        rank = dist.get_rank() if distributed else 0
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(
+                total_params, device=params[0].device, dtype=torch.bfloat16
+            )
+            curr = 0
+            for i, p in enumerate(params):
+                if i % world_size == rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    if group.get("row_normalize", False):
+                        row_norms = (
+                            g.float().norm(dim=-1, keepdim=True).clamp_min(1e-07)
+                        )
+                        g = g / row_norms.to(g.dtype)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+            if distributed:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+            wd = group.get("weight_decay", 0.0)
+            curr = 0
+            for p in params:
+                if wd > 0.0:
+                    p.data.mul_(1.0 - lr * wd)
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+        return loss
+
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights,skip_gates,attn_out_gate",
+    ).split(",")
+    if pattern
+)
+
+
+class Optimizers:
+    def __init__(self, h, base_model):
+        block_named_params = list(base_model.blocks.named_parameters())
+        matrix_attn_params = []
+        matrix_mlp_params = []
+        for name, p in block_named_params:
+            if p.ndim != 2 or any(
+                pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS
+            ):
+                continue
+            if ".mlp." in name:
+                matrix_mlp_params.append(p)
+            else:
+                matrix_attn_params.append(p)
+        scalar_params = [
+            p
+            for (name, p) in block_named_params
+            if p.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ]
+        if base_model.skip_weights.numel() > 0:
+            scalar_params.append(base_model.skip_weights)
+        if base_model.skip_gates is not None and base_model.skip_gates.numel() > 0:
+            scalar_params.append(base_model.skip_gates)
+        if hasattr(base_model, "embed_scale"):
+            scalar_params.append(base_model.embed_scale)
+        token_lr = h.tied_embed_lr if h.tie_embeddings else h.embed_lr
+        tok_params = [
+            {"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}
+        ]
+        self.optimizer_tok = torch.optim.AdamW(
+            tok_params,
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.embed_wd,
+            fused=True,
+        )
+        self.optimizer_muon = Muon(
+            [
+                {"params": matrix_attn_params, "weight_decay": h.muon_wd},
+                {"params": matrix_mlp_params, "weight_decay": h.muon_wd_mlp},
+            ],
+            lr=h.matrix_lr,
+            momentum=h.muon_momentum,
+            backend_steps=h.muon_backend_steps,
+            weight_decay=h.muon_wd,
+            row_normalize=h.muon_row_normalize,
+        )
+        for group in self.optimizer_muon.param_groups:
+            group["base_lr"] = h.matrix_lr
+        self.optimizer_scalar = torch.optim.AdamW(
+            [{"params": scalar_params, "lr": h.scalar_lr, "base_lr": h.scalar_lr}],
+            betas=(h.beta1, h.beta2),
+            eps=h.adam_eps,
+            weight_decay=h.adam_wd,
+            fused=True,
+        )
+        self.optimizers = [
+            self.optimizer_tok,
+            self.optimizer_muon,
+            self.optimizer_scalar,
+        ]
+        if h.art_halt_enabled:
+            router_params = (
+                list(base_model.art_router_first.parameters())
+                + list(base_model.art_router_early.parameters())
+                + list(base_model.art_router.parameters())
+            )
+            self.optimizer_art_router = torch.optim.AdamW(
+                [
+                    {
+                        "params": router_params,
+                        "lr": h.art_router_lr,
+                        "base_lr": h.art_router_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                weight_decay=h.art_router_wd,
+                fused=True,
+            )
+            self.optimizers.append(self.optimizer_art_router)
+        else:
+            self.optimizer_art_router = None
+        if base_model.lm_head is not None:
+            self.optimizer_head = torch.optim.Adam(
+                [
+                    {
+                        "params": [base_model.lm_head.weight],
+                        "lr": h.head_lr,
+                        "base_lr": h.head_lr,
+                    }
+                ],
+                betas=(h.beta1, h.beta2),
+                eps=h.adam_eps,
+                fused=True,
+            )
+            self.optimizers.insert(1, self.optimizer_head)
+        else:
+            self.optimizer_head = None
+
+    def __iter__(self):
+        return iter(self.optimizers)
+
+    def zero_grad_all(self):
+        for opt in self.optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    def step(self):
+        for opt in self.optimizers:
+            opt.step()
+        self.zero_grad_all()
+
+
+def restore_fp32_params(model):
+    for module in model.modules():
+        if isinstance(module, (CastedLinear, ARTHaltRouter)):
+            module.float()
+    for name, param in model.named_parameters():
+        if (
+            param.ndim < 2
+            or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+        ) and param.dtype != torch.float32:
+            param.data = param.data.float()
+
+
+def collect_hessians(model, train_loader, h, device, n_calibration_batches=64):
+    hessians = {}
+    hessian_divisors = {}
+    expected_hessian_names = []
+    hooks = []
+    capture_names = None
+    capture_divisor = max(int(n_calibration_batches), 1)
+    previous_routed_blocks = getattr(model, "use_routed_compiled_blocks", None)
+    previous_looping_active = getattr(model, "looping_active", None)
+    previous_art_runtime_active = getattr(model, "art_halt_runtime_active", None)
+    previous_training = model.training
+
+    def make_hook(name):
+        def hook_fn(module, inp, out):
+            if capture_names is not None and name not in capture_names:
+                return
+            x = inp[0].detach().float()
+            if x.ndim == 3:
+                x = x.reshape(-1, x.shape[-1])
+            if name not in hessians:
+                hessians[name] = torch.zeros(
+                    x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                )
+                hessian_divisors[name] = capture_divisor
+            hessians[name].addmm_(x.T, x)
+
+        return hook_fn
+
+    for name, module in model.named_modules():
+        if isinstance(module, CastedLinear) and module.weight.numel() > 65536:
+            cat = classify_param(name + ".weight")
+            if cat in ("mlp", "attn"):
+                hessian_name = name + ".weight"
+                expected_hessian_names.append(hessian_name)
+                hooks.append(module.register_forward_hook(make_hook(hessian_name)))
+    if model.tie_embeddings:
+        hook_module = (
+            model.head_proj if model.head_proj is not None else model.final_norm
+        )
+
+        def make_output_hook(name):
+            def hook_fn(module, inp, out):
+                if capture_names is not None and name not in capture_names:
+                    return
+                x = out.detach().float()
+                if x.ndim == 3:
+                    x = x.reshape(-1, x.shape[-1])
+                if name not in hessians:
+                    hessians[name] = torch.zeros(
+                        x.shape[1], x.shape[1], dtype=torch.float32, device=device
+                    )
+                    hessian_divisors[name] = capture_divisor
+                hessians[name].addmm_(x.T, x)
+
+            return hook_fn
+
+        expected_hessian_names.append("tok_emb.weight")
+        hooks.append(
+            hook_module.register_forward_hook(make_output_hook("tok_emb.weight"))
+        )
+
+    def run_calibration_pass(num_batches, routed_art):
+        nonlocal capture_divisor
+        capture_divisor = max(int(num_batches), 1)
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = False
+        if previous_looping_active is not None:
+            model.looping_active = True
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = bool(routed_art)
+        with torch.no_grad():
+            for _ in range(num_batches):
+                x, _ = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+                model.forward_logits(x)
+
+    routed_calibration = bool(
+        h.art_halt_enabled and getattr(h, "art_gptq_calibrate_routed", True)
+    )
+    model.eval()
+    try:
+        if routed_calibration:
+            log("GPTQ:calibration path routed_art")
+            run_calibration_pass(n_calibration_batches, routed_art=True)
+            missing = sorted(set(expected_hessian_names) - set(hessians))
+            if missing:
+                fallback_batches = max(4, min(n_calibration_batches, 16))
+                log(
+                    "GPTQ:routed calibration missed "
+                    f"{len(missing)} tensors; fallback fixed_full batches={fallback_batches}"
+                )
+                capture_names = set(missing)
+                run_calibration_pass(fallback_batches, routed_art=False)
+                capture_names = None
+        else:
+            log("GPTQ:calibration path fixed_full")
+            run_calibration_pass(n_calibration_batches, routed_art=False)
+    finally:
+        capture_names = None
+        if previous_routed_blocks is not None:
+            model.use_routed_compiled_blocks = previous_routed_blocks
+        if previous_looping_active is not None:
+            model.looping_active = previous_looping_active
+        if previous_art_runtime_active is not None:
+            model.art_halt_runtime_active = previous_art_runtime_active
+        model.train(previous_training)
+        for hook in hooks:
+            hook.remove()
+    for name in hessians:
+        hessians[name] = hessians[name].cpu() / max(float(hessian_divisors[name]), 1.0)
+    return hessians
+
+
+def gptq_quantize_weight(w, H, clip_sigmas=3.0, clip_range=63, block_size=32):
+    W_orig = w.float().clone()
+    rows, cols = W_orig.shape
+    H = H.float().clone()
+    dead = torch.diag(H) == 0
+    H[dead, dead] = 1
+    H.diagonal().mul_(1.01)
+    perm = torch.argsort(H.diag(), descending=True)
+    invperm = torch.argsort(perm)
+    W_perm = W_orig[:, perm].clone()
+    W_perm[:, dead[perm]] = 0
+    H = H[perm][:, perm]
+    Hinv = torch.cholesky_inverse(torch.linalg.cholesky(H))
+    Hinv = torch.linalg.cholesky(Hinv, upper=True)
+    row_std = W_orig.std(dim=1)
+    s = (clip_sigmas * row_std / clip_range).clamp_min(1e-10).to(torch.float16)
+    sf = s.float()
+    Q = torch.zeros(rows, cols, dtype=torch.int8)
+    W_work = W_perm.clone()
+    for i1 in range(0, cols, block_size):
+        i2 = min(i1 + block_size, cols)
+        W_block = W_work[:, i1:i2].clone()
+        Hinv_block = Hinv[i1:i2, i1:i2]
+        Err = torch.zeros(rows, i2 - i1)
+        for j in range(i2 - i1):
+            w_col = W_block[:, j]
+            d = Hinv_block[j, j]
+            q_col = torch.clamp(torch.round(w_col / sf), -clip_range, clip_range)
+            Q[:, i1 + j] = q_col.to(torch.int8)
+            err = (w_col - q_col.float() * sf) / d
+            Err[:, j] = err
+            W_block[:, j:] -= err.unsqueeze(1) * Hinv_block[j, j:].unsqueeze(0)
+        if i2 < cols:
+            W_work[:, i2:] -= Err @ Hinv[i1:i2, i2:]
+    return Q[:, invperm], s
+
+
+def _parse_lowbit_map(spec):
+    m = {}
+    for item in (spec or "").split(","):
+        item = item.strip()
+        if item:
+            pat, b = item.rsplit(":", 1)
+            m[pat.strip()] = int(b)
+    return m
+
+
+def _is_art_router_tensor(name):
+    return name.startswith("art_router")
+
+
+def gptq_mixed_quantize(state_dict, hessians, h):
+    lowbit_map = _parse_lowbit_map(getattr(h, "lowbit_layers", ""))
+    result = {}
+    meta = {}
+    for name, tensor in state_dict.items():
+        t = tensor.detach().cpu().contiguous()
+        if not t.is_floating_point() or t.numel() <= 65536:
+            if (
+                t.is_floating_point()
+                and getattr(h, "art_quant_router_fp32", True)
+                and _is_art_router_tensor(name)
+            ):
+                result[name] = t.to(torch.float32)
+                meta[name] = "passthrough (float32)"
+            else:
+                result[name] = t.to(torch.float16) if t.is_floating_point() else t
+                meta[name] = "passthrough (float16)"
+            continue
+        cs = h.embed_clip_sigmas if "tok_emb" in name else h.matrix_clip_sigmas
+        if "tok_emb" in name:
+            bits = h.embed_bits
+        else:
+            bits = h.matrix_bits
+            for pat, b in lowbit_map.items():
+                if pat in name:
+                    bits = b
+                    break
+        if name not in hessians:
+            raise KeyError(
+                f"Missing GPTQ Hessian for {name}. "
+                "Routed calibration should collect this or fill it via fixed-full fallback."
+            )
+        q, s = gptq_quantize_weight(
+            t, hessians[name], clip_sigmas=cs, clip_range=2 ** (bits - 1) - 1
+        )
+        result[name + ".q"] = q
+        result[name + ".scale"] = s
+        meta[name] = f"gptq (int{bits})"
+    categories = collections.defaultdict(set)
+    for name, cat in meta.items():
+        short = re.sub(r"\.\d+$", "", re.sub(r"blocks\.\d+", "blocks", name))
+        categories[cat].add(short)
+    log("Quantized weights:")
+    for cat in sorted(categories):
+        log(f"  {cat}: {', '.join(sorted(categories[cat]))}")
+    return result, meta
+
+
+def dequantize_mixed(result, meta, template_sd):
+    out = {}
+    for name, orig in template_sd.items():
+        info = meta.get(name)
+        if info is None:
+            continue
+        orig_dtype = orig.dtype
+        if "passthrough" in info:
+            t = result[name]
+            if t.dtype == torch.float16 and orig_dtype in (
+                torch.float32,
+                torch.bfloat16,
+            ):
+                t = t.to(orig_dtype)
+            out[name] = t
+            continue
+        q, s = result[name + ".q"], result[name + ".scale"]
+        if s.ndim > 0:
+            out[name] = (
+                q.float() * s.float().view(q.shape[0], *[1] * (q.ndim - 1))
+            ).to(orig_dtype)
+        else:
+            out[name] = (q.float() * float(s.item())).to(orig_dtype)
+    return out
+
+
+_BSHF_MAGIC = b"BSHF"
+
+
+def _byte_shuffle(data, stride=2):
+    if stride <= 1 or len(data) < stride:
+        return data
+    src = np.frombuffer(data, dtype=np.uint8)
+    n = len(src)
+    out = np.empty(n, dtype=np.uint8)
+    dest_off = 0
+    for pos in range(stride):
+        chunk = src[pos::stride]
+        out[dest_off : dest_off + len(chunk)] = chunk
+        dest_off += len(chunk)
+    return _BSHF_MAGIC + bytes([stride]) + out.tobytes()
+
+
+def _byte_unshuffle(data):
+    if len(data) < 5 or data[:4] != _BSHF_MAGIC:
+        return data
+    stride = data[4]
+    if stride < 2:
+        return data[5:]
+    payload = np.frombuffer(data, dtype=np.uint8, offset=5)
+    n = len(payload)
+    out = np.empty(n, dtype=np.uint8)
+    src_off = 0
+    for pos in range(stride):
+        chunk_len = n // stride + (1 if pos < n % stride else 0)
+        out[pos::stride][:chunk_len] = payload[src_off : src_off + chunk_len]
+        src_off += chunk_len
+    return out.tobytes()
+
+
+def _compress(data, compressor):
+    data = _byte_shuffle(data)
+    if compressor == "brotli":
+        import brotli
+
+        return brotli.compress(data, quality=11)
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def _decompress(data, compressor):
+    if compressor == "brotli":
+        import brotli
+
+        return _byte_unshuffle(brotli.decompress(data))
+    raise ValueError(f"Unknown compressor: {compressor!r}")
+
+
+def serialize(h, base_model):
+    if h.is_main_process:
+        torch.save(base_model.state_dict(), h.model_path)
+        model_bytes = os.path.getsize(h.model_path)
+        log(f"Serialized model: {model_bytes} bytes")
+    sd_cpu = {k: v.detach().cpu() for k, v in base_model.state_dict().items()}
+    device = torch.device("cuda", h.local_rank)
+    log("GPTQ:collecting Hessians from calibration data...")
+    t0 = time.perf_counter()
+    calib_loader = ShuffledSequenceLoader(h, device)
+    hessians = collect_hessians(
+        base_model,
+        calib_loader,
+        h,
+        device,
+        n_calibration_batches=h.gptq_calibration_batches,
+    )
+    log(f"GPTQ:collected {len(hessians)} Hessians in {time.perf_counter() - t0:.1f}s")
+    quant_result, quant_meta = gptq_mixed_quantize(sd_cpu, hessians, h)
+    quant_buf = io.BytesIO()
+    torch.save({"w": quant_result, "m": quant_meta}, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = _compress(quant_raw, h.compressor)
+    quant_file_bytes = len(quant_blob)
+    if h.is_main_process:
+        with open(h.quantized_model_path, "wb") as f:
+            f.write(quant_blob)
+        log(f"Serialized model quantized+{h.compressor}: {quant_file_bytes} bytes")
+    return quant_file_bytes
+
+
+def _move_state_to_device(state, device):
+    return {
+        name: tensor.to(device=device, non_blocking=True)
+        if isinstance(tensor, torch.Tensor)
+        else tensor
+        for name, tensor in state.items()
+    }
+
+
+def load_state_exact(model, state, device):
+    state = _move_state_to_device(state, device)
+    try:
+        model.load_state_dict(state, strict=True, assign=True)
+    except TypeError:
+        model.load_state_dict(state, strict=True)
+    restore_fp32_params(model)
+
+
+def deserialize(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    sd_cpu = {k: v.detach().cpu() for k, v in eval_model.state_dict().items()}
+    with open(h.quantized_model_path, "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(
+        io.BytesIO(_decompress(quant_blob_disk, h.compressor)), map_location="cpu"
+    )
+    deq_state = dequantize_mixed(quant_state["w"], quant_state["m"], sd_cpu)
+    load_state_exact(eval_model, deq_state, device)
+    return eval_model
+
+
+def deserialize_raw_checkpoint(h, device):
+    eval_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(eval_model)
+    raw_state = torch.load(h.model_path, map_location="cpu")
+    load_state_exact(eval_model, raw_state, device)
+    return eval_model
+
+
+def _loss_bpb(loss_sum, token_count, byte_count):
+    val_loss = (loss_sum / token_count).item()
+    val_bpb = val_loss / math.log(2.0) * (token_count.item() / byte_count.item())
+    return val_loss, val_bpb
+
+
+def compile_target(target, allow_graph_breaks: bool):
+    if _SMOKE_TEST:
+        return target
+    if allow_graph_breaks:
+        # ART routing uses dynamic subset execution. Letting Dynamo graph-break there
+        # recompiles helper frames for per-layer constants until it hits the limit.
+        return target
+    return torch.compile(target, dynamic=False, fullgraph=not allow_graph_breaks)
+
+
+def configure_art_eval_runtime(model, h):
+    if h.num_loops > 0:
+        model.looping_active = True
+    if h.art_halt_enabled:
+        model.art_halt_runtime_active = True
+        model.art_router_entropy_bonus = h.art_router_entropy_end
+        model.art_eval_sample_routes = h.art_eval_sample_routes
+        model.art_eval_route_mode = "sample" if h.art_eval_sample_routes else "argmax"
+        model.art_eval_route_threshold = h.art_eval_route_threshold
+        model.art_eval_force_depth = -1
+        # Keep post-serialization eval eager for triple ART. Per-block compiled
+        # routing recompiles across block-local constants and can hit Dynamo's limit.
+        model.use_routed_compiled_blocks = False
+
+
+def compare_model_states(label, reference_model, candidate_model):
+    reference_sd = reference_model.state_dict()
+    candidate_sd = candidate_model.state_dict()
+    missing = sorted(set(reference_sd) ^ set(candidate_sd))
+    dtype_mismatches = 0
+    max_abs = 0.0
+    for name, ref in reference_sd.items():
+        if name not in candidate_sd:
+            continue
+        cand = candidate_sd[name]
+        if ref.dtype != cand.dtype:
+            dtype_mismatches += 1
+        if ref.is_floating_point() or cand.is_floating_point():
+            diff = (
+                ref.detach().float()
+                - cand.detach().to(device=ref.device, dtype=torch.float32)
+            ).abs()
+            max_abs = max(max_abs, float(diff.max().item()) if diff.numel() else 0.0)
+        else:
+            mismatch = ref.detach() != cand.detach().to(device=ref.device)
+            max_abs = max(max_abs, float(mismatch.any().item()))
+    log(
+        f"{label}_state_compare:tensors:{len(reference_sd)} "
+        f"missing:{len(missing)} dtype_mismatches:{dtype_mismatches} "
+        f"max_abs:{max_abs:.9g}"
+    )
+
+
+def format_art_probe_summary(
+    step: int,
+    total_steps: int,
+    window_steps: int,
+    depth_sum: float,
+    depth_count: float,
+    continue_sum: float,
+    entropy_sum: float,
+) -> str:
+    if depth_count <= 0:
+        return (
+            f"step:{step}/{total_steps} art_probe "
+            f"window_steps:{window_steps} avg_cycles:none extra_cycle_frac:none "
+            f"avg_stop:none router_entropy:none"
+        )
+    avg_depth = depth_sum / depth_count
+    avg_continue = continue_sum / depth_count
+    avg_stop = 1.0 - avg_continue
+    avg_entropy = entropy_sum / depth_count
+    return (
+        f"step:{step}/{total_steps} art_probe "
+        f"window_steps:{window_steps} avg_cycles:{avg_depth:.3f} "
+        f"extra_cycle_frac:{avg_continue:.3f} avg_stop:{avg_stop:.3f} "
+        f"router_entropy:{avg_entropy:.4f}"
+    )
+
+
+def unwrap_model_for_stats(model):
+    unwrapped = model
+    if hasattr(unwrapped, "module"):
+        unwrapped = unwrapped.module
+    return getattr(unwrapped, "_orig_mod", unwrapped)
+
+
+def format_eval_art_route_stats(label, stats):
+    gates = stats.get("gates") or {}
+    gate_text = ",".join(f"{name}={value:.3f}" for name, value in gates.items())
+    if not gate_text:
+        gate_text = "none"
+    return (
+        f"{label}_art_routes avg_cycles:{stats['avg_cycles']:.3f} "
+        f"extra_cycle_frac:{stats['extra_cycle_frac']:.3f} "
+        f"art_entropy:{stats['entropy']:.4f} art_continue:{gate_text}"
+    )
+
+
+def eval_val(h, device, val_data, model):
+    seq_len = h.eval_seq_len
+    local_batch_tokens = h.val_batch_tokens // (h.world_size * h.grad_accum_steps)
+    if local_batch_tokens < seq_len:
+        raise ValueError(
+            f"VAL_BATCH_TOKENS must provide at least one sequence per rank; got "
+            f"VAL_BATCH_TOKENS={h.val_batch_tokens}, WORLD_SIZE={h.world_size}, "
+            f"GRAD_ACCUM_STEPS={h.grad_accum_steps}, seq_len={seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // seq_len
+    total_seqs = (val_data.val_tokens.numel() - 1) // seq_len
+    seq_start = total_seqs * h.rank // h.world_size
+    seq_end = total_seqs * (h.rank + 1) // h.world_size
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+    route_count = torch.zeros((), device=device, dtype=torch.float64)
+    route_gate_sum = None
+    route_gate_names = None
+    stats_model = unwrap_model_for_stats(model)
+    model.eval()
+    with torch.inference_mode():
+        for batch_seq_start in range(seq_start, seq_end, local_batch_seqs):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * seq_len
+            raw_end = batch_seq_end * seq_len + 1
+            local = val_data.val_tokens[raw_start:raw_end].to(
+                device=device, dtype=torch.int64, non_blocking=True
+            )
+            x = local[:-1].reshape(-1, seq_len)
+            y = local[1:].reshape(-1, seq_len)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            if getattr(h, "art_eval_route_stats", True):
+                art_avg_cycles = getattr(stats_model, "_last_art_avg_cycles_stat", None)
+                art_continue = getattr(
+                    stats_model, "_last_art_continue_rate_stat", None
+                )
+                art_entropy = getattr(
+                    stats_model, "_last_art_router_entropy_stat", None
+                )
+                if (
+                    art_avg_cycles is not None
+                    and art_continue is not None
+                    and art_entropy is not None
+                ):
+                    batch_seq_count = float(x.size(0))
+                    route_depth_sum += (
+                        art_avg_cycles.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_continue_sum += (
+                        art_continue.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_entropy_sum += (
+                        art_entropy.detach().to(device=device, dtype=torch.float64)
+                        * batch_seq_count
+                    )
+                    route_count += batch_seq_count
+                    gate_stats = getattr(
+                        stats_model, "_last_art_gate_continue_stats", None
+                    )
+                    if gate_stats is not None:
+                        gate_stats = gate_stats.detach().to(
+                            device=device, dtype=torch.float64
+                        )
+                        if route_gate_sum is None:
+                            route_gate_sum = torch.zeros_like(gate_stats)
+                            route_gate_names = getattr(
+                                stats_model, "art_gate_names", None
+                            )
+                        route_gate_sum += gate_stats * batch_seq_count
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = val_data.base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (
+                val_data.has_leading_space_lut[tgt_ids]
+                & ~val_data.is_boundary_token_lut[prev_ids]
+            ).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_depth_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_continue_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_entropy_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(route_count, op=dist.ReduceOp.SUM)
+        if route_gate_sum is not None:
+            dist.all_reduce(route_gate_sum, op=dist.ReduceOp.SUM)
+    h._last_eval_art_route_stats = None
+    if route_count.item() > 0:
+        gates = {}
+        if route_gate_sum is not None:
+            gate_values = (route_gate_sum / route_count.clamp_min(1.0)).detach().cpu()
+            names = route_gate_names or tuple(
+                f"gate{i + 1}" for i in range(int(gate_values.numel()))
+            )
+            gates = {
+                name: float(value)
+                for name, value in zip(names, gate_values.tolist(), strict=False)
+            }
+        h._last_eval_art_route_stats = {
+            "avg_cycles": float((route_depth_sum / route_count).item()),
+            "extra_cycle_frac": float((route_continue_sum / route_count).item()),
+            "entropy": float((route_entropy_sum / route_count).item()),
+            "gates": gates,
+        }
+    model.train()
+    return _loss_bpb(val_loss_sum, val_token_count, val_byte_count)
+
+
+def eval_val_sliding(h, device, val_data, base_model, batch_seqs=32):
+    base_model.eval()
+    logits_fn = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    seq_len = h.eval_seq_len
+    context_size = seq_len - h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    window_starts = [
+        ws
+        for ws in range(0, total_tokens, h.eval_stride)
+        if ws + context_size < total_tokens
+    ]
+    total_windows = len(window_starts)
+    my_s = total_windows * h.rank // h.world_size
+    my_e = total_windows * (h.rank + 1) // h.world_size
+    my_windows = window_starts[my_s:my_e]
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    with torch.inference_mode():
+        for bi in range(0, len(my_windows), batch_seqs):
+            batch_ws = my_windows[bi : bi + batch_seqs]
+            bsz = len(batch_ws)
+            x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+            wlens = []
+            for i, ws in enumerate(batch_ws):
+                we = min(ws + seq_len, total_tokens)
+                wlen = we - ws
+                wlens.append(wlen)
+                chunk = val_data.val_tokens[ws : we + 1].to(
+                    dtype=torch.int64, device=device
+                )
+                x_batch[i, :wlen] = chunk[:-1]
+                y_batch[i, :wlen] = chunk[1:]
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                logits = logits_fn(x_batch)
+            nll = F.cross_entropy(
+                logits.reshape(-1, logits.size(-1)).float(),
+                y_batch.reshape(-1),
+                reduction="none",
+            ).reshape(bsz, seq_len)
+            for i, ws in enumerate(batch_ws):
+                wlen = wlens[i]
+                s = 0 if ws == 0 else context_size
+                scored_nll = nll[i, s:wlen].to(torch.float64)
+                loss_sum += scored_nll.sum()
+                token_count += float(wlen - s)
+                tgt = y_batch[i, s:wlen]
+                prev = x_batch[i, s:wlen]
+                tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                tb += (
+                    val_data.has_leading_space_lut[tgt]
+                    & ~val_data.is_boundary_token_lut[prev]
+                ).to(torch.float64)
+                byte_count += tb.sum()
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    base_model.train()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def eval_val_ttt(h, device, val_data, base_model, batch_seqs=32):
+    rank = h.rank
+    world_size = h.world_size
+    seq_len = h.eval_seq_len
+    stride = h.eval_stride
+    total_tokens = val_data.val_tokens.numel() - 1
+    ttt_chunk = h.ttt_chunk_tokens
+    context_size = seq_len - stride
+    window_starts = [
+        ws for ws in range(0, total_tokens, stride) if ws + context_size < total_tokens
+    ]
+    num_chunks = (total_tokens + ttt_chunk - 1) // ttt_chunk
+    chunk_windows = [[] for _ in range(num_chunks)]
+    for ws in window_starts:
+        wlen = min(ws + seq_len, total_tokens) - ws
+        s = 0 if ws == 0 else context_size
+        scored_start = ws + s
+        ci = min(scored_start // ttt_chunk, num_chunks - 1)
+        chunk_windows[ci].append(ws)
+    total_windows = len(window_starts)
+    log(
+        f"ttt:start chunks={num_chunks} windows={total_windows} "
+        f"ttt_lr={h.ttt_lr} ttt_epochs={h.ttt_epochs}"
+    )
+    compiled_logits = compile_target(
+        base_model.forward_logits, allow_graph_breaks=h.art_halt_enabled
+    )
+    loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    token_count = torch.zeros((), device=device, dtype=torch.float64)
+    byte_count = torch.zeros((), device=device, dtype=torch.float64)
+    _all_ttt_candidates = [p for p in base_model.parameters()]
+    ttt_params = [p for p in _all_ttt_candidates if p.numel() >= 10000]
+    for p in _all_ttt_candidates:
+        p.requires_grad_(p.numel() >= 10000)
+    optimizer = torch.optim.SGD(
+        ttt_params, lr=h.ttt_lr, momentum=h.ttt_momentum, nesterov=True
+    )
+    ttt_start_time = time.perf_counter()
+    for ci in range(num_chunks):
+        windows = chunk_windows[ci]
+        if not windows:
+            continue
+        chunk_should_log = h.ttt_log_every_chunks > 0 and (
+            ci == 0 or (ci + 1) % h.ttt_log_every_chunks == 0 or ci == num_chunks - 1
+        )
+        chunk_t0 = time.perf_counter()
+        chunk_start = ci * ttt_chunk
+        chunk_end = min((ci + 1) * ttt_chunk, total_tokens)
+        my_s = len(windows) * rank // world_size
+        my_e = len(windows) * (rank + 1) // world_size
+        my_windows = windows[my_s:my_e]
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_start "
+                f"windows={len(windows)} local_windows={len(my_windows)}"
+            )
+        base_model.eval()
+        with torch.no_grad():
+            for bi in range(0, len(my_windows), batch_seqs):
+                batch_ws = my_windows[bi : bi + batch_seqs]
+                bsz = len(batch_ws)
+                x_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                y_batch = torch.zeros(bsz, seq_len, dtype=torch.int64, device=device)
+                wlens = []
+                for i, ws in enumerate(batch_ws):
+                    we = min(ws + seq_len, total_tokens)
+                    wlen = we - ws
+                    wlens.append(wlen)
+                    chunk_tok = val_data.val_tokens[ws : we + 1].to(
+                        dtype=torch.int64, device=device
+                    )
+                    x_batch[i, :wlen] = chunk_tok[:-1]
+                    y_batch[i, :wlen] = chunk_tok[1:]
+                with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                    logits = compiled_logits(x_batch)
+                nll = F.cross_entropy(
+                    logits.reshape(-1, logits.size(-1)).float(),
+                    y_batch.reshape(-1),
+                    reduction="none",
+                ).reshape(bsz, seq_len)
+                for i, ws in enumerate(batch_ws):
+                    wlen = wlens[i]
+                    s = 0 if ws == 0 else context_size
+                    scored_nll = nll[i, s:wlen].to(torch.float64)
+                    loss_sum += scored_nll.sum()
+                    token_count += float(wlen - s)
+                    tgt = y_batch[i, s:wlen]
+                    prev = x_batch[i, s:wlen]
+                    tb = val_data.base_bytes_lut[tgt].to(torch.float64)
+                    tb += (
+                        val_data.has_leading_space_lut[tgt]
+                        & ~val_data.is_boundary_token_lut[prev]
+                    ).to(torch.float64)
+                    byte_count += tb.sum()
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} score_done "
+                f"elapsed:{time.perf_counter() - chunk_t0:.1f}s"
+            )
+        is_last_chunk = ci == num_chunks - 1
+        if not is_last_chunk and h.ttt_epochs > 0:
+            base_model.train()
+            chunk_seqs = (chunk_end - chunk_start) // seq_len
+            if chunk_seqs > 0:
+                cos_lr = (
+                    h.ttt_lr
+                    * 0.5
+                    * (1.0 + math.cos(math.pi * ci / max(num_chunks - 1, 1)))
+                )
+                for pg in optimizer.param_groups:
+                    pg["lr"] = cos_lr
+                my_seq_s = chunk_seqs * rank // world_size
+                my_seq_e = chunk_seqs * (rank + 1) // world_size
+                my_chunk_seqs = my_seq_e - my_seq_s
+                if chunk_should_log:
+                    log(
+                        f"ttt:chunk {ci + 1}/{num_chunks} adapt_start "
+                        f"seqs={chunk_seqs} local_seqs={my_chunk_seqs} lr={cos_lr:.6g}"
+                    )
+                for _ep in range(h.ttt_epochs):
+                    epoch_t0 = time.perf_counter()
+                    for bs in range(0, my_chunk_seqs, batch_seqs):
+                        be = min(bs + batch_seqs, my_chunk_seqs)
+                        actual_bs = my_seq_s + bs
+                        start_tok = chunk_start + actual_bs * seq_len
+                        end_tok = chunk_start + (my_seq_s + be) * seq_len + 1
+                        if end_tok > val_data.val_tokens.numel():
+                            continue
+                        local = val_data.val_tokens[start_tok:end_tok].to(
+                            device=device, dtype=torch.int64
+                        )
+                        x = local[:-1].reshape(-1, seq_len)
+                        y = local[1:].reshape(-1, seq_len)
+                        optimizer.zero_grad(set_to_none=True)
+                        with torch.autocast(device_type="cuda", dtype=torch.bfloat16):
+                            _lf = base_model.forward_logits(x).reshape(-1, 8192).float()
+                            loss = (
+                                F.cross_entropy(_lf, y.reshape(-1))
+                                + 1e-5 * torch.logsumexp(_lf, dim=-1).pow(2).mean()
+                            )
+                        loss.backward()
+                        if world_size > 1:
+                            for p in ttt_params:
+                                if p.grad is not None:
+                                    dist.all_reduce(p.grad, op=dist.ReduceOp.AVG)
+                        torch.nn.utils.clip_grad_norm_(ttt_params, 1.0)
+                        optimizer.step()
+                    if chunk_should_log:
+                        log(
+                            f"ttt:chunk {ci + 1}/{num_chunks} "
+                            f"epoch:{_ep + 1}/{h.ttt_epochs} "
+                            f"elapsed:{time.perf_counter() - epoch_t0:.1f}s"
+                        )
+        if chunk_should_log:
+            log(
+                f"ttt:chunk {ci + 1}/{num_chunks} done "
+                f"total_elapsed:{time.perf_counter() - ttt_start_time:.1f}s"
+            )
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(byte_count, op=dist.ReduceOp.SUM)
+    for p in base_model.parameters():
+        p.requires_grad_(True)
+    base_model.eval()
+    return _loss_bpb(loss_sum, token_count, byte_count)
+
+
+def timed_eval(label, fn, *args, **kwargs):
+    h = args[0] if args else kwargs.get("h")
+    if h is not None:
+        h._last_eval_art_route_stats = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    val_loss, val_bpb = fn(*args, **kwargs)
+    torch.cuda.synchronize()
+    elapsed_ms = 1e3 * (time.perf_counter() - t0)
+    log(
+        f"{label} val_loss:{val_loss:.8f} val_bpb:{val_bpb:.8f} eval_time:{elapsed_ms:.0f}ms"
+    )
+    stats = getattr(h, "_last_eval_art_route_stats", None) if h is not None else None
+    if stats is not None:
+        log(format_eval_art_route_stats(label, stats))
+    return val_loss, val_bpb
+
+
+def parse_art_eval_mode(mode_spec: str):
+    token = mode_spec.strip().lower()
+    if token in ("sample", "sampled", "stochastic"):
+        return "sample", None, "sample"
+    if token in ("argmax", "greedy", "deterministic"):
+        return "argmax", None, "argmax"
+    if token.startswith("force"):
+        depth_text = token[len("force") :].lstrip("_:= ")
+        if not depth_text:
+            raise ValueError(f"Missing force depth in ART diag mode {mode_spec!r}")
+        depth = int(depth_text)
+        if depth < 0 or depth > 3:
+            raise ValueError(f"ART force depth must be in [0, 3], got {depth}")
+        return "force", depth, f"force{depth}"
+    for prefix in ("threshold", "thresh", "thr"):
+        if token.startswith(prefix):
+            value_text = token[len(prefix) :].lstrip("_:= ")
+            if not value_text:
+                raise ValueError(
+                    f"Missing threshold value in ART diag mode {mode_spec!r}"
+                )
+            threshold = float(value_text)
+            return "threshold", threshold, f"threshold{threshold:g}".replace(".", "p")
+    raise ValueError(f"Unknown ART diag mode {mode_spec!r}")
+
+
+def set_art_eval_mode(model, mode_spec: str):
+    base_model = unwrap_model_for_stats(model)
+    old_state = (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    )
+    mode, value, label = parse_art_eval_mode(mode_spec)
+    base_model.art_eval_route_mode = mode
+    if mode == "threshold":
+        base_model.art_eval_route_threshold = float(value)
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = False
+    elif mode == "force":
+        base_model.art_eval_force_depth = int(value)
+        base_model.art_eval_sample_routes = False
+    else:
+        base_model.art_eval_force_depth = -1
+        base_model.art_eval_sample_routes = mode == "sample"
+    return label, old_state
+
+
+def restore_art_eval_mode(model, old_state):
+    base_model = unwrap_model_for_stats(model)
+    (
+        base_model.art_eval_route_mode,
+        base_model.art_eval_route_threshold,
+        base_model.art_eval_force_depth,
+        base_model.art_eval_sample_routes,
+    ) = old_state
+
+
+def seed_art_diag_eval(h, label):
+    seed = int(h.seed) + 100_000 + sum(ord(ch) for ch in label)
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+
+def run_art_quant_diagnostics(stage, h, device, val_data, model):
+    if not (h.art_halt_enabled and h.art_quant_diag_enabled):
+        return
+    modes = [m.strip() for m in h.art_quant_diag_modes.split(",") if m.strip()]
+    if not modes:
+        return
+    log(f"{stage}_quant_diag:start modes={','.join(modes)}")
+    results = getattr(h, "_art_quant_diag_results", {})
+    for mode_spec in modes:
+        label, old_state = set_art_eval_mode(model, mode_spec)
+        try:
+            seed_art_diag_eval(h, label)
+            _, val_bpb = timed_eval(
+                f"{stage}_diag_{label}", eval_val, h, device, val_data, model
+            )
+        finally:
+            restore_art_eval_mode(model, old_state)
+        if stage == "prequant":
+            results[label] = val_bpb
+        elif label in results:
+            pre_bpb = results[label]
+            log(
+                f"quant_diag_delta mode:{label} "
+                f"pre_bpb:{pre_bpb:.8f} post_bpb:{val_bpb:.8f} "
+                f"delta_bpb:{val_bpb - pre_bpb:.8f}"
+            )
+    h._art_quant_diag_results = results
+    log(f"{stage}_quant_diag:done")
+
+
+def train_model(h, device, val_data):
+    base_model = GPT(h).to(device).bfloat16()
+    restore_fp32_params(base_model)
+    compiled_model = compile_target(base_model, allow_graph_breaks=False)
+    if _SMOKE_TEST:
+        log("smoke_test: torch.compile disabled (eager mode)")
+    if h.distributed:
+        model = DDP(compiled_model, device_ids=[h.local_rank], broadcast_buffers=False)
+    else:
+        model = compiled_model
+    log(f"model_params:{sum(p.numel() for p in base_model.parameters())}")
+    log(
+        "router_params:"
+        f"{sum(p.numel() for p in base_model.art_router_first.parameters()) + sum(p.numel() for p in base_model.art_router_early.parameters()) + sum(p.numel() for p in base_model.art_router.parameters())}"
+    )
+    if h.art_halt_enabled:
+        log(
+            "triple_art_halt:training starts on trunk-only 0,1,2,6,7,8,9,10; "
+            "fixed triple recurrence activates at ENABLE_LOOPING_AT; "
+            "routed path uses packed-active token-level ART after ART_HALT_ENABLE_AT; "
+            f"route_group_size:{h.art_route_group_size} "
+            f"cycle_penalty:{h.art_cycle_penalty:g} "
+            f"shard_coherent_batches:{int(h.art_shard_coherent_batches)}"
+        )
+        log(
+            "triple_art_ropefix_quant:"
+            f"gptq_calibrate_routed:{int(h.art_gptq_calibrate_routed)} "
+            f"router_fp32:{int(h.art_quant_router_fp32)} "
+            f"eval_route_stats:{int(h.art_eval_route_stats)} "
+            f"eval_sample_routes:{int(h.art_eval_sample_routes)} "
+            "reload_diag:raw_checkpoint_state_and_eval "
+            f"ema_reset_on_looping:{int(h.ema_reset_on_looping)} "
+            f"ema_reset_on_art:{int(h.ema_reset_on_art)} "
+            f"entropy_start:{h.art_router_entropy_start:g} "
+            f"entropy_end:{h.art_router_entropy_end:g}"
+        )
+    optimizers = Optimizers(h, base_model)
+    train_loader = ShuffledSequenceLoader(h, device)
+    probe_window_size = max(h.recurrence_probe_every, 1)
+    recent_depth_sums = collections.deque(maxlen=probe_window_size)
+    recent_depth_counts = collections.deque(maxlen=probe_window_size)
+    recent_continue_sums = collections.deque(maxlen=probe_window_size)
+    recent_entropy_sums = collections.deque(maxlen=probe_window_size)
+    max_wallclock_ms = (
+        1e3 * h.max_wallclock_seconds if h.max_wallclock_seconds > 0 else None
+    )
+
+    def training_frac(step, elapsed_ms):
+        if max_wallclock_ms is None:
+            return step / max(h.iterations, 1)
+        return elapsed_ms / max(max_wallclock_ms, 1e-09)
+
+    def lr_mul(frac):
+        if h.warmdown_frac <= 0:
+            return 1.0
+        if frac >= 1.0 - h.warmdown_frac:
+            return max((1.0 - frac) / h.warmdown_frac, h.min_lr)
+        return 1.0
+
+    def muon_momentum_frac(elapsed_ms):
+        if h.muon_momentum_warmup_fraction <= 0 or max_wallclock_ms is None:
+            return 1.0
+        warmup_ms = max_wallclock_ms * h.muon_momentum_warmup_fraction
+        return min(elapsed_ms / max(warmup_ms, 1e-9), 1.0)
+
+    def art_router_entropy_value(frac):
+        clamped = min(max(frac, 0.0), 1.0)
+        return (
+            1.0 - clamped
+        ) * h.art_router_entropy_start + clamped * h.art_router_entropy_end
+
+    def step_fn(step, lr_scale, elapsed_ms):
+        optimizers.zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        step_depth_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_continue_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_entropy_sum = torch.zeros((), device=device, dtype=torch.float64)
+        step_gate_continue_sum = None
+        step_art_count = 0.0
+        for micro_step in range(h.grad_accum_steps):
+            if h.distributed:
+                model.require_backward_grad_sync = micro_step == h.grad_accum_steps - 1
+            x, y = train_loader.next_batch(h.train_batch_tokens, h.grad_accum_steps)
+            with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=True):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            if (
+                base_model.art_halt_runtime_active
+                and base_model._last_art_avg_cycles_stat is not None
+                and base_model._last_art_continue_rate_stat is not None
+                and base_model._last_art_router_entropy_stat is not None
+            ):
+                step_depth_sum = (
+                    step_depth_sum
+                    + base_model._last_art_avg_cycles_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_continue_sum = (
+                    step_continue_sum
+                    + base_model._last_art_continue_rate_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                step_entropy_sum = (
+                    step_entropy_sum
+                    + base_model._last_art_router_entropy_stat.detach().to(
+                        dtype=torch.float64
+                    )
+                )
+                gate_stats = getattr(base_model, "_last_art_gate_continue_stats", None)
+                if gate_stats is not None:
+                    gate_stats = gate_stats.detach().to(
+                        device=device, dtype=torch.float64
+                    )
+                    if step_gate_continue_sum is None:
+                        step_gate_continue_sum = torch.zeros_like(gate_stats)
+                    step_gate_continue_sum = step_gate_continue_sum + gate_stats
+                step_art_count += 1.0
+            (loss / h.grad_accum_steps).backward()
+        train_loss /= h.grad_accum_steps
+        frac_mm = muon_momentum_frac(elapsed_ms)
+        muon_momentum = (
+            1 - frac_mm
+        ) * h.muon_momentum_warmup_start + frac_mm * h.muon_momentum
+        mm_blend = max(lr_scale, 0.25)
+        muon_momentum = (
+            mm_blend * muon_momentum + (1.0 - mm_blend) * h.muon_momentum_warmup_start
+        )
+        for group in optimizers.optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * lr_scale
+        if h.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), h.grad_clip_norm)
+        optimizers.step()
+        return (
+            train_loss,
+            step_depth_sum,
+            step_continue_sum,
+            step_entropy_sum,
+            step_gate_continue_sum,
+            step_art_count,
+        )
+
+    def sum_recent_stats(values):
+        total = torch.zeros((), device=device, dtype=torch.float64)
+        for value in values:
+            if isinstance(value, torch.Tensor):
+                total = total + value.detach().to(device=device, dtype=torch.float64)
+            else:
+                total = total + torch.tensor(
+                    float(value), device=device, dtype=torch.float64
+                )
+        return total
+
+    if h.warmup_steps > 0:
+        initial_model_state = {
+            name: t.detach().cpu().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        initial_optimizer_states = [
+            copy.deepcopy(opt.state_dict()) for opt in optimizers
+        ]
+        model.train()
+        for warmup_step in range(h.warmup_steps):
+            step_fn(warmup_step, 1.0, 0.0)
+            if (
+                warmup_step <= 5
+                or (warmup_step + 1) % 10 == 0
+                or warmup_step + 1 == h.warmup_steps
+            ):
+                log(f"warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+        if h.num_loops > 0:
+            base_model.looping_active = True
+            log(
+                f"loop_warmup:enabled encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            for warmup_step in range(h.warmup_steps):
+                step_fn(warmup_step, 1.0, 0.0)
+                if (
+                    warmup_step <= 5
+                    or (warmup_step + 1) % 10 == 0
+                    or warmup_step + 1 == h.warmup_steps
+                ):
+                    log(f"loop_warmup_step: {warmup_step + 1}/{h.warmup_steps}")
+            base_model.looping_active = False
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        optimizers.zero_grad_all()
+        if h.distributed:
+            model.require_backward_grad_sync = True
+        train_loader = ShuffledSequenceLoader(h, device)
+
+    if h.art_halt_enabled:
+        log("art_halt:warming routed compiled blocks")
+        warm_batch_size = max(
+            1, h.train_batch_tokens // (h.grad_accum_steps * h.train_seq_len)
+        )
+        base_model.warm_routed_compiled_blocks(
+            warm_batch_size, h.train_seq_len, device, torch.bfloat16
+        )
+        optimizers.zero_grad_all()
+        log("art_halt:warmed routed compiled blocks")
+
+    ema_state = {
+        name: t.detach().float().clone() for name, t in base_model.state_dict().items()
+    }
+    ema_decay = h.ema_decay
+
+    def reset_ema_state(reason):
+        nonlocal ema_state
+        ema_state = {
+            name: t.detach().float().clone()
+            for name, t in base_model.state_dict().items()
+        }
+        log(f"ema:reset reason:{reason}")
+
+    training_time_ms = 0.0
+    stop_after_step = None
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    step = 0
+    while True:
+        last_step = step == h.iterations or (
+            stop_after_step is not None and step >= stop_after_step
+        )
+        should_validate = last_step or (
+            h.val_loss_every > 0 and step % h.val_loss_every == 0
+        )
+        if should_validate:
+            torch.cuda.synchronize()
+            training_time_ms += 1e3 * (time.perf_counter() - t0)
+            if _SMOKE_TEST and last_step:
+                break
+            val_loss, val_bpb = eval_val(h, device, val_data, model)
+            log(
+                f"{step}/{h.iterations} val_loss: {val_loss:.4f} val_bpb: {val_bpb:.4f}"
+            )
+            torch.cuda.synchronize()
+            t0 = time.perf_counter()
+        if last_step:
+            if stop_after_step is not None and step < h.iterations:
+                log(
+                    f"stopping_early: wallclock_cap train_time: {training_time_ms:.0f}ms "
+                    f"step: {step}/{h.iterations}"
+                )
+            break
+        elapsed_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        frac = training_frac(step, elapsed_ms)
+        scale = lr_mul(frac)
+        if (
+            h.num_loops > 0
+            and not base_model.looping_active
+            and frac >= h.enable_looping_at
+        ):
+            base_model.looping_active = True
+            log(
+                f"layer_loop:enabled step:{step} frac:{frac:.3f} "
+                f"encoder:{base_model.encoder_indices} decoder:{base_model.decoder_indices}"
+            )
+            if h.ema_reset_on_looping:
+                reset_ema_state("looping_enabled")
+        if h.art_halt_enabled:
+            base_model.art_router_entropy_bonus = art_router_entropy_value(frac)
+        if (
+            h.art_halt_enabled
+            and base_model.looping_active
+            and not base_model.art_halt_runtime_active
+            and frac >= h.art_halt_enable_at
+        ):
+            base_model.art_halt_runtime_active = True
+            if compiled_model is not base_model:
+                del model
+                torch._dynamo.reset()
+                base_model.prepare_routed_compiled_blocks()
+                base_model.use_routed_compiled_blocks = True
+                compiled_model = base_model
+                if h.distributed:
+                    model = DDP(
+                        base_model, device_ids=[h.local_rank], broadcast_buffers=False
+                    )
+                else:
+                    model = base_model
+                model.train()
+            log(
+                f"art_halt:enabled step:{step} frac:{frac:.3f} "
+                f"entropy_bonus:{base_model.art_router_entropy_bonus:.4f}"
+            )
+            log("art_halt:training switched to eager routers with compiled segments")
+            if h.ema_reset_on_art:
+                reset_ema_state("art_halt_enabled")
+        (
+            train_loss,
+            local_step_depth_sum,
+            local_step_continue_sum,
+            local_step_entropy_sum,
+            local_step_gate_continue_sum,
+            local_step_art_count,
+        ) = step_fn(step, scale, elapsed_ms)
+        with torch.no_grad():
+            for name, t in base_model.state_dict().items():
+                ema_state[name].mul_(ema_decay).add_(
+                    t.detach().float(), alpha=1.0 - ema_decay
+                )
+        step += 1
+        approx_training_time_ms = training_time_ms + 1e3 * (time.perf_counter() - t0)
+        if local_step_art_count > 0:
+            recent_depth_sums.append(local_step_depth_sum)
+            recent_depth_counts.append(local_step_art_count)
+            recent_continue_sums.append(local_step_continue_sum)
+            recent_entropy_sums.append(local_step_entropy_sum)
+        should_probe_recurrence = (
+            h.art_halt_enabled
+            and base_model.art_halt_runtime_active
+            and h.recurrence_probe_every > 0
+            and step % h.recurrence_probe_every == 0
+        )
+        should_log_train = h.train_log_every > 0 and (
+            step <= 5 or step % h.train_log_every == 0 or stop_after_step is not None
+        )
+        step_art_avg_depth = 0.0
+        step_art_avg_continue = 0.0
+        step_art_avg_entropy = 0.0
+        step_art_gate_continue = None
+        if (should_probe_recurrence or should_log_train) and local_step_art_count > 0:
+            step_stats = torch.stack(
+                (
+                    local_step_depth_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_continue_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    local_step_entropy_sum.detach().to(
+                        device=device, dtype=torch.float64
+                    ),
+                    torch.tensor(
+                        local_step_art_count, device=device, dtype=torch.float64
+                    ),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(step_stats, op=dist.ReduceOp.SUM)
+            step_art_avg_depth = float(
+                (step_stats[0] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_continue = float(
+                (step_stats[1] / step_stats[3].clamp_min(1.0)).item()
+            )
+            step_art_avg_entropy = float(
+                (step_stats[2] / step_stats[3].clamp_min(1.0)).item()
+            )
+            if local_step_gate_continue_sum is not None:
+                gate_stats = local_step_gate_continue_sum.detach().to(
+                    device=device, dtype=torch.float64
+                )
+                if h.distributed:
+                    dist.all_reduce(gate_stats, op=dist.ReduceOp.SUM)
+                step_art_gate_continue = (
+                    (gate_stats / step_stats[3].clamp_min(1.0)).detach().cpu()
+                )
+        if should_probe_recurrence:
+            window_stats = torch.stack(
+                (
+                    sum_recent_stats(recent_depth_sums),
+                    sum_recent_stats(recent_depth_counts),
+                    sum_recent_stats(recent_continue_sums),
+                    sum_recent_stats(recent_entropy_sums),
+                )
+            )
+            if h.distributed:
+                dist.all_reduce(window_stats, op=dist.ReduceOp.SUM)
+        else:
+            window_stats = None
+        if should_log_train:
+            step_avg_ms = approx_training_time_ms / max(step, 1)
+            tok_per_sec = step * h.train_batch_tokens / (approx_training_time_ms / 1e3)
+            art_suffix = ""
+            if h.art_halt_enabled and base_model.art_halt_runtime_active:
+                base_model.sync_art_logging_stats()
+                gate_suffix = ""
+                if step_art_gate_continue is not None:
+                    gate_suffix = " art_continue:" + ",".join(
+                        f"{name}={float(value):.3f}"
+                        for name, value in zip(
+                            base_model.art_gate_names,
+                            step_art_gate_continue.tolist(),
+                            strict=False,
+                        )
+                    )
+                art_suffix = (
+                    f" art_cycles:{step_art_avg_depth:.3f}"
+                    f" extra_cycle_frac:{step_art_avg_continue:.3f}"
+                    f"{gate_suffix}"
+                    f" art_entropy:{step_art_avg_entropy:.4f}"
+                    f" art_router_loss:{base_model.last_art_router_loss:.4f}"
+                )
+            log(
+                f"{step}/{h.iterations} train_loss: {train_loss.item():.4f} "
+                f"train_time: {approx_training_time_ms / 60000:.1f}m "
+                f"step_avg: {step_avg_ms:.2f}ms tok/s: {tok_per_sec:.0f}"
+                f"{art_suffix}"
+            )
+        if (
+            should_probe_recurrence
+            and (not h.distributed or h.rank == 0)
+            and window_stats is not None
+        ):
+            log(
+                format_art_probe_summary(
+                    step,
+                    h.iterations,
+                    len(recent_depth_sums),
+                    float(window_stats[0].item()),
+                    float(window_stats[1].item()),
+                    float(window_stats[2].item()),
+                    float(window_stats[3].item()),
+                )
+            )
+        reached_cap = (
+            max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        )
+        if h.distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+    log(
+        f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+        f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+    )
+    log("ema:applying EMA weights")
+    current_state = base_model.state_dict()
+    avg_state = {
+        name: t.to(dtype=current_state[name].dtype) for name, t in ema_state.items()
+    }
+    base_model.load_state_dict(avg_state, strict=True)
+    return base_model, compiled_model
+
+
+def train_and_eval(h, device):
+    random.seed(h.seed)
+    np.random.seed(h.seed)
+    torch.manual_seed(h.seed)
+    torch.cuda.manual_seed_all(h.seed)
+    val_data = ValidationData(h, device)
+    log(f"experiment_variant:{h.experiment_variant}")
+    if h.experiment_notes:
+        log(f"experiment_notes:{h.experiment_notes}")
+    log(
+        "experiment_settings:"
+        f" seed:{h.seed}"
+        f" max_wallclock:{h.max_wallclock_seconds:g}s"
+        f" train_batch_tokens:{h.train_batch_tokens}"
+        f" ttt_enabled:{int(h.ttt_enabled)}"
+        f" sliding_window:{int(h.sliding_window_enabled)}"
+        f" raw_roundtrip_check:{int(h.raw_roundtrip_check_enabled)}"
+    )
+    log(
+        f"train_shards: {len(list(Path(h.datasets_dir).resolve().glob('fineweb_train_*.bin')))}"
+    )
+    log(f"val_tokens: {val_data.val_tokens.numel() - 1}")
+    base_model, compiled_model = train_model(h, device, val_data)
+    if _SMOKE_TEST:
+        log("smoke_test: training complete — running GPTQ+brotli pack for size check")
+        serialize(h, base_model)
+        if h.is_main_process:
+            import sys as _sys
+            from pathlib import Path as _Path
+
+            _proj = _Path(__file__).resolve().parent
+            if str(_proj) not in _sys.path:
+                _sys.path.insert(0, str(_proj))
+            from pack_submission import pack_code as _pack_code
+
+            code_b = len(_pack_code(_Path(__file__).read_text(encoding="utf-8")))
+            model_b = os.path.getsize(h.quantized_model_path)
+            total = code_b + model_b
+            log(f"smoke_pack_bytes: code={code_b} model={model_b} total={total}")
+        log(
+            "smoke_test:complete (code ran successfully; val_bpb not computed in smoke mode)"
+        )
+        return
+    torch._dynamo.reset()
+    timed_eval(
+        "pre-quantization post-ema", eval_val, h, device, val_data, compiled_model
+    )
+    serialize(h, base_model)
+    if h.distributed:
+        dist.barrier()
+    if h.raw_roundtrip_check_enabled:
+        raw_eval_model = deserialize_raw_checkpoint(h, device)
+        configure_art_eval_runtime(raw_eval_model, h)
+        compare_model_states("raw_checkpoint_roundtrip", base_model, raw_eval_model)
+        timed_eval(
+            "raw_checkpoint_roundtrip",
+            eval_val,
+            h,
+            device,
+            val_data,
+            raw_eval_model,
+        )
+        del raw_eval_model
+        torch.cuda.empty_cache()
+    eval_model = deserialize(h, device)
+    configure_art_eval_runtime(eval_model, h)
+    compiled_model = compile_target(eval_model, allow_graph_breaks=h.art_halt_enabled)
+    timed_eval("quantized", eval_val, h, device, val_data, compiled_model)
+    if h.sliding_window_enabled:
+        timed_eval(
+            "quantized_sliding_window",
+            eval_val_sliding,
+            h,
+            device,
+            val_data,
+            eval_model,
+        )
+    if h.ttt_enabled:
+        del eval_model, compiled_model
+        torch._dynamo.reset()
+        torch.cuda.empty_cache()
+        ttt_model = deserialize(h, device)
+        configure_art_eval_runtime(ttt_model, h)
+        log("post_quant_ttt:enabled using RoPE reload fix and routed ART eval runtime")
+        timed_eval("quantized_ttt", eval_val_ttt, h, device, val_data, ttt_model)
+        del ttt_model
+    else:
+        log("post_quant_ttt:disabled via TTT_ENABLED=0")
+
+
+def main():
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    if not torch.cuda.is_available():
+        raise RuntimeError("CUDA is required")
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(
+            f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral"
+        )
+    device = torch.device("cuda", local_rank)
+    torch.cuda.set_device(device)
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    torch.backends.cuda.matmul.allow_tf32 = True
+    torch.backends.cudnn.allow_tf32 = True
+    torch.set_float32_matmul_precision("high")
+    from torch.backends.cuda import (
+        enable_cudnn_sdp,
+        enable_flash_sdp,
+        enable_math_sdp,
+        enable_mem_efficient_sdp,
+    )
+
+    enable_cudnn_sdp(False)
+    enable_flash_sdp(True)
+    enable_mem_efficient_sdp(False)
+    enable_math_sdp(False)
+    torch._dynamo.config.optimize_ddp = False
+    h = Hyperparameters()
+    set_logging_hparams(h)
+    if h.is_main_process:
+        os.makedirs("logs", exist_ok=True)
+        log(100 * "=", console=False)
+        log("Hyperparameters:", console=True)
+        for k, v in sorted(vars(type(h)).items()):
+            if not k.startswith("_"):
+                log(f"  {k}: {v}", console=True)
+        log("=" * 100, console=False)
+        log(f"Running Python {sys.version}", console=False)
+        log(f"Running PyTorch {torch.__version__}", console=False)
+        if h.requested_vocab_size != h.vocab_size:
+            log(
+                f"sp8192_override: requested_vocab_size={h.requested_vocab_size} "
+                f"forcing_vocab_size={h.vocab_size}",
+                console=True,
+            )
+        log(
+            subprocess.run(
+                ["nvidia-smi"],
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                check=False,
+            ).stdout,
+            console=False,
+        )
+        log("=" * 100, console=False)
+    if _SMOKE_TEST:
+        log(f"[SMOKE_TEST] attention_backend=sdpa_fallback  FA3=False  smoke_test=True")
+        log(f"[SMOKE_TEST] val_bpb from this run is NOT comparable to proxy/full runs")
+    log(
+        f"attention_backend:{'flash_attn_3' if _USE_FA3 else 'sdpa_fallback(smoke)'} smoke_test:{_SMOKE_TEST}"
+    )
+    train_and_eval(h, device)
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/triple_art_small_batch.py
+++ b/records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/training_files/triple_art_small_batch.py
@@ -1,0 +1,7 @@
+from __future__ import annotations
+
+from run_variant import run_variant
+
+
+if __name__ == "__main__":
+    run_variant("batch_small_prettt")


### PR DESCRIPTION
## Summary

This is a non-record research submission for the Adaptive Recurrent Transformer (ART) architecture family.

The core example is PR1855-family + Simple ART, which reached 1.19991555 BPB after quantization and post-quant TTT on a single H100 GPU. The package also includes selected ART variants and evidence logs, including a PR1855-family Soft ART run at 1.06425679 BPB on 8xH100.

## What is included

- New folder only: `records/track_non_record_16mb/2026-05-01_AdaptiveRecurrentTransformer_ART/`
- `README.md` and `submission.json`
- Canonical Simple ART `train_gpt.py`
- Training files for selected ART variants
- Sanitized score/evidence logs for each README result row

## Non-record caveat

This is not a leaderboard claim. Some included evidence runs exceed record constraints such as artifact size or full TTT evaluation runtime. The submission is intended to document the ART architectural direction and provide reproducible code/evidence for review.

## Privacy / scope

The logs were sanitized to remove shell banners, infrastructure identifiers, host/container details, IPs, and path-heavy environment dumps. No image assets are included. This PR is based on current `openai/parameter-golf:main` and only adds the one non-record submission folder.
