### PR TITLE
add pr2069 best 8xh100 submission package

### DIFF
--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/README.md
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/README.md
@@ -1,0 +1,67 @@
+# Submission: 8xH100 QK5.25 TTT-disabled PR2069 rerun
+
+Candidate: `best4x_ttt_disabled_qk525`
+Mean val_bpb: `1.23485583`
+Artifact bytes: `15843310`
+Hardware: `8xNVIDIA H100 80GB HBM3`
+
+> Note: this generated package contains fewer than 3 seeds. For a new SOTA record PR, rerun the selected candidate with additional seeds or submit as a non-record result.
+
+## Results
+
+| Seed | val_bpb | val_loss | artifact bytes | train seconds |
+|---|---:|---:|---:|---:|
+| 1337 | 1.23485583 | 2.08500235 | 15843310 | 702.656 |
+
+## Technique
+
+4xH100 promotion of the best 1xH100 TTT-disabled QK5.25 control
+
+Candidate environment is captured in `candidate_env.json`; source batch rows are copied into `run_result*.json`.
+
+## Reproduction
+
+From this record folder:
+
+```bash
+export ARTIFACT_BUDGET_STRICT="0"
+export CANDIDATE_IMPL="autoregressive_gpt"
+export MAX_WALLCLOCK_SECONDS="600"
+export QK_GAIN_INIT="5.25"
+export SKIP_PRE_QUANT_FINAL_EVAL="1"
+export TRAIN_BATCH_TOKENS="2097152"
+export TRAIN_LOG_EVERY="100"
+export TTT_ENABLED="0"
+export VAL_LOSS_EVERY="0"
+export VOCAB_SIZE="1024"
+export NPROC_PER_NODE="${NPROC_PER_NODE:-8}"
+export DATA_PATH="${DATA_PATH:-../../data/datasets/fineweb10B_sp1024}"
+export TOKENIZER_PATH="${TOKENIZER_PATH:-../../data/tokenizers/fineweb_1024_bpe.model}"
+export RUN_ID="${RUN_ID:-submission_rerun}"
+torchrun --standalone --nproc_per_node="$NPROC_PER_NODE" train_gpt.py
+```
+
+For a 3-seed verification run:
+
+```bash
+for SEED in 42 314 1234; do
+  SEED=$SEED RUN_ID=submission_seed${SEED} \
+    torchrun --standalone --nproc_per_node=8 train_gpt.py > train_seed${SEED}_rerun.log 2>&1
+done
+```
+
+## Compliance Notes
+
+- Training under 600s in packaged run(s): `False`
+- Artifact under 16,000,000 bytes in packaged run(s): `True`
+- Three-seed evidence included: `False`
+
+## Included Files
+
+- `README.md`
+- `submission.json`
+- `train_gpt.py`
+- `train.log`
+- `candidate_env.json`
+- `train*.log`
+- `run_result*.json`

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/candidate_env.json
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/candidate_env.json
@@ -1,0 +1,16 @@
+{
+  "ARTIFACT_BUDGET_STRICT": "0",
+  "CANDIDATE_IMPL": "autoregressive_gpt",
+  "DATA_PATH": "/workspace/parameter-golf/data/datasets/fineweb10B_sp1024",
+  "MAX_WALLCLOCK_SECONDS": "600",
+  "QK_GAIN_INIT": "5.25",
+  "RUN_ID": "h100_batch_20260501T153233Z_01_best4x_ttt_disabled_qk525",
+  "SKIP_PRE_QUANT_FINAL_EVAL": "1",
+  "SUBMISSION_CODE_PATHS": "/workspace/parameter-golf/train_gpt.py,/workspace/parameter-golf/candidates,/workspace/parameter-golf/fastest/scripts/artifact_budget_analyzer.py",
+  "TOKENIZER_PATH": "/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model",
+  "TRAIN_BATCH_TOKENS": "2097152",
+  "TRAIN_LOG_EVERY": "100",
+  "TTT_ENABLED": "0",
+  "VAL_LOSS_EVERY": "0",
+  "VOCAB_SIZE": "1024"
+}

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/packaged_batch_rows.json
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/packaged_batch_rows.json
@@ -1,0 +1,480 @@
+[
+  {
+    "id": "best4x_ttt_disabled_qk525",
+    "family": "autoregressive_eval_policy",
+    "hardwareLabel": "8xNVIDIA H100 80GB HBM3",
+    "quantization": "int8-zlib-artifact",
+    "hypothesis": "qk525_ttt_disabled_scales_best_from_1x_to_4x_h100",
+    "hypothesisTags": [
+      "ttt_disabled",
+      "qk_gain",
+      "four_h100",
+      "best_1x_promotion"
+    ],
+    "description": "4xH100 promotion of the best 1xH100 TTT-disabled QK5.25 control.",
+    "hardware": {
+      "capturedAt": "2026-05-01T15:32:33Z",
+      "hostname": "ae414d72726c",
+      "platform": "Linux-6.8.0-100-generic-x86_64-with-glibc2.39",
+      "python": "3.12.3",
+      "cudaVisibleDevices": null,
+      "gpus": [
+        {
+          "index": "0",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-1d915847-cf88-904a-7b4e-05e7b50368b7",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "1",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-69e7d7c9-7040-dc89-d2f2-b6831a9ce39a",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "2",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-a9487790-8b12-9f15-1aed-2dfd8d5f475c",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "3",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-2c175e8a-af9c-4455-45a6-29699646bf2c",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "4",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-00035ce2-e937-79e5-8faf-c53162b8b68a",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "5",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-70713836-3351-bd7d-9c14-2c084ff08953",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "6",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-ffac9a65-5f4f-6370-98d7-bdda443fc91d",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        },
+        {
+          "index": "7",
+          "name": "NVIDIA H100 80GB HBM3",
+          "uuid": "GPU-85951712-daa9-fc97-529d-db92947324e3",
+          "memoryTotalMiB": "81559",
+          "driverVersion": "580.126.09",
+          "powerLimitW": "700.00"
+        }
+      ],
+      "nvidiaSmiAvailable": true,
+      "nvidiaSmiStderr": ""
+    },
+    "status": "completed",
+    "returnCode": 0,
+    "timedOut": false,
+    "terminationReason": "completed",
+    "elapsedSeconds": 702.656,
+    "runDir": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525",
+    "command": [
+      "torchrun",
+      "--standalone",
+      "--nproc_per_node=8",
+      "/workspace/parameter-golf/train_gpt.py"
+    ],
+    "nprocPerNode": 8,
+    "env": {
+      "ARTIFACT_BUDGET_STRICT": "0",
+      "CANDIDATE_IMPL": "autoregressive_gpt",
+      "DATA_PATH": "/workspace/parameter-golf/data/datasets/fineweb10B_sp1024",
+      "MAX_WALLCLOCK_SECONDS": "600",
+      "QK_GAIN_INIT": "5.25",
+      "RUN_ID": "h100_batch_20260501T153233Z_01_best4x_ttt_disabled_qk525",
+      "SKIP_PRE_QUANT_FINAL_EVAL": "1",
+      "SUBMISSION_CODE_PATHS": "/workspace/parameter-golf/train_gpt.py,/workspace/parameter-golf/candidates,/workspace/parameter-golf/fastest/scripts/artifact_budget_analyzer.py",
+      "TOKENIZER_PATH": "/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model",
+      "TRAIN_BATCH_TOKENS": "2097152",
+      "TRAIN_LOG_EVERY": "100",
+      "TTT_ENABLED": "0",
+      "VAL_LOSS_EVERY": "0",
+      "VOCAB_SIZE": "1024"
+    },
+    "selectedTrainBatchTokens": 2097152,
+    "tokensPerSecond": 13016087.388282025,
+    "batchTuneStatus": null,
+    "batchTune": {
+      "enabled": false
+    },
+    "trainingSeries": [
+      {
+        "kind": "train",
+        "step": 1,
+        "loss": 6.9369,
+        "trainTimeMs": 564.0,
+        "stepAvgMs": 563.53
+      },
+      {
+        "kind": "train",
+        "step": 2,
+        "loss": 16.6814,
+        "trainTimeMs": 631.0,
+        "stepAvgMs": 315.35
+      },
+      {
+        "kind": "train",
+        "step": 3,
+        "loss": 9.0949,
+        "trainTimeMs": 777.0,
+        "stepAvgMs": 259.1
+      },
+      {
+        "kind": "train",
+        "step": 4,
+        "loss": 6.5716,
+        "trainTimeMs": 925.0,
+        "stepAvgMs": 231.26
+      },
+      {
+        "kind": "train",
+        "step": 5,
+        "loss": 6.7011,
+        "trainTimeMs": 1073.0,
+        "stepAvgMs": 214.5
+      },
+      {
+        "kind": "train",
+        "step": 6,
+        "loss": 6.5696,
+        "trainTimeMs": 1220.0,
+        "stepAvgMs": 203.28
+      },
+      {
+        "kind": "train",
+        "step": 7,
+        "loss": 6.4346,
+        "trainTimeMs": 1367.0,
+        "stepAvgMs": 195.27
+      },
+      {
+        "kind": "train",
+        "step": 8,
+        "loss": 6.2081,
+        "trainTimeMs": 1518.0,
+        "stepAvgMs": 189.81
+      },
+      {
+        "kind": "train",
+        "step": 9,
+        "loss": 6.1313,
+        "trainTimeMs": 1670.0,
+        "stepAvgMs": 185.59
+      },
+      {
+        "kind": "train",
+        "step": 10,
+        "loss": 6.0393,
+        "trainTimeMs": 1818.0,
+        "stepAvgMs": 181.84
+      },
+      {
+        "kind": "train",
+        "step": 100,
+        "loss": 3.2199,
+        "trainTimeMs": 16305.0,
+        "stepAvgMs": 163.05
+      },
+      {
+        "kind": "train",
+        "step": 200,
+        "loss": 2.7397,
+        "trainTimeMs": 32341.0,
+        "stepAvgMs": 161.71
+      },
+      {
+        "kind": "train",
+        "step": 300,
+        "loss": 2.5549,
+        "trainTimeMs": 48414.0,
+        "stepAvgMs": 161.38
+      },
+      {
+        "kind": "train",
+        "step": 400,
+        "loss": 2.4237,
+        "trainTimeMs": 64507.0,
+        "stepAvgMs": 161.27
+      },
+      {
+        "kind": "train",
+        "step": 500,
+        "loss": 2.3555,
+        "trainTimeMs": 80675.0,
+        "stepAvgMs": 161.35
+      },
+      {
+        "kind": "train",
+        "step": 600,
+        "loss": 2.2969,
+        "trainTimeMs": 96817.0,
+        "stepAvgMs": 161.36
+      },
+      {
+        "kind": "train",
+        "step": 700,
+        "loss": 2.3869,
+        "trainTimeMs": 112863.0,
+        "stepAvgMs": 161.23
+      },
+      {
+        "kind": "train",
+        "step": 800,
+        "loss": 2.3056,
+        "trainTimeMs": 129000.0,
+        "stepAvgMs": 161.25
+      },
+      {
+        "kind": "train",
+        "step": 900,
+        "loss": 2.3323,
+        "trainTimeMs": 145126.0,
+        "stepAvgMs": 161.25
+      },
+      {
+        "kind": "train",
+        "step": 1000,
+        "loss": 2.1503,
+        "trainTimeMs": 161232.0,
+        "stepAvgMs": 161.23
+      },
+      {
+        "kind": "train",
+        "step": 1100,
+        "loss": 2.2499,
+        "trainTimeMs": 177783.0,
+        "stepAvgMs": 161.62
+      },
+      {
+        "kind": "train",
+        "step": 1200,
+        "loss": 2.2197,
+        "trainTimeMs": 193912.0,
+        "stepAvgMs": 161.59
+      },
+      {
+        "kind": "train",
+        "step": 1300,
+        "loss": 2.2843,
+        "trainTimeMs": 209985.0,
+        "stepAvgMs": 161.53
+      },
+      {
+        "kind": "train",
+        "step": 1400,
+        "loss": 2.3222,
+        "trainTimeMs": 226069.0,
+        "stepAvgMs": 161.48
+      },
+      {
+        "kind": "train",
+        "step": 1500,
+        "loss": 2.1343,
+        "trainTimeMs": 242118.0,
+        "stepAvgMs": 161.41
+      },
+      {
+        "kind": "train",
+        "step": 1600,
+        "loss": 2.119,
+        "trainTimeMs": 258131.0,
+        "stepAvgMs": 161.33
+      },
+      {
+        "kind": "train",
+        "step": 1700,
+        "loss": 2.1857,
+        "trainTimeMs": 274215.0,
+        "stepAvgMs": 161.3
+      },
+      {
+        "kind": "train",
+        "step": 1800,
+        "loss": 2.0968,
+        "trainTimeMs": 290300.0,
+        "stepAvgMs": 161.28
+      },
+      {
+        "kind": "train",
+        "step": 1900,
+        "loss": 2.1003,
+        "trainTimeMs": 306356.0,
+        "stepAvgMs": 161.24
+      },
+      {
+        "kind": "train",
+        "step": 2000,
+        "loss": 2.1114,
+        "trainTimeMs": 322406.0,
+        "stepAvgMs": 161.2
+      },
+      {
+        "kind": "train",
+        "step": 2100,
+        "loss": 2.119,
+        "trainTimeMs": 338951.0,
+        "stepAvgMs": 161.41
+      },
+      {
+        "kind": "train",
+        "step": 2200,
+        "loss": 2.2025,
+        "trainTimeMs": 354985.0,
+        "stepAvgMs": 161.36
+      },
+      {
+        "kind": "train",
+        "step": 2300,
+        "loss": 2.109,
+        "trainTimeMs": 371062.0,
+        "stepAvgMs": 161.33
+      },
+      {
+        "kind": "train",
+        "step": 2400,
+        "loss": 2.0836,
+        "trainTimeMs": 387225.0,
+        "stepAvgMs": 161.34
+      },
+      {
+        "kind": "train",
+        "step": 2500,
+        "loss": 2.1699,
+        "trainTimeMs": 403270.0,
+        "stepAvgMs": 161.31
+      },
+      {
+        "kind": "train",
+        "step": 2600,
+        "loss": 2.0281,
+        "trainTimeMs": 419299.0,
+        "stepAvgMs": 161.27
+      },
+      {
+        "kind": "train",
+        "step": 2700,
+        "loss": 2.155,
+        "trainTimeMs": 435359.0,
+        "stepAvgMs": 161.24
+      },
+      {
+        "kind": "train",
+        "step": 2800,
+        "loss": 2.1683,
+        "trainTimeMs": 451408.0,
+        "stepAvgMs": 161.22
+      },
+      {
+        "kind": "train",
+        "step": 2900,
+        "loss": 2.1371,
+        "trainTimeMs": 467439.0,
+        "stepAvgMs": 161.19
+      },
+      {
+        "kind": "train",
+        "step": 3000,
+        "loss": 2.1337,
+        "trainTimeMs": 483504.0,
+        "stepAvgMs": 161.17
+      },
+      {
+        "kind": "train",
+        "step": 3100,
+        "loss": 2.0698,
+        "trainTimeMs": 499641.0,
+        "stepAvgMs": 161.17
+      },
+      {
+        "kind": "train",
+        "step": 3200,
+        "loss": 2.1785,
+        "trainTimeMs": 516122.0,
+        "stepAvgMs": 161.29
+      },
+      {
+        "kind": "train",
+        "step": 3300,
+        "loss": 2.1206,
+        "trainTimeMs": 532184.0,
+        "stepAvgMs": 161.27
+      },
+      {
+        "kind": "train",
+        "step": 3400,
+        "loss": 2.1353,
+        "trainTimeMs": 548229.0,
+        "stepAvgMs": 161.24
+      },
+      {
+        "kind": "train",
+        "step": 3500,
+        "loss": 2.0885,
+        "trainTimeMs": 564062.0,
+        "stepAvgMs": 161.16
+      },
+      {
+        "kind": "train",
+        "step": 3600,
+        "loss": 2.0603,
+        "trainTimeMs": 580112.0,
+        "stepAvgMs": 161.14
+      },
+      {
+        "kind": "train",
+        "step": 3700,
+        "loss": 2.0658,
+        "trainTimeMs": 596145.0,
+        "stepAvgMs": 161.12
+      }
+    ],
+    "trainingCurvePath": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525/training_curve.svg",
+    "rawCheckpointKept": false,
+    "rawCheckpointPath": null,
+    "quantizedArtifactPath": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525/final_model.int8.ptz",
+    "quantizedArtifactBytes": 15738419,
+    "finalValLoss": 2.08500235,
+    "finalValBpb": 1.23485583,
+    "modelParams": 17059912,
+    "completedSteps": 3700,
+    "targetIterations": 20000,
+    "lastTrainLoss": 2.0658,
+    "trainTimeMs": 596145.0,
+    "stepAvgMs": 161.12,
+    "rawSubmissionBytes": 67327456,
+    "int8SubmissionBytes": 15840892,
+    "peakAllocatedMiB": 36440,
+    "peakReservedMiB": 36698,
+    "artifactBudgetState": "within-budget",
+    "artifactBudgetBytes": 13442586,
+    "artifactBudgetLimitBytes": 16000000,
+    "artifactBudgetHeadroomBytes": 2557414,
+    "rank": 1,
+    "_batchDir": "records/pr2069_best_8xh100/20260501T153233Z"
+  }
+]

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/run_result_seed1337.json
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/run_result_seed1337.json
@@ -1,0 +1,476 @@
+{
+  "id": "best4x_ttt_disabled_qk525",
+  "family": "autoregressive_eval_policy",
+  "hardwareLabel": "8xNVIDIA H100 80GB HBM3",
+  "quantization": "int8-zlib-artifact",
+  "hypothesis": "qk525_ttt_disabled_scales_best_from_1x_to_4x_h100",
+  "hypothesisTags": [
+    "ttt_disabled",
+    "qk_gain",
+    "four_h100",
+    "best_1x_promotion"
+  ],
+  "description": "4xH100 promotion of the best 1xH100 TTT-disabled QK5.25 control.",
+  "hardware": {
+    "capturedAt": "2026-05-01T15:32:33Z",
+    "hostname": "ae414d72726c",
+    "platform": "Linux-6.8.0-100-generic-x86_64-with-glibc2.39",
+    "python": "3.12.3",
+    "cudaVisibleDevices": null,
+    "gpus": [
+      {
+        "index": "0",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-1d915847-cf88-904a-7b4e-05e7b50368b7",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "1",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-69e7d7c9-7040-dc89-d2f2-b6831a9ce39a",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "2",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-a9487790-8b12-9f15-1aed-2dfd8d5f475c",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "3",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-2c175e8a-af9c-4455-45a6-29699646bf2c",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "4",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-00035ce2-e937-79e5-8faf-c53162b8b68a",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "5",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-70713836-3351-bd7d-9c14-2c084ff08953",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "6",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-ffac9a65-5f4f-6370-98d7-bdda443fc91d",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      },
+      {
+        "index": "7",
+        "name": "NVIDIA H100 80GB HBM3",
+        "uuid": "GPU-85951712-daa9-fc97-529d-db92947324e3",
+        "memoryTotalMiB": "81559",
+        "driverVersion": "580.126.09",
+        "powerLimitW": "700.00"
+      }
+    ],
+    "nvidiaSmiAvailable": true,
+    "nvidiaSmiStderr": ""
+  },
+  "status": "completed",
+  "returnCode": 0,
+  "timedOut": false,
+  "terminationReason": "completed",
+  "elapsedSeconds": 702.656,
+  "runDir": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525",
+  "command": [
+    "torchrun",
+    "--standalone",
+    "--nproc_per_node=8",
+    "/workspace/parameter-golf/train_gpt.py"
+  ],
+  "nprocPerNode": 8,
+  "env": {
+    "ARTIFACT_BUDGET_STRICT": "0",
+    "CANDIDATE_IMPL": "autoregressive_gpt",
+    "DATA_PATH": "/workspace/parameter-golf/data/datasets/fineweb10B_sp1024",
+    "MAX_WALLCLOCK_SECONDS": "600",
+    "QK_GAIN_INIT": "5.25",
+    "RUN_ID": "h100_batch_20260501T153233Z_01_best4x_ttt_disabled_qk525",
+    "SKIP_PRE_QUANT_FINAL_EVAL": "1",
+    "SUBMISSION_CODE_PATHS": "/workspace/parameter-golf/train_gpt.py,/workspace/parameter-golf/candidates,/workspace/parameter-golf/fastest/scripts/artifact_budget_analyzer.py",
+    "TOKENIZER_PATH": "/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model",
+    "TRAIN_BATCH_TOKENS": "2097152",
+    "TRAIN_LOG_EVERY": "100",
+    "TTT_ENABLED": "0",
+    "VAL_LOSS_EVERY": "0",
+    "VOCAB_SIZE": "1024"
+  },
+  "selectedTrainBatchTokens": 2097152,
+  "tokensPerSecond": 13016087.388282025,
+  "batchTuneStatus": null,
+  "batchTune": {
+    "enabled": false
+  },
+  "trainingSeries": [
+    {
+      "kind": "train",
+      "step": 1,
+      "loss": 6.9369,
+      "trainTimeMs": 564.0,
+      "stepAvgMs": 563.53
+    },
+    {
+      "kind": "train",
+      "step": 2,
+      "loss": 16.6814,
+      "trainTimeMs": 631.0,
+      "stepAvgMs": 315.35
+    },
+    {
+      "kind": "train",
+      "step": 3,
+      "loss": 9.0949,
+      "trainTimeMs": 777.0,
+      "stepAvgMs": 259.1
+    },
+    {
+      "kind": "train",
+      "step": 4,
+      "loss": 6.5716,
+      "trainTimeMs": 925.0,
+      "stepAvgMs": 231.26
+    },
+    {
+      "kind": "train",
+      "step": 5,
+      "loss": 6.7011,
+      "trainTimeMs": 1073.0,
+      "stepAvgMs": 214.5
+    },
+    {
+      "kind": "train",
+      "step": 6,
+      "loss": 6.5696,
+      "trainTimeMs": 1220.0,
+      "stepAvgMs": 203.28
+    },
+    {
+      "kind": "train",
+      "step": 7,
+      "loss": 6.4346,
+      "trainTimeMs": 1367.0,
+      "stepAvgMs": 195.27
+    },
+    {
+      "kind": "train",
+      "step": 8,
+      "loss": 6.2081,
+      "trainTimeMs": 1518.0,
+      "stepAvgMs": 189.81
+    },
+    {
+      "kind": "train",
+      "step": 9,
+      "loss": 6.1313,
+      "trainTimeMs": 1670.0,
+      "stepAvgMs": 185.59
+    },
+    {
+      "kind": "train",
+      "step": 10,
+      "loss": 6.0393,
+      "trainTimeMs": 1818.0,
+      "stepAvgMs": 181.84
+    },
+    {
+      "kind": "train",
+      "step": 100,
+      "loss": 3.2199,
+      "trainTimeMs": 16305.0,
+      "stepAvgMs": 163.05
+    },
+    {
+      "kind": "train",
+      "step": 200,
+      "loss": 2.7397,
+      "trainTimeMs": 32341.0,
+      "stepAvgMs": 161.71
+    },
+    {
+      "kind": "train",
+      "step": 300,
+      "loss": 2.5549,
+      "trainTimeMs": 48414.0,
+      "stepAvgMs": 161.38
+    },
+    {
+      "kind": "train",
+      "step": 400,
+      "loss": 2.4237,
+      "trainTimeMs": 64507.0,
+      "stepAvgMs": 161.27
+    },
+    {
+      "kind": "train",
+      "step": 500,
+      "loss": 2.3555,
+      "trainTimeMs": 80675.0,
+      "stepAvgMs": 161.35
+    },
+    {
+      "kind": "train",
+      "step": 600,
+      "loss": 2.2969,
+      "trainTimeMs": 96817.0,
+      "stepAvgMs": 161.36
+    },
+    {
+      "kind": "train",
+      "step": 700,
+      "loss": 2.3869,
+      "trainTimeMs": 112863.0,
+      "stepAvgMs": 161.23
+    },
+    {
+      "kind": "train",
+      "step": 800,
+      "loss": 2.3056,
+      "trainTimeMs": 129000.0,
+      "stepAvgMs": 161.25
+    },
+    {
+      "kind": "train",
+      "step": 900,
+      "loss": 2.3323,
+      "trainTimeMs": 145126.0,
+      "stepAvgMs": 161.25
+    },
+    {
+      "kind": "train",
+      "step": 1000,
+      "loss": 2.1503,
+      "trainTimeMs": 161232.0,
+      "stepAvgMs": 161.23
+    },
+    {
+      "kind": "train",
+      "step": 1100,
+      "loss": 2.2499,
+      "trainTimeMs": 177783.0,
+      "stepAvgMs": 161.62
+    },
+    {
+      "kind": "train",
+      "step": 1200,
+      "loss": 2.2197,
+      "trainTimeMs": 193912.0,
+      "stepAvgMs": 161.59
+    },
+    {
+      "kind": "train",
+      "step": 1300,
+      "loss": 2.2843,
+      "trainTimeMs": 209985.0,
+      "stepAvgMs": 161.53
+    },
+    {
+      "kind": "train",
+      "step": 1400,
+      "loss": 2.3222,
+      "trainTimeMs": 226069.0,
+      "stepAvgMs": 161.48
+    },
+    {
+      "kind": "train",
+      "step": 1500,
+      "loss": 2.1343,
+      "trainTimeMs": 242118.0,
+      "stepAvgMs": 161.41
+    },
+    {
+      "kind": "train",
+      "step": 1600,
+      "loss": 2.119,
+      "trainTimeMs": 258131.0,
+      "stepAvgMs": 161.33
+    },
+    {
+      "kind": "train",
+      "step": 1700,
+      "loss": 2.1857,
+      "trainTimeMs": 274215.0,
+      "stepAvgMs": 161.3
+    },
+    {
+      "kind": "train",
+      "step": 1800,
+      "loss": 2.0968,
+      "trainTimeMs": 290300.0,
+      "stepAvgMs": 161.28
+    },
+    {
+      "kind": "train",
+      "step": 1900,
+      "loss": 2.1003,
+      "trainTimeMs": 306356.0,
+      "stepAvgMs": 161.24
+    },
+    {
+      "kind": "train",
+      "step": 2000,
+      "loss": 2.1114,
+      "trainTimeMs": 322406.0,
+      "stepAvgMs": 161.2
+    },
+    {
+      "kind": "train",
+      "step": 2100,
+      "loss": 2.119,
+      "trainTimeMs": 338951.0,
+      "stepAvgMs": 161.41
+    },
+    {
+      "kind": "train",
+      "step": 2200,
+      "loss": 2.2025,
+      "trainTimeMs": 354985.0,
+      "stepAvgMs": 161.36
+    },
+    {
+      "kind": "train",
+      "step": 2300,
+      "loss": 2.109,
+      "trainTimeMs": 371062.0,
+      "stepAvgMs": 161.33
+    },
+    {
+      "kind": "train",
+      "step": 2400,
+      "loss": 2.0836,
+      "trainTimeMs": 387225.0,
+      "stepAvgMs": 161.34
+    },
+    {
+      "kind": "train",
+      "step": 2500,
+      "loss": 2.1699,
+      "trainTimeMs": 403270.0,
+      "stepAvgMs": 161.31
+    },
+    {
+      "kind": "train",
+      "step": 2600,
+      "loss": 2.0281,
+      "trainTimeMs": 419299.0,
+      "stepAvgMs": 161.27
+    },
+    {
+      "kind": "train",
+      "step": 2700,
+      "loss": 2.155,
+      "trainTimeMs": 435359.0,
+      "stepAvgMs": 161.24
+    },
+    {
+      "kind": "train",
+      "step": 2800,
+      "loss": 2.1683,
+      "trainTimeMs": 451408.0,
+      "stepAvgMs": 161.22
+    },
+    {
+      "kind": "train",
+      "step": 2900,
+      "loss": 2.1371,
+      "trainTimeMs": 467439.0,
+      "stepAvgMs": 161.19
+    },
+    {
+      "kind": "train",
+      "step": 3000,
+      "loss": 2.1337,
+      "trainTimeMs": 483504.0,
+      "stepAvgMs": 161.17
+    },
+    {
+      "kind": "train",
+      "step": 3100,
+      "loss": 2.0698,
+      "trainTimeMs": 499641.0,
+      "stepAvgMs": 161.17
+    },
+    {
+      "kind": "train",
+      "step": 3200,
+      "loss": 2.1785,
+      "trainTimeMs": 516122.0,
+      "stepAvgMs": 161.29
+    },
+    {
+      "kind": "train",
+      "step": 3300,
+      "loss": 2.1206,
+      "trainTimeMs": 532184.0,
+      "stepAvgMs": 161.27
+    },
+    {
+      "kind": "train",
+      "step": 3400,
+      "loss": 2.1353,
+      "trainTimeMs": 548229.0,
+      "stepAvgMs": 161.24
+    },
+    {
+      "kind": "train",
+      "step": 3500,
+      "loss": 2.0885,
+      "trainTimeMs": 564062.0,
+      "stepAvgMs": 161.16
+    },
+    {
+      "kind": "train",
+      "step": 3600,
+      "loss": 2.0603,
+      "trainTimeMs": 580112.0,
+      "stepAvgMs": 161.14
+    },
+    {
+      "kind": "train",
+      "step": 3700,
+      "loss": 2.0658,
+      "trainTimeMs": 596145.0,
+      "stepAvgMs": 161.12
+    }
+  ],
+  "trainingCurvePath": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525/training_curve.svg",
+  "rawCheckpointKept": false,
+  "rawCheckpointPath": null,
+  "quantizedArtifactPath": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525/final_model.int8.ptz",
+  "quantizedArtifactBytes": 15738419,
+  "finalValLoss": 2.08500235,
+  "finalValBpb": 1.23485583,
+  "modelParams": 17059912,
+  "completedSteps": 3700,
+  "targetIterations": 20000,
+  "lastTrainLoss": 2.0658,
+  "trainTimeMs": 596145.0,
+  "stepAvgMs": 161.12,
+  "rawSubmissionBytes": 67327456,
+  "int8SubmissionBytes": 15840892,
+  "peakAllocatedMiB": 36440,
+  "peakReservedMiB": 36698,
+  "artifactBudgetState": "within-budget",
+  "artifactBudgetBytes": 13442586,
+  "artifactBudgetLimitBytes": 16000000,
+  "artifactBudgetHeadroomBytes": 2557414
+}

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/stderr_seed1337.txt
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/stderr_seed1337.txt
@@ -1,0 +1,4 @@
+W0501 15:32:34.851000 2659 torch/distributed/run.py:852] 
+W0501 15:32:34.851000 2659 torch/distributed/run.py:852] *****************************************
+W0501 15:32:34.851000 2659 torch/distributed/run.py:852] Setting OMP_NUM_THREADS environment variable for each process to be 1 in default, to avoid your system being overloaded, please further tune the variable for optimal performance in your application as needed. 
+W0501 15:32:34.851000 2659 torch/distributed/run.py:852] *****************************************

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/submission.json
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/submission.json
@@ -1,0 +1,45 @@
+{
+  "author": "Rustam Eynaliyev",
+  "github_id": "tenet-diver",
+  "name": "8xH100 QK5.25 TTT-disabled PR2069 rerun",
+  "blurb": "4xH100 promotion of the best 1xH100 TTT-disabled QK5.25 control",
+  "date": "2026-05-01T15:51:08Z",
+  "track": "10min_16mb",
+  "candidate_id": "best4x_ttt_disabled_qk525",
+  "val_bpb": 1.23485583,
+  "seeds": [
+    "1337"
+  ],
+  "seed_results": {
+    "1337": {
+      "val_bpb": 1.23485583,
+      "val_loss": 2.08500235,
+      "artifact_bytes": 15843310,
+      "model_bytes": 15738419,
+      "code_bytes": 104891,
+      "train_time_s": 702.656,
+      "run_dir": "/workspace/parameter-golf/records/pr2069_best_8xh100/20260501T153233Z/runs/01_best4x_ttt_disabled_qk525"
+    }
+  },
+  "hardware": "8xNVIDIA H100 80GB HBM3",
+  "technique_summary": "4xH100 promotion of the best 1xH100 TTT-disabled QK5.25 control",
+  "bytes_code": 104891,
+  "compliance": {
+    "train_under_600s": false,
+    "artifact_under_16mb": true,
+    "three_seeds": false,
+    "generated_from_h100_batch": true
+  },
+  "provenance": {
+    "candidate_id": "best4x_ttt_disabled_qk525",
+    "batch_dirs": [
+      "records/pr2069_best_8xh100/20260501T153233Z"
+    ],
+    "source_git_commit": "162d5785ae57027138d95e5cbde145a8cd55c22c",
+    "generated_by": "fastest/scripts/package_competition_submission.py"
+  },
+  "val_loss": 2.08500235,
+  "bytes_model_int8_zlib": 15738419,
+  "bytes_total": 15843310,
+  "train_time_seconds": 702.656
+}

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train.log
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train.log
@@ -1,0 +1,101 @@
+NCCL version 2.27.5+cuda12.9
+logs/h100_batch_20260501T153233Z_01_best4x_ttt_disabled_qk525.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+torch_compile:enabled:1
+world_size:8 grad_accum_steps:1
+local_sgd:enabled:0 sync_steps:1 average_optimizer_states:0
+sdp_backends:cudnn=False flash=True mem_efficient=False math=0
+attention_mode:gqa num_heads:8 num_kv_heads:4 attn_norm_mode:baseline attn_norm_eps:1e-06
+sparse_attention:mode:dense window:256 global_tokens:4 block_size:64
+structured_sparsity:mlp_block_groups:1 mtp_num_tokens:1 mtp_loss_weight:0.0
+candidate_impl:autoregressive_gpt
+layer_order:encoder=[0, 1, 2, 3] decoder=[4, 5, 6, 7, 8] virtual_depth:9
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+moe:num_experts:1 top_k:1
+train_batch_tokens:2097152 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+artifact_budget:state:within-budget total_bytes:13442586 limit_bytes:16000000 headroom_bytes:2557414 quantization:int8-per-row-zlib-projection compression_ratio:0.78
+artifact_budget_component:name:embeddings params:524288 raw_quantized_bytes:524288 estimated_bytes:408945
+artifact_budget_component:name:attention_blocks params:7077888 raw_quantized_bytes:7077888 estimated_bytes:5520753
+artifact_budget_component:name:mlp_blocks params:9437184 raw_quantized_bytes:9437184 estimated_bytes:7361004
+artifact_budget_component:name:control_tensors params:9225 raw_quantized_bytes:20178 estimated_bytes:20178
+artifact_budget_component:name:quantization_overhead params:0 raw_quantized_bytes:118208 estimated_bytes:118208
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9369 train_time:564ms step_avg:563.53ms
+step:2/20000 train_loss:16.6814 train_time:631ms step_avg:315.35ms
+step:3/20000 train_loss:9.0949 train_time:777ms step_avg:259.10ms
+step:4/20000 train_loss:6.5716 train_time:925ms step_avg:231.26ms
+step:5/20000 train_loss:6.7011 train_time:1073ms step_avg:214.50ms
+step:6/20000 train_loss:6.5696 train_time:1220ms step_avg:203.28ms
+step:7/20000 train_loss:6.4346 train_time:1367ms step_avg:195.27ms
+step:8/20000 train_loss:6.2081 train_time:1518ms step_avg:189.81ms
+step:9/20000 train_loss:6.1313 train_time:1670ms step_avg:185.59ms
+step:10/20000 train_loss:6.0393 train_time:1818ms step_avg:181.84ms
+step:100/20000 train_loss:3.2199 train_time:16305ms step_avg:163.05ms
+step:200/20000 train_loss:2.7397 train_time:32341ms step_avg:161.71ms
+step:300/20000 train_loss:2.5549 train_time:48414ms step_avg:161.38ms
+step:400/20000 train_loss:2.4237 train_time:64507ms step_avg:161.27ms
+step:500/20000 train_loss:2.3555 train_time:80675ms step_avg:161.35ms
+step:600/20000 train_loss:2.2969 train_time:96817ms step_avg:161.36ms
+step:700/20000 train_loss:2.3869 train_time:112863ms step_avg:161.23ms
+step:800/20000 train_loss:2.3056 train_time:129000ms step_avg:161.25ms
+step:900/20000 train_loss:2.3323 train_time:145126ms step_avg:161.25ms
+step:1000/20000 train_loss:2.1503 train_time:161232ms step_avg:161.23ms
+step:1100/20000 train_loss:2.2499 train_time:177783ms step_avg:161.62ms
+step:1200/20000 train_loss:2.2197 train_time:193912ms step_avg:161.59ms
+step:1300/20000 train_loss:2.2843 train_time:209985ms step_avg:161.53ms
+step:1400/20000 train_loss:2.3222 train_time:226069ms step_avg:161.48ms
+step:1500/20000 train_loss:2.1343 train_time:242118ms step_avg:161.41ms
+step:1600/20000 train_loss:2.1190 train_time:258131ms step_avg:161.33ms
+step:1700/20000 train_loss:2.1857 train_time:274215ms step_avg:161.30ms
+step:1800/20000 train_loss:2.0968 train_time:290300ms step_avg:161.28ms
+step:1900/20000 train_loss:2.1003 train_time:306356ms step_avg:161.24ms
+step:2000/20000 train_loss:2.1114 train_time:322406ms step_avg:161.20ms
+step:2100/20000 train_loss:2.1190 train_time:338951ms step_avg:161.41ms
+step:2200/20000 train_loss:2.2025 train_time:354985ms step_avg:161.36ms
+step:2300/20000 train_loss:2.1090 train_time:371062ms step_avg:161.33ms
+step:2400/20000 train_loss:2.0836 train_time:387225ms step_avg:161.34ms
+step:2500/20000 train_loss:2.1699 train_time:403270ms step_avg:161.31ms
+step:2600/20000 train_loss:2.0281 train_time:419299ms step_avg:161.27ms
+step:2700/20000 train_loss:2.1550 train_time:435359ms step_avg:161.24ms
+step:2800/20000 train_loss:2.1683 train_time:451408ms step_avg:161.22ms
+step:2900/20000 train_loss:2.1371 train_time:467439ms step_avg:161.19ms
+step:3000/20000 train_loss:2.1337 train_time:483504ms step_avg:161.17ms
+step:3100/20000 train_loss:2.0698 train_time:499641ms step_avg:161.17ms
+step:3200/20000 train_loss:2.1785 train_time:516122ms step_avg:161.29ms
+step:3300/20000 train_loss:2.1206 train_time:532184ms step_avg:161.27ms
+step:3400/20000 train_loss:2.1353 train_time:548229ms step_avg:161.24ms
+step:3500/20000 train_loss:2.0885 train_time:564062ms step_avg:161.16ms
+step:3600/20000 train_loss:2.0603 train_time:580112ms step_avg:161.14ms
+step:3700/20000 train_loss:2.0658 train_time:596145ms step_avg:161.12ms
+stopping_early: wallclock_cap train_time:0ms step:3723/20000
+peak memory allocated: 36440 MiB reserved: 36698 MiB
+Serialized model: 67224983 bytes
+Code size: 102473 bytes
+Total submission size: 67327456 bytes
+Serialized model int8+zlib: 15738419 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15840892 bytes
+final_int8_zlib_roundtrip val_loss:2.0850 val_bpb:1.2349 eval_time:22966ms
+final_int8_zlib_roundtrip_exact val_loss:2.08500235 val_bpb:1.23485583

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train_gpt.py
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train_gpt.py
@@ -1,0 +1,1165 @@
+"""Self-contained Parameter Golf training script generated from the experiment branch."""
+from __future__ import annotations
+
+# --- Bundled local modules for Parameter Golf submission compliance ---
+import sys as _pg_sys
+import types as _pg_types
+
+def _pg_install_package(name):
+    module = _pg_sys.modules.get(name)
+    if module is None:
+        module = _pg_types.ModuleType(name)
+        module.__path__ = []
+        module.__package__ = name
+        _pg_sys.modules[name] = module
+    return module
+
+def _pg_install_module(name, source):
+    package_name, _, short_name = name.rpartition('.')
+    if package_name:
+        parts = package_name.split('.')
+        for index in range(1, len(parts) + 1):
+            _pg_install_package('.'.join(parts[:index]))
+    module = _pg_types.ModuleType(name)
+    module.__file__ = '<bundled ' + name + '>'
+    module.__package__ = package_name
+    _pg_sys.modules[name] = module
+    if package_name:
+        setattr(_pg_sys.modules[package_name], short_name, module)
+    exec(compile(source, module.__file__, 'exec'), module.__dict__)
+
+_pg_install_module('fastest.scripts.artifact_budget_analyzer', '\nimport argparse\nimport json\nimport math\nimport sys\nimport zlib\nfrom dataclasses import dataclass\nfrom pathlib import Path\nfrom typing import Any\n\n\nDEFAULT_LIMIT_BYTES = 16_000_000\nDEFAULT_COMPRESSION_RATIO = 0.78\nTENSOR_METADATA_BYTES = 64\n_MISSING = object()\n\n\n@dataclass(frozen=True)\nclass ArtifactComponentEstimate:\n    name: str\n    parameter_count: int\n    raw_quantized_bytes: int\n    estimated_bytes: int\n    tensor_count: int\n\n\n@dataclass(frozen=True)\nclass ArtifactBudgetEstimate:\n    limit_bytes: int\n    total_estimated_bytes: int\n    model_estimated_bytes: int\n    code_estimated_bytes: int\n    over_budget: bool\n    headroom_bytes: int\n    quantization_scheme: str\n    compression_ratio: float\n    components: tuple[ArtifactComponentEstimate, ...]\n\n    def to_log_lines(self) -> list[str]:\n        state = "over-budget" if self.over_budget else "within-budget"\n        lines = [\n            (\n                "artifact_budget:"\n                f"state:{state} total_bytes:{self.total_estimated_bytes} "\n                f"limit_bytes:{self.limit_bytes} headroom_bytes:{self.headroom_bytes} "\n                f"quantization:{self.quantization_scheme} "\n                f"compression_ratio:{self.compression_ratio:.2f}"\n            )\n        ]\n        for component in self.components:\n            lines.append(\n                "artifact_budget_component:"\n                f"name:{component.name} params:{component.parameter_count} "\n                f"raw_quantized_bytes:{component.raw_quantized_bytes} "\n                f"estimated_bytes:{component.estimated_bytes}"\n            )\n        return lines\n\n    def to_dict(self) -> dict[str, Any]:\n        return {\n            "limitBytes": self.limit_bytes,\n            "totalEstimatedBytes": self.total_estimated_bytes,\n            "modelEstimatedBytes": self.model_estimated_bytes,\n            "codeEstimatedBytes": self.code_estimated_bytes,\n            "overBudget": self.over_budget,\n            "headroomBytes": self.headroom_bytes,\n            "quantizationScheme": self.quantization_scheme,\n            "compressionRatio": self.compression_ratio,\n            "components": [\n                {\n                    "name": component.name,\n                    "parameterCount": component.parameter_count,\n                    "rawQuantizedBytes": component.raw_quantized_bytes,\n                    "estimatedBytes": component.estimated_bytes,\n                    "tensorCount": component.tensor_count,\n                }\n                for component in self.components\n            ],\n        }\n\n\ndef _attr(config: Any, name: str, default: Any = _MISSING) -> Any:\n    if isinstance(config, dict):\n        return config.get(name, default)\n    return getattr(config, name, default)\n\n\ndef _int_attr(config: Any, name: str, default: int) -> int:\n    value = _attr(config, name, _MISSING)\n    if value is _MISSING:\n        return default\n    if isinstance(value, bool):\n        raise ValueError(f"{name} must be an integer")\n    try:\n        return int(value)\n    except (TypeError, ValueError):\n        raise ValueError(f"{name} must be an integer") from None\n\n\ndef _bool_attr(config: Any, name: str, default: bool) -> bool:\n    value = _attr(config, name, default)\n    if isinstance(value, str):\n        return value.strip().lower() not in {"", "0", "false", "no"}\n    if value is None:\n        return default\n    return bool(value)\n\n\ndef _compressed_bytes(raw_quantized_bytes: int, compression_ratio: float) -> int:\n    return int(math.ceil(raw_quantized_bytes * compression_ratio))\n\n\ndef _quantized_payload_bytes(parameter_count: int, quantization_bits: int) -> int:\n    return int(math.ceil(parameter_count * quantization_bits / 8))\n\n\ndef _matrix_quantized_payload_bytes(rows: int, cols: int, quantization_bits: int) -> int:\n    return _quantized_payload_bytes(rows * cols, quantization_bits)\n\n\ndef _matrix_quantization_overhead_bytes(rows: int) -> int:\n    return rows * 4 + TENSOR_METADATA_BYTES\n\n\ndef _vector_fp16_bytes(size: int) -> int:\n    return size * 2 + TENSOR_METADATA_BYTES\n\n\ndef _component(\n    name: str,\n    *,\n    parameter_count: int,\n    raw_quantized_bytes: int,\n    tensor_count: int,\n    compression_ratio: float,\n) -> ArtifactComponentEstimate:\n    return ArtifactComponentEstimate(\n        name=name,\n        parameter_count=parameter_count,\n        raw_quantized_bytes=raw_quantized_bytes,\n        estimated_bytes=_compressed_bytes(raw_quantized_bytes, compression_ratio),\n        tensor_count=tensor_count,\n    )\n\n\ndef estimate_artifact_budget(\n    config: Any,\n    *,\n    limit_bytes: int = DEFAULT_LIMIT_BYTES,\n    compression_ratio: float = DEFAULT_COMPRESSION_RATIO,\n    code_path: str | Path | None = None,\n) -> ArtifactBudgetEstimate:\n    vocab_size = _int_attr(config, "vocab_size", 1024)\n    num_layers = _int_attr(config, "num_layers", 9)\n    model_dim = _int_attr(config, "model_dim", _int_attr(config, "dim", 512))\n    num_heads = _int_attr(config, "num_heads", 8)\n    num_kv_heads = _int_attr(config, "num_kv_heads", 4)\n    mlp_mult = _int_attr(config, "mlp_mult", 2)\n    mlp_block_groups = _int_attr(config, "mlp_block_groups", 1)\n    tie_embeddings = _bool_attr(config, "tie_embeddings", True)\n    quantization_bits = _int_attr(config, "quantization_bits", 8)\n    quantization_scheme = str(\n        _attr(config, "quantization_scheme", "int8-per-row-zlib-projection")\n    )\n\n    if model_dim <= 0 or vocab_size <= 0 or num_layers <= 0:\n        raise ValueError("vocab_size, model_dim, and num_layers must be positive")\n    if num_heads <= 0 or num_kv_heads <= 0:\n        raise ValueError("num_heads and num_kv_heads must be positive")\n    if quantization_bits <= 0:\n        raise ValueError("quantization_bits must be positive")\n    if model_dim % num_heads != 0:\n        raise ValueError("model_dim must be divisible by num_heads")\n    if num_heads % num_kv_heads != 0:\n        raise ValueError("num_heads must be divisible by num_kv_heads")\n    if mlp_block_groups <= 0:\n        raise ValueError("mlp_block_groups must be positive")\n    if model_dim % mlp_block_groups != 0:\n        raise ValueError("model_dim must be divisible by mlp_block_groups")\n\n    head_dim = model_dim // num_heads\n    kv_dim = num_kv_heads * head_dim\n    hidden_dim = model_dim * mlp_mult\n    if hidden_dim % mlp_block_groups != 0:\n        raise ValueError("hidden_dim must be divisible by mlp_block_groups")\n\n    embedding_params = vocab_size * model_dim\n    embedding_raw = _matrix_quantized_payload_bytes(\n        vocab_size,\n        model_dim,\n        quantization_bits,\n    )\n    quantization_overhead_raw = _matrix_quantization_overhead_bytes(vocab_size)\n    output_head_params = 0\n    output_head_raw = 0\n    if not tie_embeddings:\n        output_head_params = vocab_size * model_dim\n        output_head_raw = _matrix_quantized_payload_bytes(\n            vocab_size,\n            model_dim,\n            quantization_bits,\n        )\n        quantization_overhead_raw += _matrix_quantization_overhead_bytes(vocab_size)\n\n    attention_params_per_layer = model_dim * model_dim * 2 + model_dim * kv_dim * 2\n    attention_raw_per_layer = (\n        _matrix_quantized_payload_bytes(model_dim, model_dim, quantization_bits)\n        + _matrix_quantized_payload_bytes(kv_dim, model_dim, quantization_bits)\n        + _matrix_quantized_payload_bytes(kv_dim, model_dim, quantization_bits)\n        + _matrix_quantized_payload_bytes(model_dim, model_dim, quantization_bits)\n    )\n    quantization_overhead_raw += num_layers * (\n        _matrix_quantization_overhead_bytes(model_dim)\n        + _matrix_quantization_overhead_bytes(kv_dim)\n        + _matrix_quantization_overhead_bytes(kv_dim)\n        + _matrix_quantization_overhead_bytes(model_dim)\n    )\n    mlp_params_per_layer = (model_dim * hidden_dim * 2) // mlp_block_groups\n    mlp_raw_per_layer = _matrix_quantized_payload_bytes(\n        hidden_dim,\n        model_dim,\n        quantization_bits,\n    ) + _matrix_quantized_payload_bytes(\n        model_dim,\n        hidden_dim,\n        quantization_bits,\n    )\n    mlp_raw_per_layer //= mlp_block_groups\n    quantization_overhead_raw += num_layers * (\n        _matrix_quantization_overhead_bytes(hidden_dim)\n        + _matrix_quantization_overhead_bytes(model_dim)\n    )\n    control_params_per_layer = model_dim * 2 + 1\n    control_raw_per_layer = _vector_fp16_bytes(model_dim) * 2 + _vector_fp16_bytes(1)\n\n    components = [\n        _component(\n            "embeddings",\n            parameter_count=embedding_params,\n            raw_quantized_bytes=embedding_raw,\n            tensor_count=1,\n            compression_ratio=compression_ratio,\n        ),\n        _component(\n            "attention_blocks",\n            parameter_count=attention_params_per_layer * num_layers,\n            raw_quantized_bytes=attention_raw_per_layer * num_layers,\n            tensor_count=4 * num_layers,\n            compression_ratio=compression_ratio,\n        ),\n        _component(\n            "mlp_blocks",\n            parameter_count=mlp_params_per_layer * num_layers,\n            raw_quantized_bytes=mlp_raw_per_layer * num_layers,\n            tensor_count=2 * num_layers,\n            compression_ratio=compression_ratio,\n        ),\n        _component(\n            "control_tensors",\n            parameter_count=control_params_per_layer * num_layers,\n            raw_quantized_bytes=control_raw_per_layer * num_layers,\n            tensor_count=3 * num_layers,\n            compression_ratio=1.0,\n        ),\n        _component(\n            "quantization_overhead",\n            parameter_count=0,\n            raw_quantized_bytes=quantization_overhead_raw,\n            tensor_count=7 * num_layers + (2 if not tie_embeddings else 1),\n            compression_ratio=1.0,\n        ),\n    ]\n    if output_head_params:\n        components.append(\n            _component(\n                "output_head",\n                parameter_count=output_head_params,\n                raw_quantized_bytes=output_head_raw,\n                tensor_count=1,\n                compression_ratio=compression_ratio,\n            )\n        )\n\n    model_estimated_bytes = sum(component.estimated_bytes for component in components)\n    code_estimated_bytes = 0\n    if code_path is not None:\n        path = Path(code_path)\n        if path.exists():\n            code_estimated_bytes = len(zlib.compress(path.read_bytes(), level=9))\n    total_estimated_bytes = model_estimated_bytes + code_estimated_bytes\n\n    return ArtifactBudgetEstimate(\n        limit_bytes=limit_bytes,\n        total_estimated_bytes=total_estimated_bytes,\n        model_estimated_bytes=model_estimated_bytes,\n        code_estimated_bytes=code_estimated_bytes,\n        over_budget=total_estimated_bytes > limit_bytes,\n        headroom_bytes=limit_bytes - total_estimated_bytes,\n        quantization_scheme=quantization_scheme,\n        compression_ratio=compression_ratio,\n        components=tuple(components),\n    )\n\n\ndef _build_parser() -> argparse.ArgumentParser:\n    parser = argparse.ArgumentParser(\n        description="Estimate packed model artifact bytes before training or final packing."\n    )\n    parser.add_argument("--config", type=Path, required=True, help="JSON candidate/model config path.")\n    parser.add_argument(\n        "--code-path",\n        type=Path,\n        default=None,\n        help="Optional training or submission script to include as compressed code bytes.",\n    )\n    parser.add_argument("--limit-bytes", type=int, default=DEFAULT_LIMIT_BYTES)\n    parser.add_argument("--compression-ratio", type=float, default=DEFAULT_COMPRESSION_RATIO)\n    parser.add_argument("--format", choices=("text", "json"), default="text")\n    return parser\n\n\ndef main(argv: list[str] | None = None) -> int:\n    args = _build_parser().parse_args(argv)\n    config = json.loads(args.config.read_text(encoding="utf-8"))\n    if not isinstance(config, dict):\n        raise ValueError("config JSON must contain an object")\n\n    estimate = estimate_artifact_budget(\n        config,\n        limit_bytes=args.limit_bytes,\n        compression_ratio=args.compression_ratio,\n        code_path=args.code_path,\n    )\n    if args.format == "json":\n        print(json.dumps(estimate.to_dict(), indent=2, sort_keys=True))\n    else:\n        for line in estimate.to_log_lines():\n            print(line)\n    return 2 if estimate.over_budget else 0\n\n\nif __name__ == "__main__":\n    raise SystemExit(main(sys.argv[1:]))\n')
+_pg_install_module('candidates.registry', '\nimport importlib\nimport os\nfrom dataclasses import dataclass, field\nfrom typing import Any, Callable\n\n\nModelFactory = Callable[[Any], Any]\n\n\n@dataclass(frozen=True)\nclass CandidateSpec:\n    id: str\n    family: str\n    hypothesis: str\n    hypothesis_tags: tuple[str, ...]\n    quantization: str\n    description: str\n    implementation: str\n    env: dict[str, str] = field(default_factory=dict)\n    runnable: bool = True\n\n    def to_runner_dict(self) -> dict[str, Any]:\n        return {\n            "id": self.id,\n            "family": self.family,\n            "hypothesis": self.hypothesis,\n            "hypothesisTags": list(self.hypothesis_tags),\n            "quantization": self.quantization,\n            "description": self.description,\n            "implementation": self.implementation,\n            "runnable": self.runnable,\n            "env": dict(self.env),\n        }\n\n\ndef _load_module_specs(module_name: str) -> list[CandidateSpec]:\n    module = importlib.import_module(module_name)\n    specs = module.candidate_specs()\n    if not isinstance(specs, list):\n        raise TypeError(f"{module_name}.candidate_specs() must return a list")\n    return specs\n\n\ndef default_candidates() -> list[CandidateSpec]:\n    candidates = []\n    for module_name in (\n        "candidates.autoregressive.candidates",\n        "candidates.moe.candidates",\n    ):\n        candidates.extend(_load_module_specs(module_name))\n    return [candidate for candidate in candidates if candidate.runnable]\n\n\ndef default_candidate_dicts() -> list[dict[str, Any]]:\n    return [candidate.to_runner_dict() for candidate in default_candidates()]\n\n\ndef candidate_name_from_env() -> str:\n    return os.environ.get("CANDIDATE_IMPL", "autoregressive_gpt").strip() or "autoregressive_gpt"\n\n\ndef get_model_factory(name: str) -> ModelFactory:\n    factories: dict[str, str] = {\n        "autoregressive_gpt": "candidates.autoregressive.model:create_model",\n        "routed_moe_gpt": "candidates.moe.model:create_model",\n    }\n    target = factories[name]\n    module_name, function_name = target.split(":", 1)\n    module = importlib.import_module(module_name)\n    factory = getattr(module, function_name)\n    return factory\n\n\ndef build_model(args: Any) -> Any:\n    return get_model_factory(candidate_name_from_env())(args)\n')
+_pg_install_module('candidates.autoregressive.architecture', '\nimport torch\nimport torch.nn.functional as F\nfrom torch import Tensor, nn\n\nclass RMSNorm(nn.Module):\n    def __init__(self, eps: float | None = None):\n        super().__init__()\n        self.eps = eps\n\n    def forward(self, x: Tensor) -> Tensor:\n        return F.rms_norm(x, (x.size(-1),), eps=self.eps)\n\n\nclass CastedLinear(nn.Linear):\n    # Keep weights in fp32 for optimizer/state quality, cast at matmul time for bf16 compute.\n    def forward(self, x: Tensor) -> Tensor:\n        bias = self.bias.to(x.dtype) if self.bias is not None else None\n        return F.linear(x, self.weight.to(x.dtype), bias)\n\n\nclass BlockDiagonalLinear(nn.Module):\n    # Structured block sparsity: each feature group is transformed independently.\n    # The flattened 2D parameter keeps Muon handling identical to dense matrices.\n    def __init__(self, in_features: int, out_features: int, groups: int, bias: bool = False):\n        super().__init__()\n        if groups < 1:\n            raise ValueError("groups must be positive")\n        if in_features % groups != 0 or out_features % groups != 0:\n            raise ValueError(\n                f"in_features={in_features} and out_features={out_features} must be divisible by groups={groups}"\n            )\n        if bias:\n            raise ValueError("BlockDiagonalLinear currently supports bias=False only")\n        self.in_features = in_features\n        self.out_features = out_features\n        self.groups = groups\n        self.in_per_group = in_features // groups\n        self.out_per_group = out_features // groups\n        self.weight = nn.Parameter(torch.empty(out_features, self.in_per_group))\n        nn.init.kaiming_uniform_(self.weight, a=5**0.5)\n\n    def forward(self, x: Tensor) -> Tensor:\n        original_shape = x.shape[:-1]\n        grouped_x = x.reshape(*original_shape, self.groups, self.in_per_group)\n        grouped_w = self.weight.to(dtype=x.dtype).reshape(self.groups, self.out_per_group, self.in_per_group)\n        y = torch.einsum("...gi,goi->...go", grouped_x, grouped_w)\n        return y.reshape(*original_shape, self.out_features)\n\n\ndef restore_low_dim_params_to_fp32(module: nn.Module, control_patterns: tuple[str, ...]) -> None:\n    # Keep small/control parameters in fp32 even when the model body runs in bf16.\n    with torch.no_grad():\n        for name, param in module.named_parameters():\n            is_control = any(pattern in name for pattern in control_patterns)\n            if (param.ndim < 2 or is_control) and param.dtype != torch.float32:\n                param.data = param.data.float()\n\n\nclass Rotary(nn.Module):\n    # Caches cos/sin tables per sequence length on the current device.\n    def __init__(self, dim: int, base: float = 10000.0):\n        super().__init__()\n        inv_freq = 1.0 / (base ** (torch.arange(0, dim, 2, dtype=torch.float32) / dim))\n        self.register_buffer("inv_freq", inv_freq, persistent=False)\n        self._seq_len_cached = 0\n        self._cos_cached: Tensor | None = None\n        self._sin_cached: Tensor | None = None\n\n    def forward(self, seq_len: int, device: torch.device, dtype: torch.dtype) -> tuple[Tensor, Tensor]:\n        if (\n            self._cos_cached is None\n            or self._sin_cached is None\n            or self._seq_len_cached != seq_len\n            or self._cos_cached.device != device\n        ):\n            t = torch.arange(seq_len, device=device, dtype=self.inv_freq.dtype)\n            freqs = torch.outer(t, self.inv_freq.to(device))\n            self._cos_cached = freqs.cos()[None, None, :, :]\n            self._sin_cached = freqs.sin()[None, None, :, :]\n            self._seq_len_cached = seq_len\n        # Validation runs under inference_mode and may populate the cache before\n        # training starts. Clone on return so cached inference tensors are never\n        # reused directly in autograd-tracked CPU subset training.\n        return self._cos_cached.to(dtype=dtype).clone(), self._sin_cached.to(dtype=dtype).clone()\n\n\ndef apply_rotary_emb(x: Tensor, cos: Tensor, sin: Tensor) -> Tensor:\n    half = x.size(-1) // 2\n    x1, x2 = x[..., :half], x[..., half:]\n    return torch.cat((x1 * cos + x2 * sin, x1 * (-sin) + x2 * cos), dim=-1)\n\n\nclass CausalSelfAttention(nn.Module):\n    def __init__(\n        self,\n        dim: int,\n        num_heads: int,\n        num_kv_heads: int,\n        rope_base: float,\n        qk_gain_init: float,\n        attn_norm_mode: str,\n        attn_norm_eps: float,\n        sparse_attn_mode: str,\n        sparse_attn_window: int,\n        sparse_attn_global_tokens: int,\n        sparse_attn_block_size: int,\n    ):\n        super().__init__()\n        if dim % num_heads != 0:\n            raise ValueError("model_dim must be divisible by num_heads")\n        if num_heads % num_kv_heads != 0:\n            raise ValueError("num_heads must be divisible by num_kv_heads")\n        self.num_heads = num_heads\n        self.num_kv_heads = num_kv_heads\n        self.head_dim = dim // num_heads\n        if self.head_dim % 2 != 0:\n            raise ValueError("head_dim must be even for RoPE")\n        kv_dim = self.num_kv_heads * self.head_dim\n        self.c_q = CastedLinear(dim, dim, bias=False)\n        self.c_k = CastedLinear(dim, kv_dim, bias=False)\n        self.c_v = CastedLinear(dim, kv_dim, bias=False)\n        self.proj = CastedLinear(dim, dim, bias=False)\n        self.proj._zero_init = True\n        if attn_norm_mode not in {"baseline", "qk_rmsnorm", "qk_norm_per_head"}:\n            raise ValueError(f"Unsupported ATTN_NORM_MODE={attn_norm_mode!r}")\n        if attn_norm_eps <= 0.0:\n            raise ValueError(f"ATTN_NORM_EPS must be > 0, got {attn_norm_eps}")\n        if sparse_attn_mode not in {\n            "dense",\n            "local_global",\n            "block_local_global",\n            "rotating_block_local_global",\n            "head_swarm_block",\n        }:\n            raise ValueError(f"Unsupported SPARSE_ATTN_MODE={sparse_attn_mode!r}")\n        if sparse_attn_window < 1:\n            raise ValueError(f"SPARSE_ATTN_WINDOW must be >= 1, got {sparse_attn_window}")\n        if sparse_attn_global_tokens < 0:\n            raise ValueError(\n                f"SPARSE_ATTN_GLOBAL_TOKENS must be >= 0, got {sparse_attn_global_tokens}"\n            )\n        if sparse_attn_block_size < 1:\n            raise ValueError(f"SPARSE_ATTN_BLOCK_SIZE must be >= 1, got {sparse_attn_block_size}")\n        self.attn_norm_mode = attn_norm_mode\n        self.attn_norm_eps = attn_norm_eps\n        self.sparse_attn_mode = sparse_attn_mode\n        self.sparse_attn_window = sparse_attn_window\n        self.sparse_attn_global_tokens = sparse_attn_global_tokens\n        self.sparse_attn_block_size = sparse_attn_block_size\n        self.q_gain = nn.Parameter(torch.full((num_heads,), qk_gain_init, dtype=torch.float32))\n        self.rotary = Rotary(self.head_dim, base=rope_base)\n        self._mask_cache_key: tuple[int, torch.device, int, int] | None = None\n        self._mask_cached: Tensor | None = None\n\n    def _normalize_qk(self, q: Tensor, k: Tensor) -> tuple[Tensor, Tensor]:\n        if self.attn_norm_mode == "qk_rmsnorm":\n            q = F.rms_norm(q, (q.size(-1),), eps=self.attn_norm_eps)\n            k = F.rms_norm(k, (k.size(-1),), eps=self.attn_norm_eps)\n            return q, k\n        if self.attn_norm_mode == "qk_norm_per_head":\n            q = F.normalize(q, p=2.0, dim=-1, eps=self.attn_norm_eps)\n            k = F.normalize(k, p=2.0, dim=-1, eps=self.attn_norm_eps)\n            return q, k\n        return q, k\n\n    def _local_global_mask(self, seqlen: int, device: torch.device) -> Tensor:\n        if (\n            self._mask_cached is not None\n            and self._mask_cache_key == (seqlen, device, 0, 0)\n            and self._mask_cached.device == device\n        ):\n            return self._mask_cached\n        positions = torch.arange(seqlen, device=device)\n        query_pos = positions[:, None]\n        key_pos = positions[None, :]\n        causal = key_pos <= query_pos\n        local = key_pos >= (query_pos - self.sparse_attn_window + 1)\n        global_key = key_pos < self.sparse_attn_global_tokens\n        mask = (causal & (local | global_key))[None, None, :, :]\n        self._mask_cached = mask\n        self._mask_cache_key = (seqlen, device, 0, 0)\n        return mask\n\n    def _block_local_global_mask(\n        self,\n        seqlen: int,\n        device: torch.device,\n        pattern_step: int = 0,\n        *,\n        rotating: bool = False,\n    ) -> Tensor:\n        mode_key = 2 if rotating else 1\n        if (\n            self._mask_cached is not None\n            and self._mask_cache_key == (seqlen, device, pattern_step, mode_key)\n            and self._mask_cached.device == device\n        ):\n            return self._mask_cached\n        positions = torch.arange(seqlen, device=device)\n        query_pos = positions[:, None]\n        key_pos = positions[None, :]\n        query_block = query_pos // self.sparse_attn_block_size\n        key_block = key_pos // self.sparse_attn_block_size\n        block_window = max(\n            (self.sparse_attn_window + self.sparse_attn_block_size - 1)\n            // self.sparse_attn_block_size,\n            1,\n        )\n        causal = key_pos <= query_pos\n        local_blocks = key_block >= (query_block - block_window + 1)\n        if rotating:\n            max_stride = max((seqlen + self.sparse_attn_block_size - 1) // self.sparse_attn_block_size, 1)\n            stride = min(2 ** (pattern_step % 6), max_stride)\n            dilated_block = key_block == (query_block - stride)\n            offset_block = key_block == (query_block - stride - block_window)\n            local_blocks = local_blocks | dilated_block | offset_block\n        global_key = key_pos < self.sparse_attn_global_tokens\n        mask = (causal & (local_blocks | global_key))[None, None, :, :]\n        self._mask_cached = mask\n        self._mask_cache_key = (seqlen, device, pattern_step, mode_key)\n        return mask\n\n    def _head_swarm_block_mask(self, seqlen: int, device: torch.device, pattern_step: int) -> Tensor:\n        if (\n            self._mask_cached is not None\n            and self._mask_cache_key == (seqlen, device, pattern_step, 3)\n            and self._mask_cached.device == device\n        ):\n            return self._mask_cached\n        positions = torch.arange(seqlen, device=device)\n        query_pos = positions[:, None]\n        key_pos = positions[None, :]\n        query_block = query_pos // self.sparse_attn_block_size\n        key_block = key_pos // self.sparse_attn_block_size\n        block_window = max(\n            (self.sparse_attn_window + self.sparse_attn_block_size - 1)\n            // self.sparse_attn_block_size,\n            1,\n        )\n        causal = key_pos <= query_pos\n        global_key = key_pos < self.sparse_attn_global_tokens\n        local_blocks = key_block >= (query_block - block_window + 1)\n        head_masks = []\n        max_stride = max((seqlen + self.sparse_attn_block_size - 1) // self.sparse_attn_block_size, 1)\n        for head_index in range(self.num_heads):\n            stride = min(2 ** ((head_index + pattern_step) % 6), max_stride)\n            remote = (key_block == (query_block - stride)) | (key_block == (query_block - stride - block_window))\n            head_masks.append(causal & (local_blocks | global_key | remote))\n        mask = torch.stack(head_masks, dim=0)[None, :, :, :]\n        self._mask_cached = mask\n        self._mask_cache_key = (seqlen, device, pattern_step, 3)\n        return mask\n\n    def forward(self, x: Tensor, pattern_step: int = 0) -> Tensor:\n        bsz, seqlen, dim = x.shape\n        q = self.c_q(x).reshape(bsz, seqlen, self.num_heads, self.head_dim).transpose(1, 2)\n        k = self.c_k(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)\n        v = self.c_v(x).reshape(bsz, seqlen, self.num_kv_heads, self.head_dim).transpose(1, 2)\n        cos, sin = self.rotary(seqlen, x.device, q.dtype)\n        q = apply_rotary_emb(q, cos, sin)\n        k = apply_rotary_emb(k, cos, sin)\n        q, k = self._normalize_qk(q, k)\n        if self.attn_norm_mode == "baseline":\n            q = q * self.q_gain.to(dtype=q.dtype)[None, :, None, None]\n        if self.sparse_attn_mode == "dense":\n            y = F.scaled_dot_product_attention(\n                q,\n                k,\n                v,\n                attn_mask=None,\n                is_causal=True,\n                enable_gqa=(self.num_kv_heads != self.num_heads),\n            )\n        elif self.sparse_attn_mode == "local_global":\n            y = F.scaled_dot_product_attention(\n                q,\n                k,\n                v,\n                attn_mask=self._local_global_mask(seqlen, x.device),\n                is_causal=False,\n                enable_gqa=(self.num_kv_heads != self.num_heads),\n            )\n        elif self.sparse_attn_mode == "block_local_global":\n            y = F.scaled_dot_product_attention(\n                q,\n                k,\n                v,\n                attn_mask=self._block_local_global_mask(seqlen, x.device),\n                is_causal=False,\n                enable_gqa=(self.num_kv_heads != self.num_heads),\n            )\n        elif self.sparse_attn_mode == "rotating_block_local_global":\n            y = F.scaled_dot_product_attention(\n                q,\n                k,\n                v,\n                attn_mask=self._block_local_global_mask(seqlen, x.device, pattern_step, rotating=True),\n                is_causal=False,\n                enable_gqa=(self.num_kv_heads != self.num_heads),\n            )\n        else:\n            y = F.scaled_dot_product_attention(\n                q,\n                k,\n                v,\n                attn_mask=self._head_swarm_block_mask(seqlen, x.device, pattern_step),\n                is_causal=False,\n                enable_gqa=(self.num_kv_heads != self.num_heads),\n            )\n        y = y.transpose(1, 2).contiguous().reshape(bsz, seqlen, dim)\n        return self.proj(y)\n\n\nclass MLP(nn.Module):\n    # relu^2 MLP from the original modded-nanogpt setup\n    def __init__(\n        self,\n        dim: int,\n        mlp_mult: int,\n        activation_mode: str,\n        swiglu_clamp_enabled: bool,\n        swiglu_linear_clamp_min: float,\n        swiglu_linear_clamp_max: float,\n        swiglu_gate_clamp_max: float,\n        block_groups: int = 1,\n    ):\n        super().__init__()\n        hidden = mlp_mult * dim\n        if activation_mode not in {"relu2", "swiglu"}:\n            raise ValueError(f"Unsupported ACTIVATION_MODE: {activation_mode}")\n        if swiglu_linear_clamp_min > swiglu_linear_clamp_max:\n            raise ValueError(\n                "SWIGLU_LINEAR_CLAMP_MIN must be <= SWIGLU_LINEAR_CLAMP_MAX"\n            )\n        if swiglu_gate_clamp_max <= 0.0:\n            raise ValueError("SWIGLU_GATE_CLAMP_MAX must be positive")\n        self.activation_mode = activation_mode\n        self.swiglu_clamp_enabled = swiglu_clamp_enabled\n        self.swiglu_linear_clamp_min = swiglu_linear_clamp_min\n        self.swiglu_linear_clamp_max = swiglu_linear_clamp_max\n        self.swiglu_gate_clamp_max = swiglu_gate_clamp_max\n        self.block_groups = block_groups\n        fc_out = hidden * (2 if activation_mode == "swiglu" else 1)\n        if block_groups == 1:\n            self.fc = CastedLinear(dim, fc_out, bias=False)\n            self.proj = CastedLinear(hidden, dim, bias=False)\n        else:\n            self.fc = BlockDiagonalLinear(dim, fc_out, block_groups, bias=False)\n            self.proj = BlockDiagonalLinear(hidden, dim, block_groups, bias=False)\n        self.proj._zero_init = True\n\n    def forward(self, x: Tensor) -> Tensor:\n        if self.activation_mode == "swiglu":\n            linear, gate = self.fc(x).chunk(2, dim=-1)\n            if self.swiglu_clamp_enabled:\n                linear = torch.clamp(\n                    linear,\n                    min=self.swiglu_linear_clamp_min,\n                    max=self.swiglu_linear_clamp_max,\n                )\n                gate = torch.clamp(gate, max=self.swiglu_gate_clamp_max)\n            return self.proj(linear * F.silu(gate))\n        x = torch.relu(self.fc(x))\n        return self.proj(x.square())\n\n\nclass MoEMLP(nn.Module):\n    def __init__(\n        self,\n        dim: int,\n        mlp_mult: int,\n        activation_mode: str,\n        swiglu_clamp_enabled: bool,\n        swiglu_linear_clamp_min: float,\n        swiglu_linear_clamp_max: float,\n        swiglu_gate_clamp_max: float,\n        num_experts: int,\n        top_k: int,\n        block_groups: int,\n    ):\n        super().__init__()\n        if num_experts < 2:\n            raise ValueError("MOE_NUM_EXPERTS must be >= 2 for MoE")\n        if top_k < 1 or top_k > num_experts:\n            raise ValueError("MOE_TOP_K must be in [1, MOE_NUM_EXPERTS]")\n        self.num_experts = num_experts\n        self.top_k = top_k\n        self.router = CastedLinear(dim, num_experts, bias=False)\n        self.experts = nn.ModuleList(\n            [\n                MLP(\n                    dim,\n                    mlp_mult,\n                    activation_mode,\n                    swiglu_clamp_enabled,\n                    swiglu_linear_clamp_min,\n                    swiglu_linear_clamp_max,\n                    swiglu_gate_clamp_max,\n                    block_groups,\n                )\n                for _ in range(num_experts)\n            ]\n        )\n\n    def forward(self, x: Tensor) -> Tensor:\n        router_logits = self.router(x).float()\n        top_values, top_indices = torch.topk(router_logits, k=self.top_k, dim=-1)\n        top_weights = F.softmax(top_values, dim=-1).to(dtype=x.dtype)\n        result = torch.zeros_like(x)\n        # This is a real routed MoE path. It computes only the selected expert\n        # token subsets, which keeps memory use closer to a production top-k MoE.\n        for expert_index, expert in enumerate(self.experts):\n            selected = top_indices == expert_index\n            if not bool(selected.any()):\n                continue\n            token_mask = selected.any(dim=-1)\n            expert_input = x[token_mask]\n            expert_output = expert(expert_input)\n            weights = (selected.to(dtype=x.dtype) * top_weights).sum(dim=-1)[token_mask]\n            result[token_mask] += expert_output * weights[:, None]\n        return result\n\n\nclass Block(nn.Module):\n    def __init__(\n        self,\n        dim: int,\n        num_heads: int,\n        num_kv_heads: int,\n        mlp_mult: int,\n        rope_base: float,\n        qk_gain_init: float,\n        attn_norm_mode: str,\n        attn_norm_eps: float,\n        sparse_attn_mode: str,\n        sparse_attn_window: int,\n        sparse_attn_global_tokens: int,\n        sparse_attn_block_size: int,\n        activation_mode: str,\n        swiglu_clamp_enabled: bool,\n        swiglu_linear_clamp_min: float,\n        swiglu_linear_clamp_max: float,\n        swiglu_gate_clamp_max: float,\n        parallel_residual: bool,\n        moe_num_experts: int,\n        moe_top_k: int,\n        mlp_block_groups: int,\n    ):\n        super().__init__()\n        self.parallel_residual = parallel_residual\n        self.attn_norm = RMSNorm()\n        self.mlp_norm = RMSNorm()\n        self.attn = CausalSelfAttention(\n            dim,\n            num_heads,\n            num_kv_heads,\n            rope_base,\n            qk_gain_init,\n            attn_norm_mode,\n            attn_norm_eps,\n            sparse_attn_mode,\n            sparse_attn_window,\n            sparse_attn_global_tokens,\n            sparse_attn_block_size,\n        )\n        if moe_num_experts > 1:\n            self.mlp = MoEMLP(\n                dim,\n                mlp_mult,\n                activation_mode,\n                swiglu_clamp_enabled,\n                swiglu_linear_clamp_min,\n                swiglu_linear_clamp_max,\n                swiglu_gate_clamp_max,\n                moe_num_experts,\n                moe_top_k,\n                mlp_block_groups,\n            )\n        else:\n            self.mlp = MLP(\n                dim,\n                mlp_mult,\n                activation_mode,\n                swiglu_clamp_enabled,\n                swiglu_linear_clamp_min,\n                swiglu_linear_clamp_max,\n                swiglu_gate_clamp_max,\n                mlp_block_groups,\n            )\n        self.attn_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))\n        self.mlp_scale = nn.Parameter(torch.ones(dim, dtype=torch.float32))\n        self.resid_mix = nn.Parameter(torch.stack((torch.ones(dim), torch.zeros(dim))).float())\n\n    def forward(self, x: Tensor, x0: Tensor, pattern_step: int = 0) -> Tensor:\n        mix = self.resid_mix.to(dtype=x.dtype)\n        x = mix[0][None, None, :] * x + mix[1][None, None, :] * x0\n        attn_out = self.attn(self.attn_norm(x), pattern_step=pattern_step)\n        if self.parallel_residual:\n            mlp_out = self.mlp(self.mlp_norm(x))\n            x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out\n            x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * mlp_out\n            return x\n        x = x + self.attn_scale.to(dtype=x.dtype)[None, None, :] * attn_out\n        x = x + self.mlp_scale.to(dtype=x.dtype)[None, None, :] * self.mlp(self.mlp_norm(x))\n        return x\n\n\ndef parse_layer_order(spec: str, default: list[int], num_layers: int, label: str) -> list[int]:\n    if not spec:\n        return default\n    tokens = [token.strip() for token in spec.split(",")]\n    if any(not token for token in tokens):\n        raise ValueError(f"{label} contains an empty layer index: {spec!r}")\n    order = [int(token) for token in tokens]\n    for index in order:\n        if index < 0 or index >= num_layers:\n            raise ValueError(f"{label} index {index} is out of range for NUM_LAYERS={num_layers}")\n    return order\n\n\nclass GPT(nn.Module):\n    def __init__(\n        self,\n        vocab_size: int,\n        num_layers: int,\n        model_dim: int,\n        num_heads: int,\n        num_kv_heads: int,\n        mlp_mult: int,\n        tie_embeddings: bool,\n        tied_embed_init_std: float,\n        logit_softcap: float,\n        rope_base: float,\n        qk_gain_init: float,\n        attn_norm_mode: str,\n        attn_norm_eps: float,\n        sparse_attn_mode: str,\n        sparse_attn_window: int,\n        sparse_attn_global_tokens: int,\n        sparse_attn_block_size: int,\n        activation_mode: str,\n        swiglu_clamp_enabled: bool,\n        swiglu_linear_clamp_min: float,\n        swiglu_linear_clamp_max: float,\n        swiglu_gate_clamp_max: float,\n        parallel_residual: bool,\n        encoder_layer_order: str,\n        decoder_layer_order: str,\n        moe_num_experts: int,\n        moe_top_k: int,\n        mlp_block_groups: int,\n        mtp_num_tokens: int,\n        mtp_loss_weight: float,\n    ):\n        super().__init__()\n        if logit_softcap <= 0.0:\n            raise ValueError(f"logit_softcap must be positive, got {logit_softcap}")\n        if mlp_block_groups < 1:\n            raise ValueError(f"MLP_BLOCK_GROUPS must be positive, got {mlp_block_groups}")\n        if mtp_num_tokens < 1:\n            raise ValueError(f"MTP_NUM_TOKENS must be positive, got {mtp_num_tokens}")\n        if mtp_loss_weight < 0.0:\n            raise ValueError(f"MTP_LOSS_WEIGHT must be non-negative, got {mtp_loss_weight}")\n        self.tie_embeddings = tie_embeddings\n        self.tied_embed_init_std = tied_embed_init_std\n        self.logit_softcap = logit_softcap\n        self.mtp_num_tokens = mtp_num_tokens\n        self.mtp_loss_weight = mtp_loss_weight\n        self.tok_emb = nn.Embedding(vocab_size, model_dim)\n        default_num_encoder_layers = num_layers // 2\n        default_encoder_layer_order = list(range(default_num_encoder_layers))\n        default_decoder_layer_order = list(range(default_num_encoder_layers, num_layers))\n        self.encoder_layer_order = parse_layer_order(\n            encoder_layer_order,\n            default_encoder_layer_order,\n            num_layers,\n            "ENCODER_LAYER_ORDER",\n        )\n        self.decoder_layer_order = parse_layer_order(\n            decoder_layer_order,\n            default_decoder_layer_order,\n            num_layers,\n            "DECODER_LAYER_ORDER",\n        )\n        self.num_skip_weights = min(len(self.encoder_layer_order), len(self.decoder_layer_order))\n        self.skip_weights = nn.Parameter(torch.ones(self.num_skip_weights, model_dim, dtype=torch.float32))\n        self.blocks = nn.ModuleList(\n            [\n                Block(\n                    model_dim,\n                    num_heads,\n                    num_kv_heads,\n                    mlp_mult,\n                    rope_base,\n                    qk_gain_init,\n                    attn_norm_mode,\n                    attn_norm_eps,\n                    sparse_attn_mode,\n                    sparse_attn_window,\n                    sparse_attn_global_tokens,\n                    sparse_attn_block_size,\n                    activation_mode,\n                    swiglu_clamp_enabled,\n                    swiglu_linear_clamp_min,\n                    swiglu_linear_clamp_max,\n                    swiglu_gate_clamp_max,\n                    parallel_residual,\n                    moe_num_experts,\n                    moe_top_k,\n                    mlp_block_groups,\n                )\n                for i in range(num_layers)\n            ]\n        )\n        self.final_norm = RMSNorm()\n        self.lm_head = None if tie_embeddings else CastedLinear(model_dim, vocab_size, bias=False)\n        if self.lm_head is not None:\n            self.lm_head._zero_init = True\n        self._init_weights()\n\n    def _init_weights(self) -> None:\n        if self.tie_embeddings:\n            nn.init.normal_(self.tok_emb.weight, mean=0.0, std=self.tied_embed_init_std)\n        for module in self.modules():\n            if isinstance(module, (nn.Linear, BlockDiagonalLinear)) and getattr(module, "_zero_init", False):\n                nn.init.zeros_(module.weight)\n\n    def _project_logits(self, x: Tensor) -> Tensor:\n        if self.tie_embeddings:\n            logits_proj = F.linear(x, self.tok_emb.weight)\n        else:\n            if self.lm_head is None:\n                raise RuntimeError("lm_head is required when tie_embeddings=False")\n            logits_proj = self.lm_head(x)\n        return self.logit_softcap * torch.tanh(logits_proj / self.logit_softcap)\n\n    def forward(self, input_ids: Tensor, target_ids: Tensor) -> Tensor:\n        x = self.tok_emb(input_ids)\n        x = F.rms_norm(x, (x.size(-1),))\n        x0 = x\n        skips: list[Tensor] = []\n        pattern_step = 0\n\n        # First half stores skips; second half reuses them in reverse order.\n        for block_index in self.encoder_layer_order:\n            x = self.blocks[block_index](x, x0, pattern_step=pattern_step)\n            pattern_step += 1\n            skips.append(x)\n        for i, block_index in enumerate(self.decoder_layer_order):\n            if i < self.num_skip_weights and skips:\n                x = x + self.skip_weights[i].to(dtype=x.dtype)[None, None, :] * skips.pop()\n            x = self.blocks[block_index](x, x0, pattern_step=pattern_step)\n            pattern_step += 1\n\n        hidden = self.final_norm(x)\n        logits = self._project_logits(hidden.reshape(-1, hidden.size(-1)))\n        loss = F.cross_entropy(logits.float(), target_ids.reshape(-1), reduction="mean")\n        if self.training and self.mtp_num_tokens > 1 and self.mtp_loss_weight > 0.0:\n            aux_losses = []\n            for offset in range(1, self.mtp_num_tokens):\n                if hidden.size(1) <= offset:\n                    continue\n                aux_logits = self._project_logits(hidden[:, :-offset, :].reshape(-1, hidden.size(-1)))\n                aux_targets = target_ids[:, offset:].reshape(-1)\n                aux_losses.append(F.cross_entropy(aux_logits.float(), aux_targets, reduction="mean"))\n            if aux_losses:\n                loss = loss + self.mtp_loss_weight * torch.stack(aux_losses).mean()\n        return loss\n')
+_pg_install_module('candidates.autoregressive.model', '\nfrom candidates.autoregressive.architecture import (\n    GPT,\n    CastedLinear,\n    MLP,\n    restore_low_dim_params_to_fp32,\n)\n\n\ndef create_model(args):\n    return GPT(\n        vocab_size=args.vocab_size,\n        num_layers=args.num_layers,\n        model_dim=args.model_dim,\n        num_heads=args.num_heads,\n        num_kv_heads=args.num_kv_heads,\n        mlp_mult=args.mlp_mult,\n        tie_embeddings=args.tie_embeddings,\n        tied_embed_init_std=args.tied_embed_init_std,\n        logit_softcap=args.logit_softcap,\n        rope_base=args.rope_base,\n        qk_gain_init=args.qk_gain_init,\n        attn_norm_mode=args.attn_norm_mode,\n        attn_norm_eps=args.attn_norm_eps,\n        sparse_attn_mode=args.sparse_attn_mode,\n        sparse_attn_window=args.sparse_attn_window,\n        sparse_attn_global_tokens=args.sparse_attn_global_tokens,\n        sparse_attn_block_size=args.sparse_attn_block_size,\n        activation_mode=args.activation_mode,\n        swiglu_clamp_enabled=args.swiglu_clamp_enabled,\n        swiglu_linear_clamp_min=args.swiglu_linear_clamp_min,\n        swiglu_linear_clamp_max=args.swiglu_linear_clamp_max,\n        swiglu_gate_clamp_max=args.swiglu_gate_clamp_max,\n        parallel_residual=args.parallel_residual,\n        encoder_layer_order=args.encoder_layer_order,\n        decoder_layer_order=args.decoder_layer_order,\n        moe_num_experts=1,\n        moe_top_k=1,\n        mlp_block_groups=args.mlp_block_groups,\n        mtp_num_tokens=args.mtp_num_tokens,\n        mtp_loss_weight=args.mtp_loss_weight,\n    )\n\n\n__all__ = ["CastedLinear", "MLP", "create_model", "restore_low_dim_params_to_fp32"]\n')
+_pg_install_module('candidates.moe.model', '\nfrom candidates.autoregressive.architecture import GPT\n\n\ndef create_model(args):\n    return GPT(\n        vocab_size=args.vocab_size,\n        num_layers=args.num_layers,\n        model_dim=args.model_dim,\n        num_heads=args.num_heads,\n        num_kv_heads=args.num_kv_heads,\n        mlp_mult=args.mlp_mult,\n        tie_embeddings=args.tie_embeddings,\n        tied_embed_init_std=args.tied_embed_init_std,\n        logit_softcap=args.logit_softcap,\n        rope_base=args.rope_base,\n        qk_gain_init=args.qk_gain_init,\n        attn_norm_mode=args.attn_norm_mode,\n        attn_norm_eps=args.attn_norm_eps,\n        sparse_attn_mode=args.sparse_attn_mode,\n        sparse_attn_window=args.sparse_attn_window,\n        sparse_attn_global_tokens=args.sparse_attn_global_tokens,\n        sparse_attn_block_size=args.sparse_attn_block_size,\n        activation_mode=args.activation_mode,\n        swiglu_clamp_enabled=args.swiglu_clamp_enabled,\n        swiglu_linear_clamp_min=args.swiglu_linear_clamp_min,\n        swiglu_linear_clamp_max=args.swiglu_linear_clamp_max,\n        swiglu_gate_clamp_max=args.swiglu_gate_clamp_max,\n        parallel_residual=args.parallel_residual,\n        encoder_layer_order=args.encoder_layer_order,\n        decoder_layer_order=args.decoder_layer_order,\n        moe_num_experts=args.moe_num_experts,\n        moe_top_k=args.moe_top_k,\n        mlp_block_groups=args.mlp_block_groups,\n        mtp_num_tokens=args.mtp_num_tokens,\n        mtp_loss_weight=args.mtp_loss_weight,\n    )\n')
+_pg_install_module('candidates.autoregressive.candidates', '\nfrom candidates.registry import CandidateSpec\n\n\nIMPLEMENTATION = "autoregressive_gpt"\n\n\ndef candidate_specs() -> list[CandidateSpec]:\n    return [\n        CandidateSpec(\n            id="ar_baseline_int8",\n            family="autoregressive",\n            hypothesis="baseline_control",\n            hypothesis_tags=("control", "autoregressive", "int8_artifact"),\n            quantization="int8-zlib-artifact",\n            description="Repo baseline: 9L 512d GQA transformer with tied embeddings.",\n            implementation=IMPLEMENTATION,\n            env={"CANDIDATE_IMPL": IMPLEMENTATION},\n        ),\n        CandidateSpec(\n            id="ar_nonquant_reference",\n            family="autoregressive",\n            hypothesis="quantization_artifact_cost",\n            hypothesis_tags=("control", "raw_checkpoint", "artifact_size"),\n            quantization="raw-fp32-reference-plus-int8-eval",\n            description="Baseline training kept to compare raw checkpoint size against quantized artifact size.",\n            implementation=IMPLEMENTATION,\n            env={"CANDIDATE_IMPL": IMPLEMENTATION, "RUN_NOTE": "nonquant-reference"},\n        ),\n        CandidateSpec(\n            id="parallel_residual_qk5",\n            family="autoregressive",\n            hypothesis="parallel_residual_improves_optimization",\n            hypothesis_tags=("parallel_residual", "qk_gain", "leaderboard_motif"),\n            quantization="int8-zlib-artifact",\n            description="Parallel residual lane probe with higher QK gain.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "PARALLEL_RESIDUAL": "1",\n                "QK_GAIN_INIT": "5.0",\n                "MATRIX_LR": "0.035",\n            },\n        ),\n        CandidateSpec(\n            id="depth_recurrence_loop45",\n            family="recurrent_autoregressive_transformer",\n            hypothesis="depth_recurrence_increases_compute_per_parameter",\n            hypothesis_tags=("depth_recurrence", "parameter_sharing", "layer_reuse"),\n            quantization="int8-zlib-artifact",\n            description="Reuses real transformer blocks to test depth-recurrence style parameter sharing pressure.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "ENCODER_LAYER_ORDER": "0,1,2,3,4,5",\n                "DECODER_LAYER_ORDER": "4,5,6,7,8",\n                "QK_GAIN_INIT": "5.0",\n            },\n        ),\n        CandidateSpec(\n            id="swiglu_clamped",\n            family="autoregressive_mlp",\n            hypothesis="swiglu_clamps_improve_capacity_stability",\n            hypothesis_tags=("swiglu", "activation_clamp", "mlp"),\n            quantization="int8-zlib-artifact",\n            description="SwiGLU MLP with conservative activation clamps.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "ACTIVATION_MODE": "swiglu",\n                "SWIGLU_CLAMP_ENABLED": "1",\n                "SWIGLU_LINEAR_CLAMP_MIN": "-10",\n                "SWIGLU_LINEAR_CLAMP_MAX": "10",\n                "SWIGLU_GATE_CLAMP_MAX": "10",\n                "MLP_MULT": "2",\n            },\n        ),\n        CandidateSpec(\n            id="qk_rmsnorm_longctx",\n            family="long_context_autoregressive",\n            hypothesis="long_context_qk_norm_improves_byte_compression",\n            hypothesis_tags=("long_context", "qk_norm", "stability"),\n            quantization="int8-zlib-artifact",\n            description="Longer context plus QK RMSNorm to test stability under 2048-token training.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "TRAIN_SEQ_LEN": "2048",\n                "TRAIN_BATCH_TOKENS": "524288",\n                "ATTN_NORM_MODE": "qk_rmsnorm",\n                "ATTN_NORM_EPS": "1e-5",\n                "QK_GAIN_INIT": "1.0",\n            },\n        ),\n        CandidateSpec(\n            id="local_global_sparse_attention",\n            family="sparse_attention_autoregressive",\n            hypothesis="local_global_sparse_attention_reduces_dependencies_with_global_summary_tokens",\n            hypothesis_tags=("sparse_attention", "local_window", "global_tokens", "throughput"),\n            quantization="int8-zlib-artifact",\n            description=(\n                "Local-window causal attention with a small number of global source tokens, "\n                "kept behind an explicit dense fallback."\n            ),\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "SPARSE_ATTN_MODE": "local_global",\n                "SPARSE_ATTN_WINDOW": "256",\n                "SPARSE_ATTN_GLOBAL_TOKENS": "4",\n                "PARALLEL_RESIDUAL": "1",\n                "QK_GAIN_INIT": "5.25",\n            },\n        ),\n        CandidateSpec(\n            id="wide_shallow",\n            family="autoregressive_shape",\n            hypothesis="width_beats_depth_at_fixed_artifact_budget",\n            hypothesis_tags=("shape", "wide", "shallow"),\n            quantization="int8-zlib-artifact",\n            description="Fewer wider layers to test width versus depth under the same artifact budget.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "NUM_LAYERS": "7",\n                "MODEL_DIM": "608",\n                "NUM_HEADS": "8",\n                "NUM_KV_HEADS": "4",\n                "MLP_MULT": "2",\n            },\n        ),\n        CandidateSpec(\n            id="narrow_deep",\n            family="autoregressive_shape",\n            hypothesis="depth_beats_width_at_fixed_artifact_budget",\n            hypothesis_tags=("shape", "narrow", "deep"),\n            quantization="int8-zlib-artifact",\n            description="More narrower layers to test depth and computation density.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "NUM_LAYERS": "13",\n                "MODEL_DIM": "448",\n                "NUM_HEADS": "7",\n                "NUM_KV_HEADS": "1",\n                "MLP_MULT": "2",\n            },\n        ),\n    ]\n')
+_pg_install_module('candidates.moe.candidates', '\nfrom candidates.registry import CandidateSpec\n\n\nIMPLEMENTATION = "routed_moe_gpt"\n\n\ndef candidate_specs() -> list[CandidateSpec]:\n    return [\n        CandidateSpec(\n            id="moe_top2_4expert",\n            family="mixture_of_experts",\n            hypothesis="top2_moe_increases_conditional_capacity_under_artifact_budget",\n            hypothesis_tags=("moe", "top2_routing", "conditional_capacity"),\n            quantization="int8-zlib-artifact",\n            description="Real routed MoE with a learned token router, 4 experts, and top-2 expert weighting.",\n            implementation=IMPLEMENTATION,\n            env={\n                "CANDIDATE_IMPL": IMPLEMENTATION,\n                "NUM_LAYERS": "5",\n                "MODEL_DIM": "384",\n                "NUM_HEADS": "6",\n                "NUM_KV_HEADS": "3",\n                "MLP_MULT": "2",\n                "MOE_NUM_EXPERTS": "4",\n                "MOE_TOP_K": "2",\n            },\n        )\n    ]\n')
+del _pg_install_module, _pg_install_package, _pg_sys, _pg_types
+# --- End bundled local modules ---
+"""
+The `train_gpt.py` and `train_gpt_mlx.py` scripts are intended as good launching-off points for new participants, not SOTA configs. We'll accept PRs that tune, improve, or simplify these scripts without significantly increasing complexity, but competitive submissions should stay in the `/records` folder.
+
+Hard stop: To keep readable for newcomers, let's make sure `train_gpt.py` and `train_gpt_mlx.py` never are longer than 1500 lines.
+"""
+
+
+import copy
+import glob
+import io
+import math
+import os
+import random
+import subprocess
+import sys
+import time
+import uuid
+import zlib
+from pathlib import Path
+
+import numpy as np
+import sentencepiece as spm
+import torch
+import torch.distributed as dist
+from torch import Tensor, nn
+from torch.nn.parallel import DistributedDataParallel as DDP
+
+sys.modules.setdefault("train_gpt", sys.modules[__name__])
+from candidates.registry import build_model, candidate_name_from_env
+from fastest.scripts.artifact_budget_analyzer import estimate_artifact_budget
+
+
+def submission_code_files(main_file: Path) -> list[Path]:
+    raw_paths = os.environ.get("SUBMISSION_CODE_PATHS", "").strip()
+    if not raw_paths:
+        return [main_file]
+
+    script_dir = main_file.parent
+    files: set[Path] = {main_file.resolve()}
+    for raw in raw_paths.split(","):
+        raw = raw.strip()
+        if not raw:
+            continue
+        path = Path(raw)
+        if not path.is_absolute():
+            path = script_dir / path
+        if path.is_dir():
+            files.update(
+                item.resolve()
+                for item in path.rglob("*.py")
+                if "__pycache__" not in item.parts
+            )
+        elif path.is_file():
+            files.add(path.resolve())
+    return sorted(files)
+
+
+def submission_code_size_bytes(main_file: Path) -> int:
+    return sum(path.stat().st_size for path in submission_code_files(main_file))
+
+# -----------------------------
+# HYPERPARAMETERS
+# -----------------------------
+# Default Simple Baseline run:
+# - 9 transformer blocks at width 512
+# - 8 attention heads with 4 KV heads (GQA) and 2x MLP expansion
+# - vocab size 1024, sequence length 1024, tied embeddings
+# - 524,288 train tokens per step for 20,000 iterations with a ~10 minute cap
+
+class Hyperparameters:
+    # Data paths are shard globs produced by the existing preprocessing pipeline.
+    data_path = os.environ.get("DATA_PATH", "./data/datasets/fineweb10B_sp1024")
+    train_files = os.path.join(data_path, "fineweb_train_*.bin")
+    val_files = os.path.join(data_path, "fineweb_val_*.bin")
+    tokenizer_path = os.environ.get("TOKENIZER_PATH", "./data/tokenizers/fineweb_1024_bpe.model")
+    run_id = os.environ.get("RUN_ID", str(uuid.uuid4()))
+    seed = int(os.environ.get("SEED", 1337))
+
+    # Validation cadence and batch size. Validation always uses the full fineweb_val split.
+    val_batch_size = int(os.environ.get("VAL_BATCH_SIZE", 524_288))
+    val_loss_every = int(os.environ.get("VAL_LOSS_EVERY", 1000))
+    train_log_every = int(os.environ.get("TRAIN_LOG_EVERY", 200))
+
+    # Training length.
+    iterations = int(os.environ.get("ITERATIONS", 20000))
+    warmdown_iters = int(os.environ.get("WARMDOWN_ITERS", 1200))
+    warmup_steps = int(os.environ.get("WARMUP_STEPS", 20))
+    train_batch_tokens = int(os.environ.get("TRAIN_BATCH_TOKENS", 524_288))
+    train_seq_len = int(os.environ.get("TRAIN_SEQ_LEN", 1024))
+    max_wallclock_seconds = float(os.environ.get("MAX_WALLCLOCK_SECONDS", 600.0))
+    qk_gain_init = float(os.environ.get("QK_GAIN_INIT", 1.5))
+    attn_norm_mode = os.environ.get("ATTN_NORM_MODE", "baseline").strip().lower()
+    attn_norm_eps = float(os.environ.get("ATTN_NORM_EPS", 1e-6))
+    sparse_attn_mode = os.environ.get("SPARSE_ATTN_MODE", "dense").strip().lower()
+    sparse_attn_window = int(os.environ.get("SPARSE_ATTN_WINDOW", "256"))
+    sparse_attn_global_tokens = int(os.environ.get("SPARSE_ATTN_GLOBAL_TOKENS", "4"))
+    sparse_attn_block_size = int(os.environ.get("SPARSE_ATTN_BLOCK_SIZE", "64"))
+    activation_mode = os.environ.get("ACTIVATION_MODE", "relu2").strip().lower()
+    swiglu_clamp_enabled = bool(int(os.environ.get("SWIGLU_CLAMP_ENABLED", "0")))
+    swiglu_linear_clamp_min = float(os.environ.get("SWIGLU_LINEAR_CLAMP_MIN", -10.0))
+    swiglu_linear_clamp_max = float(os.environ.get("SWIGLU_LINEAR_CLAMP_MAX", 10.0))
+    swiglu_gate_clamp_max = float(os.environ.get("SWIGLU_GATE_CLAMP_MAX", 10.0))
+    mlp_block_groups = int(os.environ.get("MLP_BLOCK_GROUPS", "1"))
+    mtp_num_tokens = int(os.environ.get("MTP_NUM_TOKENS", "1"))
+    mtp_loss_weight = float(os.environ.get("MTP_LOSS_WEIGHT", "0.0"))
+    moe_num_experts = int(os.environ.get("MOE_NUM_EXPERTS", "1"))
+    moe_top_k = int(os.environ.get("MOE_TOP_K", "1"))
+    candidate_impl = os.environ.get("CANDIDATE_IMPL", "autoregressive_gpt").strip() or "autoregressive_gpt"
+    torch_compile = bool(int(os.environ.get("TORCH_COMPILE", "1")))
+
+    # Model shape.
+    vocab_size = int(os.environ.get("VOCAB_SIZE", 1024))
+    num_layers = int(os.environ.get("NUM_LAYERS", 9))
+    num_kv_heads = int(os.environ.get("NUM_KV_HEADS", 4))
+    model_dim = int(os.environ.get("MODEL_DIM", 512))
+    num_heads = int(os.environ.get("NUM_HEADS", 8))
+    mlp_mult = int(os.environ.get("MLP_MULT", 2))
+    tie_embeddings = bool(int(os.environ.get("TIE_EMBEDDINGS", "1")))
+    rope_base = float(os.environ.get("ROPE_BASE", 10000.0))
+    logit_softcap = float(os.environ.get("LOGIT_SOFTCAP", 30.0))
+    parallel_residual = bool(int(os.environ.get("PARALLEL_RESIDUAL", "0")))
+    encoder_layer_order = os.environ.get("ENCODER_LAYER_ORDER", "").strip()
+    decoder_layer_order = os.environ.get("DECODER_LAYER_ORDER", "").strip()
+
+    # Optimizer hyperparameters.
+    embed_lr = float(os.environ.get("EMBED_LR", 0.6))
+    head_lr = float(os.environ.get("HEAD_LR", 0.008))
+    tied_embed_lr = float(os.environ.get("TIED_EMBED_LR", 0.05))
+    tied_embed_init_std = float(os.environ.get("TIED_EMBED_INIT_STD", 0.005))
+    matrix_lr = float(os.environ.get("MATRIX_LR", 0.04))
+    scalar_lr = float(os.environ.get("SCALAR_LR", 0.04))
+    muon_momentum = float(os.environ.get("MUON_MOMENTUM", 0.95))
+    muon_backend_steps = int(os.environ.get("MUON_BACKEND_STEPS", 5))
+    muon_momentum_warmup_start = float(os.environ.get("MUON_MOMENTUM_WARMUP_START", 0.85))
+    muon_momentum_warmup_steps = int(os.environ.get("MUON_MOMENTUM_WARMUP_STEPS", 500))
+    beta1 = float(os.environ.get("BETA1", 0.9))
+    beta2 = float(os.environ.get("BETA2", 0.95))
+    adam_eps = float(os.environ.get("ADAM_EPS", 1e-8))
+    grad_clip_norm = float(os.environ.get("GRAD_CLIP_NORM", 0.0))
+    local_sgd_sync_steps = int(os.environ.get("LOCAL_SGD_SYNC_STEPS", "1"))
+    local_sgd_average_optimizer_states = bool(int(os.environ.get("LOCAL_SGD_AVERAGE_OPTIMIZER_STATES", "0")))
+
+# -----------------------------
+# MUON OPTIMIZER 
+# -----------------------------
+# 
+# As borrowed from modded-nanogpt
+# Background on Muon: https://kellerjordan.github.io/posts/muon/
+
+def zeropower_via_newtonschulz5(G: Tensor, steps: int = 10, eps: float = 1e-7) -> Tensor:
+    # Orthogonalize a 2D update matrix with a fast Newton-Schulz iteration.
+    # Muon uses this to normalize matrix-shaped gradients before applying them.
+    a, b, c = (3.4445, -4.7750, 2.0315)
+    X = G.bfloat16()
+    X /= X.norm() + eps
+    transposed = G.size(0) > G.size(1)
+    if transposed:
+        X = X.T
+    for _ in range(steps):
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+    return X.T if transposed else X
+
+
+class Muon(torch.optim.Optimizer):
+    def __init__(
+        self,
+        params,
+        lr: float,
+        momentum: float,
+        backend_steps: int,
+        nesterov: bool = True,
+        distributed_reduce: bool = True,
+    ):
+        super().__init__(
+            params,
+            dict(
+                lr=lr,
+                momentum=momentum,
+                backend_steps=backend_steps,
+                nesterov=nesterov,
+                distributed_reduce=distributed_reduce,
+            ),
+        )
+
+    @torch.no_grad()
+    def step(self, closure=None):
+        loss = None
+        if closure is not None:
+            with torch.enable_grad():
+                loss = closure()
+
+        for group in self.param_groups:
+            params = group["params"]
+            if not params:
+                continue
+            lr = group["lr"]
+            momentum = group["momentum"]
+            backend_steps = group["backend_steps"]
+            nesterov = group["nesterov"]
+            distributed_reduce = group["distributed_reduce"]
+            distributed = dist.is_available() and dist.is_initialized()
+            shard_world_size = dist.get_world_size() if distributed and distributed_reduce else 1
+            shard_rank = dist.get_rank() if distributed and distributed_reduce else 0
+
+            total_params = sum(int(p.numel()) for p in params)
+            updates_flat = torch.zeros(total_params, device=params[0].device, dtype=torch.bfloat16)
+
+            curr = 0
+            for i, p in enumerate(params):
+                if i % shard_world_size == shard_rank and p.grad is not None:
+                    g = p.grad
+                    state = self.state[p]
+                    if "momentum_buffer" not in state:
+                        state["momentum_buffer"] = torch.zeros_like(g)
+                    buf = state["momentum_buffer"]
+                    buf.mul_(momentum).add_(g)
+                    if nesterov:
+                        g = g.add(buf, alpha=momentum)
+                    g = zeropower_via_newtonschulz5(g, steps=backend_steps)
+                    # Scale correction from Muon reference implementations.
+                    g *= max(1, g.size(0) / g.size(1)) ** 0.5
+                    updates_flat[curr : curr + p.numel()] = g.reshape(-1)
+                curr += p.numel()
+
+            if distributed and distributed_reduce:
+                dist.all_reduce(updates_flat, op=dist.ReduceOp.SUM)
+
+            curr = 0
+            for p in params:
+                g = updates_flat[curr : curr + p.numel()].view_as(p).to(dtype=p.dtype)
+                p.add_(g, alpha=-lr)
+                curr += p.numel()
+
+        return loss
+
+
+# -----------------------------
+# TOKENIZER-AGNOSTIC EVALUATION SETUP 
+# -----------------------------
+#
+# It's common for small models have a large fraction of their parameters be embeddings, since the 2 * d_model * d_vocab vectors can be gigantic.
+# Instead of locking the tokenizer, we let you bring your own and calculate our validation metrics on the average compression of the validation set.
+# We calculate BPB (bits-per-byte) instead of validation loss, so we need methods to count the number of bits per token in the tokenizer.
+# Note: Submissions that edit the tokenizer will be examined more carefully, since screwing this up might unjustly improve your score.
+
+def build_sentencepiece_luts(
+    sp: spm.SentencePieceProcessor, vocab_size: int, device: torch.device
+) -> tuple[Tensor, Tensor, Tensor]:
+    sp_vocab_size = int(sp.vocab_size())
+    table_size = max(sp_vocab_size, vocab_size)
+    base_bytes_np = np.zeros((table_size,), dtype=np.int16)
+    has_leading_space_np = np.zeros((table_size,), dtype=np.bool_)
+    is_boundary_token_np = np.ones((table_size,), dtype=np.bool_)
+    for token_id in range(sp_vocab_size):
+        if sp.is_control(token_id) or sp.is_unknown(token_id) or sp.is_unused(token_id):
+            continue
+        is_boundary_token_np[token_id] = False
+        if sp.is_byte(token_id):
+            base_bytes_np[token_id] = 1
+            continue
+        piece = sp.id_to_piece(token_id)
+        if piece.startswith("▁"):
+            has_leading_space_np[token_id] = True
+            piece = piece[1:]
+        base_bytes_np[token_id] = len(piece.encode("utf-8"))
+    return (
+        torch.tensor(base_bytes_np, dtype=torch.int16, device=device),
+        torch.tensor(has_leading_space_np, dtype=torch.bool, device=device),
+        torch.tensor(is_boundary_token_np, dtype=torch.bool, device=device),
+    )
+
+
+def load_validation_tokens(pattern: str, seq_len: int) -> Tensor:
+    files = [Path(p) for p in sorted(glob.glob(pattern))]
+    if not files:
+        raise FileNotFoundError(f"No files found for pattern: {pattern}")
+    # The export pipeline writes the fixed first-50k-doc validation set to fineweb_val_*.
+    tokens = torch.cat([load_data_shard(file) for file in files]).contiguous()
+    token_limit = int(os.environ.get("VAL_TOKEN_LIMIT", "0"))
+    if token_limit > 0:
+        tokens = tokens[: min(tokens.numel(), token_limit + 1)]
+    usable = ((tokens.numel() - 1) // seq_len) * seq_len
+    if usable <= 0:
+        raise ValueError(f"Validation split is too short for TRAIN_SEQ_LEN={seq_len}")
+    return tokens[: usable + 1]
+
+
+def eval_val(
+    args: Hyperparameters,
+    model: nn.Module,
+    rank: int,
+    world_size: int,
+    device: torch.device,
+    grad_accum_steps: int,
+    val_tokens: Tensor,
+    base_bytes_lut: Tensor,
+    has_leading_space_lut: Tensor,
+    is_boundary_token_lut: Tensor,
+) -> tuple[float, float]:
+    # Validation computes two metrics:
+    # - val_loss: token cross-entropy (natural log)
+    # - val_bpb: tokenizer-agnostic compression metric used by the challenge
+    local_batch_tokens = args.val_batch_size // world_size
+    if local_batch_tokens < args.train_seq_len:
+        raise ValueError(
+            "VAL_BATCH_SIZE must provide at least one sequence per rank; "
+            f"got VAL_BATCH_SIZE={args.val_batch_size}, WORLD_SIZE={world_size}, "
+            f"TRAIN_SEQ_LEN={args.train_seq_len}"
+        )
+    local_batch_seqs = local_batch_tokens // args.train_seq_len
+    total_seqs = (val_tokens.numel() - 1) // args.train_seq_len
+    seq_start = (total_seqs * rank) // world_size
+    seq_end = (total_seqs * (rank + 1)) // world_size
+    progress_every = int(os.environ.get("VAL_PROGRESS_EVERY", "0"))
+    num_batches = max((seq_end - seq_start + local_batch_seqs - 1) // local_batch_seqs, 1)
+    val_loss_sum = torch.zeros((), device=device, dtype=torch.float64)
+    val_token_count = torch.zeros((), device=device, dtype=torch.float64)
+    val_byte_count = torch.zeros((), device=device, dtype=torch.float64)
+
+    model.eval()
+    with torch.inference_mode():
+        for batch_idx, batch_seq_start in enumerate(range(seq_start, seq_end, local_batch_seqs), start=1):
+            batch_seq_end = min(batch_seq_start + local_batch_seqs, seq_end)
+            raw_start = batch_seq_start * args.train_seq_len
+            raw_end = batch_seq_end * args.train_seq_len + 1
+            local = val_tokens[raw_start:raw_end].to(device=device, dtype=torch.int64, non_blocking=True)
+            x = local[:-1].reshape(-1, args.train_seq_len)
+            y = local[1:].reshape(-1, args.train_seq_len)
+            with torch.autocast(
+                device_type=device.type,
+                dtype=torch.bfloat16,
+                enabled=device.type == "cuda",
+            ):
+                batch_loss = model(x, y).detach()
+            batch_token_count = float(y.numel())
+            val_loss_sum += batch_loss.to(torch.float64) * batch_token_count
+            val_token_count += batch_token_count
+            prev_ids = x.reshape(-1)
+            tgt_ids = y.reshape(-1)
+            token_bytes = base_bytes_lut[tgt_ids].to(dtype=torch.int16)
+            token_bytes += (has_leading_space_lut[tgt_ids] & ~is_boundary_token_lut[prev_ids]).to(dtype=torch.int16)
+            val_byte_count += token_bytes.to(torch.float64).sum()
+            if rank == 0 and progress_every > 0 and (batch_idx % progress_every == 0 or batch_idx == num_batches):
+                print(
+                    f"val_progress:{batch_idx}/{num_batches} val_tokens:{int(val_token_count.item())}",
+                    flush=True,
+                )
+
+    if dist.is_available() and dist.is_initialized():
+        dist.all_reduce(val_loss_sum, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_token_count, op=dist.ReduceOp.SUM)
+        dist.all_reduce(val_byte_count, op=dist.ReduceOp.SUM)
+
+    val_loss = val_loss_sum / val_token_count
+    bits_per_token = val_loss.item() / math.log(2.0)
+    tokens_per_byte = val_token_count.item() / val_byte_count.item()
+    model.train()
+    return float(val_loss.item()), float(bits_per_token * tokens_per_byte)
+
+# -----------------------------
+# POST-TRAINING QUANTIZATION
+# -----------------------------
+#
+# It's silly to export our model, which is trained in bf16 and fp32, at that same precision.
+# Instead, we get approximately the same model (with a small hit) by quantizing the model to int8 & zlib compressing.
+# We can then decompress the model and run in higher precision for evaluation, after closing in under the size limit.
+
+CONTROL_TENSOR_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "CONTROL_TENSOR_NAME_PATTERNS",
+        "attn_scale,attn_scales,mlp_scale,mlp_scales,resid_mix,resid_mixes,q_gain,skip_weight,skip_weights",
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_FP32_NAME_PATTERNS = tuple(
+    pattern
+    for pattern in os.environ.get(
+        "INT8_KEEP_FLOAT_FP32_NAME_PATTERNS",
+        ",".join(CONTROL_TENSOR_NAME_PATTERNS),
+    ).split(",")
+    if pattern
+)
+INT8_KEEP_FLOAT_MAX_NUMEL = 65_536
+INT8_KEEP_FLOAT_STORE_DTYPE = torch.float16
+INT8_PER_ROW_SCALE_DTYPE = torch.float16
+INT8_CLIP_PERCENTILE = 99.99984
+INT8_CLIP_Q = INT8_CLIP_PERCENTILE / 100.0
+
+def tensor_nbytes(t: Tensor) -> int:
+    return int(t.numel()) * int(t.element_size())
+
+def keep_float_tensor(name: str, t: Tensor, passthrough_orig_dtypes: dict[str, str]) -> Tensor:
+    if any(pattern in name for pattern in INT8_KEEP_FLOAT_FP32_NAME_PATTERNS):
+        return t.float().contiguous()
+    if t.dtype in {torch.float32, torch.bfloat16}:
+        passthrough_orig_dtypes[name] = str(t.dtype).removeprefix("torch.")
+        return t.to(dtype=INT8_KEEP_FLOAT_STORE_DTYPE).contiguous()
+    return t
+
+def quantize_float_tensor(t: Tensor) -> tuple[Tensor, Tensor]:
+    t32 = t.float()
+    if t32.ndim == 2:
+        # Matrices get one scale per row, which usually tracks output-channel
+        # ranges much better than a single tensor-wide scale.
+        clip_abs = (
+            torch.quantile(t32.abs(), INT8_CLIP_Q, dim=1)
+            if t32.numel()
+            else torch.empty((t32.shape[0],), dtype=torch.float32)
+        )
+        clipped = torch.maximum(torch.minimum(t32, clip_abs[:, None]), -clip_abs[:, None])
+        scale = (clip_abs / 127.0).clamp_min(1.0 / 127.0)
+        q = torch.clamp(torch.round(clipped / scale[:, None]), -127, 127).to(torch.int8).contiguous()
+        return q, scale.to(dtype=INT8_PER_ROW_SCALE_DTYPE).contiguous()
+
+    # Vectors / scalars use a simpler per-tensor scale.
+    clip_abs = float(torch.quantile(t32.abs().flatten(), INT8_CLIP_Q).item()) if t32.numel() else 0.0
+    scale = torch.tensor(clip_abs / 127.0 if clip_abs > 0 else 1.0, dtype=torch.float32)
+    q = torch.clamp(torch.round(torch.clamp(t32, -clip_abs, clip_abs) / scale), -127, 127).to(torch.int8).contiguous()
+    return q, scale
+
+def quantize_state_dict_int8(state_dict: dict[str, Tensor]):
+    # Single supported clean-script export format:
+    # - per-row int8 for 2D float tensors
+    # - per-tensor int8 for other float tensors
+    # - exact passthrough for non-floats
+    # - passthrough for small float tensors, stored as fp16 to save bytes
+    quantized: dict[str, Tensor] = {}
+    scales: dict[str, Tensor] = {}
+    dtypes: dict[str, str] = {}
+    passthrough: dict[str, Tensor] = {}
+    passthrough_orig_dtypes: dict[str, str] = {}
+    qmeta: dict[str, dict[str, object]] = {}
+    stats = dict.fromkeys(
+        ("param_count", "num_tensors", "num_float_tensors", "num_nonfloat_tensors", "baseline_tensor_bytes", "int8_payload_bytes"),
+        0,
+    )
+
+    for name, tensor in state_dict.items():
+        t = tensor.detach().to("cpu").contiguous()
+        stats["param_count"] += int(t.numel())
+        stats["num_tensors"] += 1
+        stats["baseline_tensor_bytes"] += tensor_nbytes(t)
+
+        if not t.is_floating_point():
+            stats["num_nonfloat_tensors"] += 1
+            passthrough[name] = t
+            stats["int8_payload_bytes"] += tensor_nbytes(t)
+            continue
+
+        # Small float tensors are cheap enough to keep directly. We still downcast
+        # fp32/bf16 passthrough tensors to fp16 so metadata does not dominate size.
+        if t.numel() <= INT8_KEEP_FLOAT_MAX_NUMEL:
+            kept = keep_float_tensor(name, t, passthrough_orig_dtypes)
+            passthrough[name] = kept
+            stats["int8_payload_bytes"] += tensor_nbytes(kept)
+            continue
+
+        stats["num_float_tensors"] += 1
+        q, s = quantize_float_tensor(t)
+        if s.ndim > 0:
+            qmeta[name] = {"scheme": "per_row", "axis": 0}
+        quantized[name] = q
+        scales[name] = s
+        dtypes[name] = str(t.dtype).removeprefix("torch.")
+        stats["int8_payload_bytes"] += tensor_nbytes(q) + tensor_nbytes(s)
+
+    obj: dict[str, object] = {
+        "__quant_format__": "int8_clean_per_row_v1",
+        "quantized": quantized,
+        "scales": scales,
+        "dtypes": dtypes,
+        "passthrough": passthrough,
+    }
+    if qmeta:
+        obj["qmeta"] = qmeta
+    if passthrough_orig_dtypes:
+        obj["passthrough_orig_dtypes"] = passthrough_orig_dtypes
+    return obj, stats
+
+def dequantize_state_dict_int8(obj: dict[str, object]) -> dict[str, Tensor]:
+    out: dict[str, Tensor] = {}
+    qmeta = obj.get("qmeta", {})
+    passthrough_orig_dtypes = obj.get("passthrough_orig_dtypes", {})
+    for name, q in obj["quantized"].items():
+        dtype = getattr(torch, obj["dtypes"][name])
+        s = obj["scales"][name]
+        if qmeta.get(name, {}).get("scheme") == "per_row" or s.ndim > 0:
+            s = s.to(dtype=torch.float32)
+            # Broadcast the saved row scale back across trailing dimensions.
+            out[name] = (q.float() * s.view(q.shape[0], *([1] * (q.ndim - 1)))).to(dtype=dtype).contiguous()
+        else:
+            scale = float(s.item())
+            out[name] = (q.float() * scale).to(dtype=dtype).contiguous()
+    for name, t in obj["passthrough"].items():
+        # Restore small tensors, undoing the temporary fp16 storage cast if needed.
+        out_t = t.detach().to("cpu").contiguous()
+        orig_dtype = passthrough_orig_dtypes.get(name)
+        if isinstance(orig_dtype, str):
+            out_t = out_t.to(dtype=getattr(torch, orig_dtype)).contiguous()
+        out[name] = out_t
+    return out
+
+
+# -----------------------------
+# DATA LOADING 
+# -----------------------------
+
+def load_data_shard(file: Path) -> Tensor:
+    header_bytes = 256 * np.dtype("<i4").itemsize
+    token_bytes = np.dtype("<u2").itemsize
+    header = np.fromfile(file, dtype="<i4", count=256)
+    # SHARD HEADER INTS & SHARD_MAGIC
+    if header.size != 256 or int(header[0]) != 20240520 or int(header[1]) != 1:
+        raise ValueError(f"Unexpected shard header for {file}")
+    num_tokens = int(header[2])
+    expected_size = header_bytes + num_tokens * token_bytes
+    if file.stat().st_size != expected_size:
+        raise ValueError(f"Shard size mismatch for {file}: expected {expected_size} bytes")
+    tokens_np = np.fromfile(file, dtype="<u2", count=num_tokens, offset=header_bytes)
+    if tokens_np.size != num_tokens:
+        raise ValueError(f"Short read for {file}")
+    return torch.from_numpy(tokens_np.astype(np.uint16, copy=False))
+
+
+class TokenStream:
+    # Reads shards sequentially and wraps around forever. The training loop therefore
+    # has deterministic, simple streaming behavior with no sampling or workers.
+    def __init__(self, pattern: str):
+        self.files = [Path(p) for p in sorted(glob.glob(pattern))]
+        if not self.files:
+            raise FileNotFoundError(f"No files found for pattern: {pattern}")
+        self.file_idx = 0
+        self.tokens = load_data_shard(self.files[0])
+        self.pos = 0
+
+    def _advance_file(self) -> None:
+        self.file_idx = (self.file_idx + 1) % len(self.files)
+        self.tokens = load_data_shard(self.files[self.file_idx])
+        self.pos = 0
+
+    def take(self, n: int) -> Tensor:
+        chunks: list[Tensor] = []
+        remaining = n
+        while remaining > 0:
+            avail = self.tokens.numel() - self.pos
+            if avail <= 0:
+                self._advance_file()
+                continue
+            k = min(remaining, avail)
+            chunks.append(self.tokens[self.pos : self.pos + k])
+            self.pos += k
+            remaining -= k
+        return chunks[0] if len(chunks) == 1 else torch.cat(chunks)
+
+
+class DistributedTokenLoader:
+    # Each call consumes a contiguous chunk from the shared token stream, then slices out
+    # one disjoint span per rank. The extra "+1" token lets us build (x, y) by shifting.
+    def __init__(self, pattern: str, rank: int, world_size: int, device: torch.device):
+        self.rank = rank
+        self.world_size = world_size
+        self.device = device
+        self.stream = TokenStream(pattern)
+
+    def next_batch(self, global_tokens: int, seq_len: int, grad_accum_steps: int) -> tuple[Tensor, Tensor]:
+        local_tokens = global_tokens // (self.world_size * grad_accum_steps)
+        per_rank_span = local_tokens + 1
+        chunk = self.stream.take(per_rank_span * self.world_size)
+        start = self.rank * per_rank_span
+        local = chunk[start : start + per_rank_span].to(dtype=torch.int64)
+        x = local[:-1].reshape(-1, seq_len)
+        y = local[1:].reshape(-1, seq_len)
+        return x.to(self.device, non_blocking=True), y.to(self.device, non_blocking=True)
+
+
+def resolve_local_sgd_sync_steps(value: int) -> int:
+    if value < 1:
+        raise ValueError(f"LOCAL_SGD_SYNC_STEPS must be >= 1, got {value}")
+    return value
+
+
+def should_average_local_sgd(step: int, sync_steps: int) -> bool:
+    return sync_steps > 1 and step > 0 and step % sync_steps == 0
+
+
+@torch.no_grad()
+def average_model_parameters(module: nn.Module) -> None:
+    if not (dist.is_available() and dist.is_initialized()):
+        return
+    world_size = dist.get_world_size()
+    for param in module.parameters():
+        dist.all_reduce(param.data, op=dist.ReduceOp.SUM)
+        param.data.div_(world_size)
+
+
+@torch.no_grad()
+def average_optimizer_tensor_states(optimizers: list[torch.optim.Optimizer]) -> None:
+    if not (dist.is_available() and dist.is_initialized()):
+        return
+    world_size = dist.get_world_size()
+    for optimizer in optimizers:
+        for state in optimizer.state.values():
+            for value in state.values():
+                if torch.is_tensor(value) and value.is_floating_point():
+                    dist.all_reduce(value, op=dist.ReduceOp.SUM)
+                    value.div_(world_size)
+
+# -----------------------------
+# CANDIDATE MODEL INTERFACE
+# -----------------------------
+
+from candidates.autoregressive.architecture import BlockDiagonalLinear, CastedLinear, restore_low_dim_params_to_fp32
+
+
+
+# -----------------------------
+# TRAINING
+# -----------------------------
+
+def main() -> None:
+    global zeropower_via_newtonschulz5
+
+    code_path = Path(__file__)
+    code = code_path.read_text(encoding="utf-8")
+    code_bytes = submission_code_size_bytes(code_path)
+    args = Hyperparameters()
+    compile_enabled = torch.cuda.is_available() and args.torch_compile
+    if compile_enabled:
+        zeropower_via_newtonschulz5 = torch.compile(zeropower_via_newtonschulz5)
+
+    # -----------------------------
+    # DISTRIBUTED + CUDA SETUP
+    # -----------------------------
+
+    distributed = "RANK" in os.environ and "WORLD_SIZE" in os.environ
+    rank = int(os.environ.get("RANK", "0"))
+    world_size = int(os.environ.get("WORLD_SIZE", "1"))
+    local_rank = int(os.environ.get("LOCAL_RANK", "0"))
+    if world_size <= 0:
+        raise ValueError(f"WORLD_SIZE must be positive, got {world_size}")
+    if 8 % world_size != 0:
+        raise ValueError(f"WORLD_SIZE={world_size} must divide 8 so grad_accum_steps stays integral")
+    grad_accum_steps = 8 // world_size
+    grad_scale = 1.0 / grad_accum_steps
+    use_cuda = torch.cuda.is_available()
+    device = torch.device("cuda", local_rank) if use_cuda else torch.device("cpu")
+    if use_cuda:
+        torch.cuda.set_device(device)
+    elif distributed:
+        raise RuntimeError("Distributed mode requires CUDA on this script")
+    if distributed:
+        dist.init_process_group(backend="nccl", device_id=device)
+        dist.barrier()
+    local_sgd_sync_steps = resolve_local_sgd_sync_steps(args.local_sgd_sync_steps)
+    local_sgd_enabled = distributed and local_sgd_sync_steps > 1
+    master_process = rank == 0
+    autocast_enabled = use_cuda
+    autocast_dtype = torch.bfloat16
+
+    def synchronize_device() -> None:
+        if use_cuda:
+            torch.cuda.synchronize()
+
+    # Fast math knobs
+    if use_cuda:
+        torch.backends.cuda.matmul.allow_tf32 = True
+        torch.backends.cudnn.allow_tf32 = True
+        from torch.backends.cuda import enable_cudnn_sdp, enable_flash_sdp, enable_math_sdp, enable_mem_efficient_sdp
+
+        masked_sparse_attention = args.sparse_attn_mode != "dense"
+        enable_cudnn_sdp(False)
+        enable_flash_sdp(True)
+        enable_mem_efficient_sdp(False)
+        enable_math_sdp(masked_sparse_attention)
+
+    logfile = None
+    if master_process:
+        os.makedirs("logs", exist_ok=True)
+        logfile = f"logs/{args.run_id}.txt"
+        print(logfile)
+
+    def log0(msg: str, console: bool = True) -> None:
+        if not master_process:
+            return
+        if console:
+            print(msg)
+        if logfile is not None:
+            with open(logfile, "a", encoding="utf-8") as f:
+                print(msg, file=f)
+
+    log0(code, console=False)
+    log0("=" * 100, console=False)
+    log0(f"Running Python {sys.version}", console=False)
+    log0(f"Running PyTorch {torch.__version__}", console=False)
+    if use_cuda:
+        log0(
+            subprocess.run(["nvidia-smi"], stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True, check=False).stdout,
+            console=False,
+        )
+    else:
+        log0("Running on CPU", console=False)
+    log0("=" * 100, console=False)
+
+    # -----------------------------
+    # TOKENIZER + VALIDATION METRIC SETUP
+    # -----------------------------
+
+    random.seed(args.seed)
+    np.random.seed(args.seed)
+    torch.manual_seed(args.seed)
+    if use_cuda:
+        torch.cuda.manual_seed_all(args.seed)
+
+    if not args.tokenizer_path.endswith(".model"):
+        raise ValueError(f"Script only setup for SentencePiece .model file: {args.tokenizer_path}")
+    sp = spm.SentencePieceProcessor(model_file=args.tokenizer_path)
+    if int(sp.vocab_size()) != args.vocab_size:
+        raise ValueError(
+            f"VOCAB_SIZE={args.vocab_size} does not match tokenizer vocab_size={int(sp.vocab_size())}"
+        )
+    dataset_dir = Path(args.data_path).resolve()
+    actual_train_files = len(list(dataset_dir.glob("fineweb_train_*.bin")))
+    val_tokens = load_validation_tokens(args.val_files, args.train_seq_len)
+    val_token_limit = int(os.environ.get("VAL_TOKEN_LIMIT", "0"))
+    base_bytes_lut, has_leading_space_lut, is_boundary_token_lut = build_sentencepiece_luts(
+        sp, args.vocab_size, device
+    )
+    log0(f"val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path={args.tokenizer_path}")
+    log0(f"train_loader:dataset:{dataset_dir.name} train_shards:{actual_train_files}")
+    log0(f"val_loader:shards pattern={args.val_files} tokens:{val_tokens.numel() - 1}")
+    if val_token_limit > 0:
+        log0(f"val_loader:token_limit:{val_token_limit}")
+
+    # -----------------------------
+    # MODEL + OPTIMIZER SETUP
+    # -----------------------------
+
+    base_model = build_model(args).to(device)
+    if use_cuda:
+        base_model = base_model.bfloat16()
+    for module in base_model.modules():
+        if isinstance(module, (CastedLinear, BlockDiagonalLinear)):
+            module.float()
+    restore_low_dim_params_to_fp32(base_model, CONTROL_TENSOR_NAME_PATTERNS)
+    compiled_model = torch.compile(base_model, dynamic=False, fullgraph=True) if compile_enabled else base_model
+    model: nn.Module = DDP(compiled_model, device_ids=[local_rank], broadcast_buffers=False) if distributed else compiled_model
+
+    # Optimizer split:
+    # - token embedding (Adam) uses EMBED_LR
+    # - untied lm_head (Adam) uses HEAD_LR
+    # - matrix params in transformer blocks use MATRIX_LR via Muon
+    # - vectors/scalars use SCALAR_LR via Adam
+    block_named_params = list(base_model.blocks.named_parameters())
+    matrix_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim == 2 and not any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    scalar_params = [
+        p
+        for name, p in block_named_params
+        if p.ndim < 2 or any(pattern in name for pattern in CONTROL_TENSOR_NAME_PATTERNS)
+    ]
+    if base_model.skip_weights.numel() > 0:
+        scalar_params.append(base_model.skip_weights)
+    token_lr = args.tied_embed_lr if args.tie_embeddings else args.embed_lr
+    optimizer_tok = torch.optim.Adam(
+        [{"params": [base_model.tok_emb.weight], "lr": token_lr, "base_lr": token_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_cuda,
+    )
+    optimizer_muon = Muon(
+        matrix_params,
+        lr=args.matrix_lr,
+        momentum=args.muon_momentum,
+        backend_steps=args.muon_backend_steps,
+        distributed_reduce=not local_sgd_enabled,
+    )
+    for group in optimizer_muon.param_groups:
+        group["base_lr"] = args.matrix_lr
+    optimizer_scalar = torch.optim.Adam(
+        [{"params": scalar_params, "lr": args.scalar_lr, "base_lr": args.scalar_lr}],
+        betas=(args.beta1, args.beta2),
+        eps=args.adam_eps,
+        fused=use_cuda,
+    )
+    optimizers: list[torch.optim.Optimizer] = [optimizer_tok, optimizer_muon, optimizer_scalar]
+    if base_model.lm_head is not None:
+        optimizer_head = torch.optim.Adam(
+            [{"params": [base_model.lm_head.weight], "lr": args.head_lr, "base_lr": args.head_lr}],
+            betas=(args.beta1, args.beta2),
+            eps=args.adam_eps,
+            fused=use_cuda,
+        )
+        optimizers.insert(1, optimizer_head)
+
+    n_params = sum(p.numel() for p in base_model.parameters())
+    log0(f"model_params:{n_params}")
+    log0(f"torch_compile:enabled:{int(compile_enabled)}")
+    log0(f"world_size:{world_size} grad_accum_steps:{grad_accum_steps}")
+    log0(
+        f"local_sgd:enabled:{int(local_sgd_enabled)} sync_steps:{local_sgd_sync_steps} "
+        f"average_optimizer_states:{int(args.local_sgd_average_optimizer_states)}"
+    )
+    log0(f"sdp_backends:cudnn=False flash=True mem_efficient=False math={int(args.sparse_attn_mode != 'dense')}")
+    log0(
+        f"attention_mode:gqa num_heads:{args.num_heads} num_kv_heads:{args.num_kv_heads} "
+        f"attn_norm_mode:{args.attn_norm_mode} attn_norm_eps:{args.attn_norm_eps}"
+    )
+    log0(
+        f"sparse_attention:mode:{args.sparse_attn_mode} window:{args.sparse_attn_window} "
+        f"global_tokens:{args.sparse_attn_global_tokens} block_size:{args.sparse_attn_block_size}"
+    )
+    log0(
+        f"structured_sparsity:mlp_block_groups:{args.mlp_block_groups} "
+        f"mtp_num_tokens:{args.mtp_num_tokens} mtp_loss_weight:{args.mtp_loss_weight}"
+    )
+    log0(f"candidate_impl:{candidate_name_from_env()}")
+    log0(
+        f"layer_order:encoder={base_model.encoder_layer_order} "
+        f"decoder={base_model.decoder_layer_order} "
+        f"virtual_depth:{len(base_model.encoder_layer_order) + len(base_model.decoder_layer_order)}"
+    )
+    log0(
+        f"tie_embeddings:{args.tie_embeddings} embed_lr:{token_lr} "
+        f"head_lr:{args.head_lr if base_model.lm_head is not None else 0.0} "
+        f"matrix_lr:{args.matrix_lr} scalar_lr:{args.scalar_lr}"
+    )
+    log0(f"moe:num_experts:{args.moe_num_experts} top_k:{args.moe_top_k}")
+    log0(
+        f"train_batch_tokens:{args.train_batch_tokens} train_seq_len:{args.train_seq_len} "
+        f"iterations:{args.iterations} warmup_steps:{args.warmup_steps} "
+        f"max_wallclock_seconds:{args.max_wallclock_seconds:.3f}"
+    )
+    budget_estimate = estimate_artifact_budget(args, code_path=__file__)
+    for line in budget_estimate.to_log_lines():
+        log0(line)
+    if budget_estimate.over_budget:
+        log0(
+            "WARNING: artifact budget estimate exceeds 16MB before training; "
+            "reduce vocab, width, depth, MLP size, untied heads, or quantized payload."
+        )
+        if bool(int(os.environ.get("ARTIFACT_BUDGET_STRICT", "0"))):
+            raise RuntimeError("artifact budget estimate exceeds 16MB")
+    log0(f"seed:{args.seed}")
+
+    # -----------------------------
+    # DATA LOADER & MODEL WARMUP
+    # -----------------------------
+
+    train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    def zero_grad_all() -> None:
+        for opt in optimizers:
+            opt.zero_grad(set_to_none=True)
+
+    max_wallclock_ms = 1000.0 * args.max_wallclock_seconds if args.max_wallclock_seconds > 0 else None
+    skip_pre_quant_final_eval = bool(int(os.environ.get("SKIP_PRE_QUANT_FINAL_EVAL", "0")))
+
+    def lr_mul(step: int, elapsed_ms: float) -> float:
+        if args.warmdown_iters <= 0:
+            return 1.0
+        if max_wallclock_ms is None:
+            warmdown_start = max(args.iterations - args.warmdown_iters, 0)
+            return max((args.iterations - step) / max(args.warmdown_iters, 1), 0.0) if warmdown_start <= step < args.iterations else 1.0
+        step_ms = elapsed_ms / max(step, 1)
+        warmdown_ms = args.warmdown_iters * step_ms
+        remaining_ms = max(max_wallclock_ms - elapsed_ms, 0.0)
+        return remaining_ms / max(warmdown_ms, 1e-9) if remaining_ms <= warmdown_ms else 1.0
+
+    batch_tune_only = bool(int(os.environ.get("BATCH_TUNE_ONLY", "0")))
+    if batch_tune_only:
+        model.train()
+        synchronize_device()
+        t_tune = time.perf_counter()
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = (
+                    not local_sgd_enabled and micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type=device.type, dtype=autocast_dtype, enabled=autocast_enabled):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+        for opt in optimizers:
+            opt.step()
+        if local_sgd_enabled:
+            average_model_parameters(base_model)
+            if args.local_sgd_average_optimizer_states:
+                average_optimizer_tensor_states(optimizers)
+        zero_grad_all()
+        synchronize_device()
+        tune_ms = 1000.0 * (time.perf_counter() - t_tune)
+        if use_cuda:
+            allocated_mib = torch.cuda.max_memory_allocated() // 1024 // 1024
+            reserved_mib = torch.cuda.max_memory_reserved() // 1024 // 1024
+        else:
+            allocated_mib = 0
+            reserved_mib = 0
+        log0(
+            f"batch_tune_success train_batch_tokens:{args.train_batch_tokens} "
+            f"train_seq_len:{args.train_seq_len} train_loss:{train_loss.item():.4f} "
+            f"step_time:{tune_ms:.0f}ms peak_allocated_mib:{allocated_mib} "
+            f"peak_reserved_mib:{reserved_mib}"
+        )
+        if distributed:
+            dist.destroy_process_group()
+        return
+
+    # Warmup primes the compiled forward/backward/optimizer paths, then we restore the
+    # initial weights/optimizer state so measured training starts from the true init.
+    if args.warmup_steps > 0:
+        initial_model_state = {name: tensor.detach().cpu().clone() for name, tensor in base_model.state_dict().items()}
+        initial_optimizer_states = [copy.deepcopy(opt.state_dict()) for opt in optimizers]
+        model.train()
+        for warmup_step in range(args.warmup_steps):
+            zero_grad_all()
+            for micro_step in range(grad_accum_steps):
+                if distributed:
+                    model.require_backward_grad_sync = (
+                        not local_sgd_enabled and micro_step == grad_accum_steps - 1
+                    )
+                x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+                with torch.autocast(device_type=device.type, dtype=autocast_dtype, enabled=autocast_enabled):
+                    warmup_loss = model(x, y)
+                (warmup_loss * grad_scale).backward()
+            for opt in optimizers:
+                opt.step()
+            if local_sgd_enabled:
+                average_model_parameters(base_model)
+                if args.local_sgd_average_optimizer_states:
+                    average_optimizer_tensor_states(optimizers)
+            zero_grad_all()
+            if args.warmup_steps <= 20 or (warmup_step + 1) % 10 == 0 or warmup_step + 1 == args.warmup_steps:
+                log0(f"warmup_step:{warmup_step + 1}/{args.warmup_steps}")
+        base_model.load_state_dict(initial_model_state, strict=True)
+        for opt, state in zip(optimizers, initial_optimizer_states, strict=True):
+            opt.load_state_dict(state)
+        zero_grad_all()
+        if distributed:
+            model.require_backward_grad_sync = True
+        train_loader = DistributedTokenLoader(args.train_files, rank, world_size, device)
+
+    # -----------------------------
+    # MAIN TRAINING LOOP
+    # -----------------------------
+
+    training_time_ms = 0.0
+    stop_after_step: int | None = None
+    synchronize_device()
+    t0 = time.perf_counter()
+
+    step = 0
+    while True:
+        last_step = step == args.iterations or (stop_after_step is not None and step >= stop_after_step)
+
+        should_validate = (
+            (last_step and not skip_pre_quant_final_eval)
+            or (args.val_loss_every > 0 and step % args.val_loss_every == 0)
+        )
+        if should_validate:
+            synchronize_device()
+            training_time_ms += 1000.0 * (time.perf_counter() - t0)
+            val_loss, val_bpb = eval_val(
+                args,
+                model,
+                rank,
+                world_size,
+                device,
+                grad_accum_steps,
+                val_tokens,
+                base_bytes_lut,
+                has_leading_space_lut,
+                is_boundary_token_lut,
+            )
+            log0(
+                f"step:{step}/{args.iterations} val_loss:{val_loss:.4f} val_bpb:{val_bpb:.4f} "
+                f"train_time:{training_time_ms:.0f}ms step_avg:{training_time_ms / max(step, 1):.2f}ms"
+            )
+            synchronize_device()
+            t0 = time.perf_counter()
+
+        if last_step:
+            if stop_after_step is not None and step < args.iterations:
+                log0(
+                    f"stopping_early: wallclock_cap train_time:{training_time_ms:.0f}ms "
+                    f"step:{step}/{args.iterations}"
+                )
+            break
+
+        elapsed_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        scale = lr_mul(step, elapsed_ms)
+        zero_grad_all()
+        train_loss = torch.zeros((), device=device)
+        for micro_step in range(grad_accum_steps):
+            if distributed:
+                model.require_backward_grad_sync = (
+                    not local_sgd_enabled and micro_step == grad_accum_steps - 1
+                )
+            x, y = train_loader.next_batch(args.train_batch_tokens, args.train_seq_len, grad_accum_steps)
+            with torch.autocast(device_type=device.type, dtype=autocast_dtype, enabled=autocast_enabled):
+                loss = model(x, y)
+            train_loss += loss.detach()
+            (loss * grad_scale).backward()
+        train_loss /= grad_accum_steps
+
+        frac = min(step / args.muon_momentum_warmup_steps, 1.0) if args.muon_momentum_warmup_steps > 0 else 1.0
+        muon_momentum = (1 - frac) * args.muon_momentum_warmup_start + frac * args.muon_momentum
+        for group in optimizer_muon.param_groups:
+            group["momentum"] = muon_momentum
+
+        for opt in optimizers:
+            for group in opt.param_groups:
+                group["lr"] = group["base_lr"] * scale
+
+        if args.grad_clip_norm > 0:
+            torch.nn.utils.clip_grad_norm_(base_model.parameters(), args.grad_clip_norm)
+        for opt in optimizers:
+            opt.step()
+        if local_sgd_enabled and should_average_local_sgd(step + 1, local_sgd_sync_steps):
+            average_model_parameters(base_model)
+            if args.local_sgd_average_optimizer_states:
+                average_optimizer_tensor_states(optimizers)
+            log0(f"local_sgd_average step:{step + 1} sync_steps:{local_sgd_sync_steps}")
+        zero_grad_all()
+
+        step += 1
+        approx_training_time_ms = training_time_ms + 1000.0 * (time.perf_counter() - t0)
+        should_log_train = (
+            args.train_log_every > 0
+            and (step <= 10 or step % args.train_log_every == 0 or stop_after_step is not None)
+        )
+        if should_log_train:
+            log0(
+                f"step:{step}/{args.iterations} train_loss:{train_loss.item():.4f} "
+                f"train_time:{approx_training_time_ms:.0f}ms step_avg:{approx_training_time_ms / step:.2f}ms"
+            )
+
+        # Needed to sync whether we've reached the wallclock cap.
+        reached_cap = max_wallclock_ms is not None and approx_training_time_ms >= max_wallclock_ms
+        if distributed and max_wallclock_ms is not None:
+            reached_cap_tensor = torch.tensor(int(reached_cap), device=device)
+            dist.all_reduce(reached_cap_tensor, op=dist.ReduceOp.MAX)
+            reached_cap = bool(reached_cap_tensor.item())
+        if stop_after_step is None and reached_cap:
+            stop_after_step = step
+
+    if use_cuda:
+        log0(
+            f"peak memory allocated: {torch.cuda.max_memory_allocated() // 1024 // 1024} MiB "
+            f"reserved: {torch.cuda.max_memory_reserved() // 1024 // 1024} MiB"
+        )
+    else:
+        log0("peak memory allocated: cpu-run")
+
+    # -----------------------------
+    # SERIALIZATION + ROUNDTRIP VALIDATION
+    # -----------------------------
+    # Save the raw state (useful for debugging/loading in PyTorch directly), then always produce
+    # the compressed int8+zlib artifact and validate the round-tripped weights.
+
+    if master_process:
+        torch.save(base_model.state_dict(), "final_model.pt")
+        model_bytes = os.path.getsize("final_model.pt")
+        log0(f"Serialized model: {model_bytes} bytes")
+        log0(f"Code size: {code_bytes} bytes")
+        log0(f"Total submission size: {model_bytes + code_bytes} bytes")
+
+    quant_obj, quant_stats = quantize_state_dict_int8(base_model.state_dict())
+    quant_buf = io.BytesIO()
+    torch.save(quant_obj, quant_buf)
+    quant_raw = quant_buf.getvalue()
+    quant_blob = zlib.compress(quant_raw, level=9)
+    quant_raw_bytes = len(quant_raw)
+    if master_process:
+        with open("final_model.int8.ptz", "wb") as f:
+            f.write(quant_blob)
+        quant_file_bytes = os.path.getsize("final_model.int8.ptz")
+        ratio = quant_stats["baseline_tensor_bytes"] / max(quant_stats["int8_payload_bytes"], 1)
+        log0(
+            f"Serialized model int8+zlib: {quant_file_bytes} bytes "
+            f"(payload:{quant_stats['int8_payload_bytes']} raw_torch:{quant_raw_bytes} payload_ratio:{ratio:.2f}x)"
+        )
+        log0(f"Total submission size int8+zlib: {quant_file_bytes + code_bytes} bytes")
+
+    if distributed:
+        dist.barrier()
+    with open("final_model.int8.ptz", "rb") as f:
+        quant_blob_disk = f.read()
+    quant_state = torch.load(io.BytesIO(zlib.decompress(quant_blob_disk)), map_location="cpu")
+    base_model.load_state_dict(dequantize_state_dict_int8(quant_state), strict=True)
+    synchronize_device()
+    t_qeval = time.perf_counter()
+    q_val_loss, q_val_bpb = eval_val(
+        args,
+        model,
+        rank,
+        world_size,
+        device,
+        grad_accum_steps,
+        val_tokens,
+        base_bytes_lut,
+        has_leading_space_lut,
+        is_boundary_token_lut,
+    )
+    synchronize_device()
+    log0(
+        f"final_int8_zlib_roundtrip val_loss:{q_val_loss:.4f} val_bpb:{q_val_bpb:.4f} "
+        f"eval_time:{1000.0 * (time.perf_counter() - t_qeval):.0f}ms"
+    )
+    log0(f"final_int8_zlib_roundtrip_exact val_loss:{q_val_loss:.8f} val_bpb:{q_val_bpb:.8f}")
+
+    if distributed:
+        dist.destroy_process_group()
+
+
+if __name__ == "__main__":
+    main()

--- a/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train_seed1337.log
+++ b/records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train_seed1337.log
@@ -1,0 +1,101 @@
+NCCL version 2.27.5+cuda12.9
+logs/h100_batch_20260501T153233Z_01_best4x_ttt_disabled_qk525.txt
+val_bpb:enabled tokenizer_kind=sentencepiece tokenizer_path=/workspace/parameter-golf/data/tokenizers/fineweb_1024_bpe.model
+train_loader:dataset:fineweb10B_sp1024 train_shards:80
+val_loader:shards pattern=/workspace/parameter-golf/data/datasets/fineweb10B_sp1024/fineweb_val_*.bin tokens:62021632
+model_params:17059912
+torch_compile:enabled:1
+world_size:8 grad_accum_steps:1
+local_sgd:enabled:0 sync_steps:1 average_optimizer_states:0
+sdp_backends:cudnn=False flash=True mem_efficient=False math=0
+attention_mode:gqa num_heads:8 num_kv_heads:4 attn_norm_mode:baseline attn_norm_eps:1e-06
+sparse_attention:mode:dense window:256 global_tokens:4 block_size:64
+structured_sparsity:mlp_block_groups:1 mtp_num_tokens:1 mtp_loss_weight:0.0
+candidate_impl:autoregressive_gpt
+layer_order:encoder=[0, 1, 2, 3] decoder=[4, 5, 6, 7, 8] virtual_depth:9
+tie_embeddings:True embed_lr:0.05 head_lr:0.0 matrix_lr:0.04 scalar_lr:0.04
+moe:num_experts:1 top_k:1
+train_batch_tokens:2097152 train_seq_len:1024 iterations:20000 warmup_steps:20 max_wallclock_seconds:600.000
+artifact_budget:state:within-budget total_bytes:13442586 limit_bytes:16000000 headroom_bytes:2557414 quantization:int8-per-row-zlib-projection compression_ratio:0.78
+artifact_budget_component:name:embeddings params:524288 raw_quantized_bytes:524288 estimated_bytes:408945
+artifact_budget_component:name:attention_blocks params:7077888 raw_quantized_bytes:7077888 estimated_bytes:5520753
+artifact_budget_component:name:mlp_blocks params:9437184 raw_quantized_bytes:9437184 estimated_bytes:7361004
+artifact_budget_component:name:control_tensors params:9225 raw_quantized_bytes:20178 estimated_bytes:20178
+artifact_budget_component:name:quantization_overhead params:0 raw_quantized_bytes:118208 estimated_bytes:118208
+seed:1337
+warmup_step:1/20
+warmup_step:2/20
+warmup_step:3/20
+warmup_step:4/20
+warmup_step:5/20
+warmup_step:6/20
+warmup_step:7/20
+warmup_step:8/20
+warmup_step:9/20
+warmup_step:10/20
+warmup_step:11/20
+warmup_step:12/20
+warmup_step:13/20
+warmup_step:14/20
+warmup_step:15/20
+warmup_step:16/20
+warmup_step:17/20
+warmup_step:18/20
+warmup_step:19/20
+warmup_step:20/20
+step:1/20000 train_loss:6.9369 train_time:564ms step_avg:563.53ms
+step:2/20000 train_loss:16.6814 train_time:631ms step_avg:315.35ms
+step:3/20000 train_loss:9.0949 train_time:777ms step_avg:259.10ms
+step:4/20000 train_loss:6.5716 train_time:925ms step_avg:231.26ms
+step:5/20000 train_loss:6.7011 train_time:1073ms step_avg:214.50ms
+step:6/20000 train_loss:6.5696 train_time:1220ms step_avg:203.28ms
+step:7/20000 train_loss:6.4346 train_time:1367ms step_avg:195.27ms
+step:8/20000 train_loss:6.2081 train_time:1518ms step_avg:189.81ms
+step:9/20000 train_loss:6.1313 train_time:1670ms step_avg:185.59ms
+step:10/20000 train_loss:6.0393 train_time:1818ms step_avg:181.84ms
+step:100/20000 train_loss:3.2199 train_time:16305ms step_avg:163.05ms
+step:200/20000 train_loss:2.7397 train_time:32341ms step_avg:161.71ms
+step:300/20000 train_loss:2.5549 train_time:48414ms step_avg:161.38ms
+step:400/20000 train_loss:2.4237 train_time:64507ms step_avg:161.27ms
+step:500/20000 train_loss:2.3555 train_time:80675ms step_avg:161.35ms
+step:600/20000 train_loss:2.2969 train_time:96817ms step_avg:161.36ms
+step:700/20000 train_loss:2.3869 train_time:112863ms step_avg:161.23ms
+step:800/20000 train_loss:2.3056 train_time:129000ms step_avg:161.25ms
+step:900/20000 train_loss:2.3323 train_time:145126ms step_avg:161.25ms
+step:1000/20000 train_loss:2.1503 train_time:161232ms step_avg:161.23ms
+step:1100/20000 train_loss:2.2499 train_time:177783ms step_avg:161.62ms
+step:1200/20000 train_loss:2.2197 train_time:193912ms step_avg:161.59ms
+step:1300/20000 train_loss:2.2843 train_time:209985ms step_avg:161.53ms
+step:1400/20000 train_loss:2.3222 train_time:226069ms step_avg:161.48ms
+step:1500/20000 train_loss:2.1343 train_time:242118ms step_avg:161.41ms
+step:1600/20000 train_loss:2.1190 train_time:258131ms step_avg:161.33ms
+step:1700/20000 train_loss:2.1857 train_time:274215ms step_avg:161.30ms
+step:1800/20000 train_loss:2.0968 train_time:290300ms step_avg:161.28ms
+step:1900/20000 train_loss:2.1003 train_time:306356ms step_avg:161.24ms
+step:2000/20000 train_loss:2.1114 train_time:322406ms step_avg:161.20ms
+step:2100/20000 train_loss:2.1190 train_time:338951ms step_avg:161.41ms
+step:2200/20000 train_loss:2.2025 train_time:354985ms step_avg:161.36ms
+step:2300/20000 train_loss:2.1090 train_time:371062ms step_avg:161.33ms
+step:2400/20000 train_loss:2.0836 train_time:387225ms step_avg:161.34ms
+step:2500/20000 train_loss:2.1699 train_time:403270ms step_avg:161.31ms
+step:2600/20000 train_loss:2.0281 train_time:419299ms step_avg:161.27ms
+step:2700/20000 train_loss:2.1550 train_time:435359ms step_avg:161.24ms
+step:2800/20000 train_loss:2.1683 train_time:451408ms step_avg:161.22ms
+step:2900/20000 train_loss:2.1371 train_time:467439ms step_avg:161.19ms
+step:3000/20000 train_loss:2.1337 train_time:483504ms step_avg:161.17ms
+step:3100/20000 train_loss:2.0698 train_time:499641ms step_avg:161.17ms
+step:3200/20000 train_loss:2.1785 train_time:516122ms step_avg:161.29ms
+step:3300/20000 train_loss:2.1206 train_time:532184ms step_avg:161.27ms
+step:3400/20000 train_loss:2.1353 train_time:548229ms step_avg:161.24ms
+step:3500/20000 train_loss:2.0885 train_time:564062ms step_avg:161.16ms
+step:3600/20000 train_loss:2.0603 train_time:580112ms step_avg:161.14ms
+step:3700/20000 train_loss:2.0658 train_time:596145ms step_avg:161.12ms
+stopping_early: wallclock_cap train_time:0ms step:3723/20000
+peak memory allocated: 36440 MiB reserved: 36698 MiB
+Serialized model: 67224983 bytes
+Code size: 102473 bytes
+Total submission size: 67327456 bytes
+Serialized model int8+zlib: 15738419 bytes (payload:17178912 raw_torch:17224025 payload_ratio:3.91x)
+Total submission size int8+zlib: 15840892 bytes
+final_int8_zlib_roundtrip val_loss:2.0850 val_bpb:1.2349 eval_time:22966ms
+final_int8_zlib_roundtrip_exact val_loss:2.08500235 val_bpb:1.23485583


### PR DESCRIPTION
# Post-deadline negative rerun of PR #2069 on 8xH100

This PR preserves an 8xH100 target-hardware rerun of the same candidate I submitted in PR #2069:

https://github.com/openai/parameter-golf/pull/2069

PR #2069 packaged the best completed deadline-search result from a 4xH100 machine as a non-record / unlimited-compute 16MB submission because I did not get access to an 8xH100 box before the deadline. I am opening this follow-up after the deadline because I finally got access to an 8xH100 machine and wanted to preserve the direct reproduction evidence for the same candidate, including the fact that the 8xH100 rerun did not beat the leaderboard baseline.

## Candidate

- Candidate ID: `best4x_ttt_disabled_qk525`
- Base submission: PR #2069
- Hardware for this rerun: `8x NVIDIA H100 80GB HBM3`
- Primary change from PR #2069: hardware only, moving from `4xH100` to `8xH100`
- Intent: post-deadline target-hardware reproduction evidence, not a retroactive record claim

## Background

The original deadline search promoted the strongest completed 1xH100 candidate into a 4xH100 batch. The best completed promoted candidate was:

| Candidate | PR #2069 val_bpb | Notes |
|---|---:|---|
| `best4x_ttt_disabled_qk525` | `1.26066159` | QK gain 5.25, TTT disabled |

This PR reruns that same candidate on the intended 8xH100 hardware.

## Configuration

The rerun uses the same candidate configuration:

- `CANDIDATE_IMPL=autoregressive_gpt`
- `QK_GAIN_INIT=5.25`
- `TTT_ENABLED=0`
- `TRAIN_BATCH_TOKENS=2097152`
- `VOCAB_SIZE=1024`
- `MAX_WALLCLOCK_SECONDS=600`

## Results

- val_bpb: `1.23485583`
- val_loss: `2.08500235`
- artifact bytes: `15843310`
- model bytes: `15738419`
- code bytes: `104891`
- train seconds: `702.656`
- seed: `1337`
- packaged records directory: `records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z`

## Leaderboard Context

This is a negative result relative to the current `10min_16mb` leaderboard. The upstream README lists the naive baseline at `1.2244`, so this rerun is worse by `0.01045583` bpb. It is included only to document the target-hardware reproduction attempt for PR #2069.

## Validation

- `python3 -m json.tool records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/submission.json >/dev/null`
- `python3 -m py_compile records/track_10min_16mb/2026-05-01_pr2069-best-8xh100_20260501T153233Z/train_gpt.py`

## Compliance Notes

This is not meant to retroactively change the deadline status of PR #2069.

The package is under the 16MB artifact limit, but the single rerun took `702.656s` and includes one seed. The generated `submission.json` therefore records:

- `artifact_under_16mb: true`
- `train_under_600s: false`
- `three_seeds: false`

I am submitting this as post-deadline reproduction evidence for the same candidate, not as a compliant 10-minute record claim or leaderboard improvement.
